### PR TITLE
BAU: Added workflow_dispatch

### DIFF
--- a/.github/workflows/pre-merge-integration-test.yml
+++ b/.github/workflows/pre-merge-integration-test.yml
@@ -6,6 +6,7 @@ on:
       - reopened
       - ready_for_review
       - synchronize
+  workflow_dispatch:
 
 jobs:
   deploy:

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,10 +76,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -118,7 +114,7 @@
         "filename": ".github/workflows/pre-merge-integration-test.yml",
         "hashed_secret": "4b0b79e641eb2908e8e42cb32013ce4d60348413",
         "is_verified": false,
-        "line_number": 20
+        "line_number": 21
       }
     ],
     "infrastructure/lambda/public-api.yaml": [
@@ -258,5 +254,5 @@
       }
     ]
   },
-  "generated_at": "2023-11-23T00:12:27Z"
+  "generated_at": "2023-12-12T11:03:34Z"
 }


### PR DESCRIPTION
Added `workflow_dispatch` to pre-merge-integration tests action so that we can manually trigger this without needing to raise a PR