### PR TITLE
OJ-1811-remove-unnecessary-code

### DIFF
--- a/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionHandler.java
+++ b/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionHandler.java
@@ -27,7 +27,6 @@ import uk.gov.di.ipv.cri.common.library.util.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.kbv.api.domain.KBVItem;
 import uk.gov.di.ipv.cri.kbv.api.domain.KbvQuestion;
-import uk.gov.di.ipv.cri.kbv.api.domain.QuestionAnswerRequest;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionRequest;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionState;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionsResponse;
@@ -222,32 +221,24 @@ public class QuestionHandler
 
     private QuestionsResponse getQuestionAnswerResponse(
             KBVItem kbvItem, SessionItem sessionItem, Map<String, String> requestHeaders)
-            throws JsonProcessingException, SqsException {
+            throws SqsException {
         Objects.requireNonNull(kbvItem, "kbvItem cannot be null");
 
-        if (kbvItem.getExpiryDate() == 0L) { // first request for questions for a given session
-            var personIdentity =
-                    personIdentityService.getPersonIdentityDetailed(kbvItem.getSessionId());
-            var questionRequest = new QuestionRequest();
-            var strategy = this.configurationService.getParameterValue(IIQ_STRATEGY_PARAM_NAME);
-            questionRequest.setStrategy(strategy);
-            questionRequest.setIiqOperatorId(
-                    this.configurationService.getParameterValue(IIQ_OPERATOR_ID_PARAM_NAME));
-            questionRequest.setPersonIdentity(
-                    personIdentityService.convertToPersonIdentitySummary(personIdentity));
-            eventProbe.addDimensions(Map.of(METRIC_DIMENSION_QUESTION_STRATEGY, strategy));
-            auditService.sendAuditEvent(
-                    AuditEventType.REQUEST_SENT,
-                    new AuditEventContext(personIdentity, requestHeaders, sessionItem),
-                    Map.of("component_id", configurationService.getVerifiableCredentialIssuer()));
-            return this.kbvService.getQuestions(questionRequest);
-        }
-        var questionState = objectMapper.readValue(kbvItem.getQuestionState(), QuestionState.class);
-        var questionAnswerRequest = new QuestionAnswerRequest();
-        questionAnswerRequest.setUrn(kbvItem.getUrn());
-        questionAnswerRequest.setAuthRefNo(kbvItem.getAuthRefNo());
-        questionAnswerRequest.setQuestionAnswers(questionState.getAnswers());
-        return this.kbvService.submitAnswers(questionAnswerRequest);
+        var personIdentity =
+                personIdentityService.getPersonIdentityDetailed(kbvItem.getSessionId());
+        var questionRequest = new QuestionRequest();
+        var strategy = this.configurationService.getParameterValue(IIQ_STRATEGY_PARAM_NAME);
+        questionRequest.setStrategy(strategy);
+        questionRequest.setIiqOperatorId(
+                this.configurationService.getParameterValue(IIQ_OPERATOR_ID_PARAM_NAME));
+        questionRequest.setPersonIdentity(
+                personIdentityService.convertToPersonIdentitySummary(personIdentity));
+        eventProbe.addDimensions(Map.of(METRIC_DIMENSION_QUESTION_STRATEGY, strategy));
+        auditService.sendAuditEvent(
+                AuditEventType.REQUEST_SENT,
+                new AuditEventContext(personIdentity, requestHeaders, sessionItem),
+                Map.of("component_id", configurationService.getVerifiableCredentialIssuer()));
+        return this.kbvService.getQuestions(questionRequest);
     }
 
     private APIGatewayProxyResponseEvent handleException(


### PR DESCRIPTION
## Proposed changes

In the Experian API, there is just one call to the `/SAA` endpoint i.e getQuestions and multiple calls to `/RTQ` endpoint i.e submitAnswers

### What changed

This [code](https://github.com/govuk-one-login/ipv-cri-kbv-api/pull/295/files#diff-88f028988d98316335066950a4387f73c4f3c0a7dd782b1420507d88d46d4358L245-L250) has been hanging around for a while, and causes confusion

### Why did it change

- [OJ-1811](https://govukverify.atlassian.net/browse/OJ-1811)

[OJ-1811]: https://govukverify.atlassian.net/browse/OJ-1811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ