### PR TITLE
OJ-2209: Update project name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -139,7 +139,7 @@ subprojects {
 	}
 }
 
-sonarqube {
+sonar {
 	properties {
 		property "sonar.projectKey", "ipv-cri-kbv-api"
 		property "sonar.organization", "govuk-one-login"

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,4 @@
-rootProject.name = "di-ipv-cri-kbv-api"
+rootProject.name = "ipv-cri-kbv-api"
 
 // Experian lib
 include "lib"


### PR DESCRIPTION
By default, SonarCloud sets the project name based on the gradle project name, so set it to the new value post-migration.