### PR TITLE
KBV-619 add provisioned concurrency

### DIFF
--- a/infrastructure/lambda/private-api.yaml
+++ b/infrastructure/lambda/private-api.yaml
@@ -33,7 +33,7 @@ paths:
         type: "aws_proxy"
         httpMethod: "POST"
         uri:
-          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${AuthorizationFunction.Arn}/invocations"
+          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${AuthorizationFunction.Arn}:live/invocations"
         passthroughBehavior: "when_no_match"
 
   /session:
@@ -67,7 +67,7 @@ paths:
       x-amazon-apigateway-integration:
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${SessionFunction.Arn}/invocations
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${SessionFunction.Arn}:live/invocations
         responses:
           default:
             statusCode: "200"
@@ -105,7 +105,7 @@ paths:
         type: "aws_proxy"
         httpMethod: "POST"
         uri:
-          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${KBVQuestionFunction.Arn}/invocations"
+          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${KBVQuestionFunction.Arn}:live/invocations"
         passthroughBehavior: "when_no_match"
 
   /answer:
@@ -138,7 +138,7 @@ paths:
         type: "aws_proxy"
         httpMethod: "POST"
         uri:
-          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${KBVAnswerFunction.Arn}/invocations"
+          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${KBVAnswerFunction.Arn}:live/invocations"
         passthroughBehavior: "when_no_match"
 
   /abandon:
@@ -165,7 +165,7 @@ paths:
         type: "aws_proxy"
         httpMethod: "POST"
         uri:
-          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${KBVAbandonFunction.Arn}/invocations"
+          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${KBVAbandonFunction.Arn}:live/invocations"
         passthroughBehavior: "when_no_match"
 components:
   parameters:

--- a/infrastructure/lambda/public-api.yaml
+++ b/infrastructure/lambda/public-api.yaml
@@ -62,7 +62,7 @@ paths:
       x-amazon-apigateway-integration:
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${AccessTokenFunction.Arn}/invocations
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${AccessTokenFunction.Arn}:live/invocations
         responses:
           default:
             statusCode: "200"
@@ -112,7 +112,7 @@ paths:
       x-amazon-apigateway-integration:
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${IssueCredentialFunction.Arn}/invocations
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${IssueCredentialFunction.Arn}:live/invocations
         responses:
           default:
             statusCode: "200"

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -46,6 +46,7 @@ Conditions:
     - dev
   IsNotDevEnvironment: !Not
     - Condition: IsDevEnvironment
+  UseProvisionedConcurrency: !Or [!Equals IsProdEnvironment, IsDevEnvironment]
   UsePermissionsBoundary:
     Fn::Not:
       - Fn::Equals:
@@ -67,7 +68,6 @@ Globals:
       - !Ref AWS::NoValue
     Timeout: 30 # seconds
     Runtime: java11
-    AutoPublishAlias: live
     Tracing: Active
     MemorySize: 512
     Environment:
@@ -77,10 +77,11 @@ Globals:
         POWERTOOLS_LOG_LEVEL: INFO
         POWERTOOLS_METRICS_NAMESPACE: di-ipv-cri-kbv-api
         SQS_AUDIT_EVENT_PREFIX: IPV_KBV_CRI
+    AutoPublishAlias: live
     ProvisionedConcurrencyConfig: !If
-      - IsProdEnvironment
+      - UseProvisionedConcurrency
       - ProvisionedConcurrentExecutions: 1
-      - !Ref AWS::NoValue
+      - ProvisionedConcurrentExecutions: 0
 
 Mappings:
 


### PR DESCRIPTION
## Proposed changes

### What changed

Added changes to test provisioned concurrency

### Why did it change

So that we can provide provisioned concurrency in production

### Issue tracking

- [KBV-619](https://govukverify.atlassian.net/browse/KBV-619)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

### Other considerations

Block placed on staging to prevent propagation to integration and production