### PR TITLE
OJ-2113: Increased usage plan to match APIGW limits

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -659,7 +659,7 @@ Resources:
         Period: DAY
       Throttle:
         BurstLimit: 200 # requests the API can handle concurrently
-        RateLimit: 100 # allowed requests per second
+        RateLimit: 400 # allowed requests per second
 
   PrivateApiUsagePlan:
     Type: AWS::ApiGateway::UsagePlan
@@ -675,7 +675,7 @@ Resources:
         Period: DAY
       Throttle:
         BurstLimit: 200 # requests the API can handle concurrently
-        RateLimit: 100 # allowed requests per second
+        RateLimit: 400 # allowed requests per second
 
   LinkUsagePlanApiKey1:
     Condition: IsNotDevEnvironment


### PR DESCRIPTION
## Proposed changes

### What changed
Rate Limits in the Usage Plan

### Why did it change
HTTP 429s occurred during the performance testing. The usage plan had a smaller burst limit than what was set as the limits for the API gateway. By design, AWS uses the lower value between the Usage Plan and API Gateway. This PR sets them to both be the same.

### Issue tracking
- [OJ-2113](https://govukverify.atlassian.net/browse/OJ-2113)


[OJ-2113]: https://govukverify.atlassian.net/browse/OJ-2113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ