### PR TITLE
OJ-2241: extend vc issued with kbv outcomes

### DIFF
--- a/lambdas/answer/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandler.java
+++ b/lambdas/answer/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandler.java
@@ -34,8 +34,8 @@ import uk.gov.di.ipv.cri.kbv.api.service.KBVStorageService;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Objects;
 
-import static java.util.Objects.nonNull;
 import static org.apache.logging.log4j.Level.ERROR;
 import static uk.gov.di.ipv.cri.common.library.error.ErrorResponse.SESSION_EXPIRED;
 import static uk.gov.di.ipv.cri.common.library.error.ErrorResponse.SESSION_NOT_FOUND;
@@ -54,7 +54,7 @@ public class QuestionAnswerHandler
     private final SessionService sessionService;
     private final EventProbe eventProbe;
     private final AuditService auditService;
-    private ConfigurationService configurationService;
+    private final ConfigurationService configurationService;
 
     @ExcludeFromGeneratedCoverageReport
     public QuestionAnswerHandler() {
@@ -172,7 +172,7 @@ public class QuestionAnswerHandler
             var serializedQuestionState = objectMapper.writeValueAsString(questionState);
             kbvItem.setQuestionState(serializedQuestionState);
             kbvStorageService.update(kbvItem);
-        } else if (nonNull(questionsResponse.getResults())
+        } else if (Objects.nonNull(questionsResponse.getResults())
                 && questionsResponse.hasQuestionRequestEnded()) {
             var serializedQuestionState = objectMapper.writeValueAsString(questionState);
             kbvItem.setQuestionState(serializedQuestionState);

--- a/lambdas/answer/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandler.java
+++ b/lambdas/answer/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandler.java
@@ -35,9 +35,12 @@ import uk.gov.di.ipv.cri.kbv.api.service.KBVStorageService;
 import java.io.IOException;
 import java.util.Map;
 
+import static java.util.Objects.nonNull;
 import static org.apache.logging.log4j.Level.ERROR;
 import static uk.gov.di.ipv.cri.common.library.error.ErrorResponse.SESSION_EXPIRED;
 import static uk.gov.di.ipv.cri.common.library.error.ErrorResponse.SESSION_NOT_FOUND;
+import static uk.gov.di.ipv.cri.kbv.api.domain.KbvResponsesAuditExtension.EXPERIAN_IIQ_RESPONSE;
+import static uk.gov.di.ipv.cri.kbv.api.domain.KbvResponsesAuditExtension.createAuditEventExtensions;
 
 public class QuestionAnswerHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -163,13 +166,13 @@ public class QuestionAnswerHandler
         auditService.sendAuditEvent(
                 AuditEventType.RESPONSE_RECEIVED,
                 new AuditEventContext(requestHeaders, sessionItem),
-                this.kbvService.createAuditEventExtensions(questionsResponse));
+                Map.of(EXPERIAN_IIQ_RESPONSE, createAuditEventExtensions(questionsResponse)));
         if (questionsResponse.hasQuestions()) {
             questionState.setQAPairs(questionsResponse.getQuestions());
             var serializedQuestionState = objectMapper.writeValueAsString(questionState);
             kbvItem.setQuestionState(serializedQuestionState);
             kbvStorageService.update(kbvItem);
-        } else if (questionsResponse.getResults() != null
+        } else if (nonNull(questionsResponse.getResults())
                 && questionsResponse.hasQuestionRequestEnded()) {
             var serializedQuestionState = objectMapper.writeValueAsString(questionState);
             kbvItem.setQuestionState(serializedQuestionState);

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/VerifiableCredentialServiceTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/VerifiableCredentialServiceTest.java
@@ -10,6 +10,7 @@ import com.nimbusds.jose.crypto.ECDSAVerifier;
 import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -45,12 +46,12 @@ import java.util.UUID;
 import static com.nimbusds.jwt.JWTClaimNames.ISSUER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -60,9 +61,10 @@ import static uk.gov.di.ipv.cri.kbv.api.domain.VerifiableCredentialConstants.VC_
 import static uk.gov.di.ipv.cri.kbv.api.domain.VerifiableCredentialConstants.VC_BIRTHDATE_KEY;
 import static uk.gov.di.ipv.cri.kbv.api.domain.VerifiableCredentialConstants.VC_EVIDENCE_KEY;
 import static uk.gov.di.ipv.cri.kbv.api.domain.VerifiableCredentialConstants.VC_NAME_KEY;
+import static uk.gov.di.ipv.cri.kbv.api.service.fixtures.TestFixtures.KBV_QUESTION_QUALITY_MAPPING_SERIALIZED;
 
 @ExtendWith(MockitoExtension.class)
-class VerifiableCredentialServiceTest implements TestFixtures {
+class VerifiableCredentialServiceTest {
     private static final String SUBJECT = "subject";
     private static final JWTClaimsSet TEST_CLAIMS_SET =
             new JWTClaimsSet.Builder().subject("test").issuer("test").build();
@@ -79,142 +81,184 @@ class VerifiableCredentialServiceTest implements TestFixtures {
     @Captor private ArgumentCaptor<Map<String, Object>> mapArgumentCaptor;
     private VerifiableCredentialService verifiableCredentialService;
 
-    @ParameterizedTest
-    @CsvSource({
-        "authenticated,3,3,0,2,",
-        "authenticated,4,3,1,2,",
-        "Not Authenticated,4,2,2,0,V03",
-        "Not Authenticated,4,1,3,0,V03",
-        "Not Authenticated,2,0,2,0,V03",
-        "Unable to Authenticate,3,2,1,0,V03",
-    })
-    void shouldReturnASignedVerifiableCredentialJwt(
-            String authenticationResult,
-            int totalQuestionsAsked,
-            int answeredCorrectly,
-            int answeredInCorrectly,
-            int expectedVerificationScore,
-            ContraIndicator expectedContraIndicator)
-            throws JOSEException, InvalidKeySpecException, NoSuchAlgorithmException, ParseException,
-                    JsonProcessingException {
-        initMockConfigurationService();
-        SignedJWTFactory signedJwtFactory = new SignedJWTFactory(new ECDSASigner(getPrivateKey()));
-        spyEvidenceFactory =
-                spy(
-                        new EvidenceFactory(
-                                objectMapper,
-                                mockEventProbe,
-                                KBV_QUESTION_QUALITY_MAPPING_SERIALIZED));
-        this.verifiableCredentialService =
-                new VerifiableCredentialService(
-                        signedJwtFactory,
-                        mockConfigurationService,
-                        objectMapper,
-                        mockVcClaimSetBuilder,
-                        spyEvidenceFactory);
+    @Nested
+    class KbvVerifiableCredentialJwt implements TestFixtures {
+        @ParameterizedTest
+        @CsvSource({
+            "authenticated,3,3,0,2,",
+            "authenticated,4,3,1,2,",
+            "Not Authenticated,4,2,2,0,V03",
+            "Not Authenticated,4,1,3,0,V03",
+            "Not Authenticated,2,0,2,0,V03",
+            "Unable to Authenticate,3,2,1,0,V03",
+        })
+        void shouldReturnASignedVerifiableCredentialJwt(
+                String authenticationResult,
+                int totalQuestionsAsked,
+                int answeredCorrectly,
+                int answeredInCorrectly,
+                int expectedVerificationScore,
+                ContraIndicator expectedContraIndicator)
+                throws JOSEException, InvalidKeySpecException, NoSuchAlgorithmException,
+                        ParseException, JsonProcessingException {
+            initMockConfigurationService();
+            SignedJWTFactory signedJwtFactory =
+                    new SignedJWTFactory(new ECDSASigner(getPrivateKey()));
+            spyEvidenceFactory =
+                    spy(
+                            new EvidenceFactory(
+                                    objectMapper,
+                                    mockEventProbe,
+                                    KBV_QUESTION_QUALITY_MAPPING_SERIALIZED));
+            verifiableCredentialService =
+                    new VerifiableCredentialService(
+                            signedJwtFactory,
+                            mockConfigurationService,
+                            objectMapper,
+                            mockVcClaimSetBuilder,
+                            spyEvidenceFactory);
 
-        initMockVCClaimSetBuilder();
+            initMockVCClaimSetBuilder();
 
-        KBVItem kbvItem = getKbvItem();
-        kbvItem.setStatus(authenticationResult);
-        kbvItem.setQuestionAnswerResultSummary(
-                getKbvQuestionAnswerSummary(
-                        totalQuestionsAsked, answeredCorrectly, answeredInCorrectly));
-        setKbvItemQuestionState(kbvItem);
-        PersonIdentityDetailed personIdentity = createPersonIdentity();
+            KBVItem kbvItem = getKbvItem();
+            kbvItem.setStatus(authenticationResult);
+            kbvItem.setQuestionAnswerResultSummary(
+                    getKbvQuestionAnswerSummary(
+                            totalQuestionsAsked, answeredCorrectly, answeredInCorrectly));
+            setKbvItemQuestionState(kbvItem);
+            PersonIdentityDetailed personIdentity = createPersonIdentity();
 
-        when(mockVcClaimSetBuilder.build()).thenReturn(TEST_CLAIMS_SET);
+            when(mockVcClaimSetBuilder.build()).thenReturn(TEST_CLAIMS_SET);
 
-        SignedJWT signedJWT =
-                verifiableCredentialService.generateSignedVerifiableCredentialJwt(
-                        SUBJECT, personIdentity, kbvItem);
+            SignedJWT signedJWT =
+                    verifiableCredentialService.generateSignedVerifiableCredentialJwt(
+                            SUBJECT, personIdentity, kbvItem);
 
-        assertTrue(signedJWT.verify(new ECDSAVerifier(ECKey.parse(TestFixtures.EC_PUBLIC_JWK_1))));
-        verify(mockConfigurationService).getParameterValue("JwtTtlUnit");
-        verify(mockConfigurationService).getMaxJwtTtl();
-        verify(mockVcClaimSetBuilder).subject(SUBJECT);
-        verify(mockVcClaimSetBuilder).verifiableCredentialType(KBV_CREDENTIAL_TYPE);
-        verify(spyEvidenceFactory).create(kbvItem);
+            assertTrue(
+                    signedJWT.verify(new ECDSAVerifier(ECKey.parse(TestFixtures.EC_PUBLIC_JWK_1))));
+            verify(mockConfigurationService).getParameterValue("JwtTtlUnit");
+            verify(mockConfigurationService).getMaxJwtTtl();
+            verify(mockVcClaimSetBuilder).subject(SUBJECT);
+            verify(mockVcClaimSetBuilder).verifiableCredentialType(KBV_CREDENTIAL_TYPE);
+            verify(spyEvidenceFactory).create(kbvItem);
 
-        makeEvidenceClaimsAssertions(
-                expectedVerificationScore, expectedContraIndicator, kbvItem.getAuthRefNo());
+            makeEvidenceClaimsAssertions(
+                    expectedVerificationScore, expectedContraIndicator, kbvItem.getAuthRefNo());
 
-        makeVerifiableCredentialSubjectClaimsAssertions(personIdentity);
+            makeVerifiableCredentialSubjectClaimsAssertions(personIdentity);
+        }
+
+        @ParameterizedTest
+        @CsvSource({"some-other-experian-status,an auth ref no,0", ",an auth ref no,0"})
+        void shouldCreateValidSignedJWTWithVcZeroWhenKbvStatusNullOrAnyOtherValue(
+                String status, String authRefNo, int expectedVerificationScore)
+                throws JOSEException, JsonProcessingException {
+            SignedJWTFactory signedJWTFactory = mock(SignedJWTFactory.class);
+            initMockVCClaimSetBuilder();
+            initMockConfigurationService();
+
+            spyEvidenceFactory =
+                    spy(
+                            new EvidenceFactory(
+                                    objectMapper,
+                                    mockEventProbe,
+                                    KBV_QUESTION_QUALITY_MAPPING_SERIALIZED));
+            verifiableCredentialService =
+                    new VerifiableCredentialService(
+                            signedJWTFactory,
+                            mockConfigurationService,
+                            objectMapper,
+                            mockVcClaimSetBuilder,
+                            spyEvidenceFactory);
+
+            KBVItem kbvItem = new KBVItem();
+            kbvItem.setStatus(status);
+            kbvItem.setAuthRefNo(authRefNo);
+
+            when(mockVcClaimSetBuilder.build()).thenReturn(TEST_CLAIMS_SET);
+
+            verifiableCredentialService.generateSignedVerifiableCredentialJwt(
+                    SUBJECT, createPersonIdentity(), kbvItem);
+
+            verify(mockVcClaimSetBuilder)
+                    .verifiableCredentialEvidence(mapArrayArgumentCaptor.capture());
+            verify(signedJWTFactory).createSignedJwt(TEST_CLAIMS_SET);
+            verify(spyEvidenceFactory).create(kbvItem);
+            Map<String, Object> evidenceItems = mapArrayArgumentCaptor.getValue()[0];
+            assertEquals(kbvItem.getAuthRefNo(), evidenceItems.get("txn"));
+            assertEquals(expectedVerificationScore, evidenceItems.get("verificationScore"));
+        }
     }
 
-    @ParameterizedTest
-    @CsvSource({"some-other-experian-status,an auth ref no,0", ",an auth ref no,0"})
-    void shouldCreateValidSignedJWTWithVcZeroWhenKbvStatusNullOrAnyOtherValue(
-            String status, String authRefNo, int expectedVerificationScore)
-            throws JOSEException, JsonProcessingException {
-        SignedJWTFactory signedJWTFactory = mock(SignedJWTFactory.class);
-        initMockVCClaimSetBuilder();
-        initMockConfigurationService();
+    @Nested
+    class KbvAuditEventExtensions implements TestFixtures {
+        private final String txn = String.valueOf(UUID.randomUUID());
+        @Test
+        void shouldGetAuditEventExtensions() throws JsonProcessingException {
+            SignedJWTFactory signedJWTFactory = mock(SignedJWTFactory.class);
 
-        spyEvidenceFactory =
-                spy(
-                        new EvidenceFactory(
-                                objectMapper,
-                                mockEventProbe,
-                                KBV_QUESTION_QUALITY_MAPPING_SERIALIZED));
-        this.verifiableCredentialService =
-                new VerifiableCredentialService(
-                        signedJWTFactory,
-                        mockConfigurationService,
-                        objectMapper,
-                        mockVcClaimSetBuilder,
-                        spyEvidenceFactory);
+            spyEvidenceFactory =
+                    spy(
+                            new EvidenceFactory(
+                                    objectMapper,
+                                    mockEventProbe,
+                                    KBV_QUESTION_QUALITY_MAPPING_SERIALIZED));
+            verifiableCredentialService =
+                    new VerifiableCredentialService(
+                            signedJWTFactory,
+                            mockConfigurationService,
+                            objectMapper,
+                            mockVcClaimSetBuilder,
+                            spyEvidenceFactory);
 
-        KBVItem kbvItem = new KBVItem();
-        kbvItem.setStatus(status);
-        kbvItem.setAuthRefNo(authRefNo);
+            KBVItem kbvItem = new KBVItem();
+            kbvItem.setAuthRefNo(UUID.randomUUID().toString());
+            kbvItem.setStatus("Not Authenticated");
+            kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(2, 0, 2));
+            setKbvItemQuestionState(kbvItem);
+            String issuer = "test-issuer";
 
-        when(mockVcClaimSetBuilder.build()).thenReturn(TEST_CLAIMS_SET);
+            Object[] evidence = {
+                Map.of(
+                        "txn",
+                        txn,
+                        "verificationScore",
+                        2,
+                        "checkDetails",
+                        List.of(
+                                Map.of(
+                                        "checkMethod",
+                                        "kbv",
+                                        "kbvResponseMode",
+                                        "multiple_choice",
+                                        "kbvQuality",
+                                        3),
+                                Map.of(
+                                        "checkMethod",
+                                        "kbv",
+                                        "kbvResponseMode",
+                                        "multiple_choice",
+                                        "kbvQuality",
+                                        3),
+                                Map.of(
+                                        "checkMethod",
+                                        "kbv",
+                                        "kbvResponseMode",
+                                        "multiple_choice",
+                                        "kbvQuality",
+                                        3)),
+                        "type",
+                        "IdentityCheck")
+            };
 
-        verifiableCredentialService.generateSignedVerifiableCredentialJwt(
-                SUBJECT, createPersonIdentity(), kbvItem);
+            when(mockConfigurationService.getVerifiableCredentialIssuer()).thenReturn(issuer);
+            doReturn(evidence).when(spyEvidenceFactory).create(kbvItem);
 
-        verify(mockVcClaimSetBuilder)
-                .verifiableCredentialEvidence(mapArrayArgumentCaptor.capture());
-        verify(signedJWTFactory).createSignedJwt(TEST_CLAIMS_SET);
-        verify(spyEvidenceFactory).create(kbvItem);
-        Map<String, Object> evidenceItems = mapArrayArgumentCaptor.getValue()[0];
-        assertEquals(kbvItem.getAuthRefNo(), evidenceItems.get("txn"));
-        assertEquals(expectedVerificationScore, evidenceItems.get("verificationScore"));
-    }
+            var auditEventExtensions = verifiableCredentialService.getAuditEventExtensions(kbvItem);
 
-    @Test
-    void shouldGetAuditEventExtensions() throws JsonProcessingException {
-        SignedJWTFactory signedJWTFactory = mock(SignedJWTFactory.class);
-
-        spyEvidenceFactory =
-                spy(
-                        new EvidenceFactory(
-                                objectMapper,
-                                mockEventProbe,
-                                KBV_QUESTION_QUALITY_MAPPING_SERIALIZED));
-        this.verifiableCredentialService =
-                new VerifiableCredentialService(
-                        signedJWTFactory,
-                        mockConfigurationService,
-                        objectMapper,
-                        mockVcClaimSetBuilder,
-                        spyEvidenceFactory);
-
-        KBVItem kbvItem = new KBVItem();
-        kbvItem.setAuthRefNo(UUID.randomUUID().toString());
-        kbvItem.setStatus("Not Authenticated");
-        kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(2, 0, 2));
-        setKbvItemQuestionState(kbvItem);
-        String issuer = "test-issuer";
-        when(mockConfigurationService.getVerifiableCredentialIssuer()).thenReturn(issuer);
-
-        Map<String, Object> auditEventExtensions =
-                verifiableCredentialService.getAuditEventExtensions(kbvItem);
-
-        verify(spyEvidenceFactory).create(kbvItem);
-        assertEquals(auditEventExtensions.get(ISSUER), issuer);
-        assertNotNull(auditEventExtensions.get(VC_EVIDENCE_KEY));
+            verify(spyEvidenceFactory).create(kbvItem);
+            assertEquals(auditEventExtensions, Map.of(ISSUER, issuer, VC_EVIDENCE_KEY, evidence));
+        }
     }
 
     private PersonIdentityDetailed createPersonIdentity() {

--- a/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionHandler.java
+++ b/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionHandler.java
@@ -46,6 +46,8 @@ import static org.apache.logging.log4j.Level.ERROR;
 import static uk.gov.di.ipv.cri.common.library.error.ErrorResponse.SESSION_EXPIRED;
 import static uk.gov.di.ipv.cri.common.library.error.ErrorResponse.SESSION_NOT_FOUND;
 import static uk.gov.di.ipv.cri.kbv.api.domain.IIQAuditEventType.EXPERIAN_IIQ_STARTED;
+import static uk.gov.di.ipv.cri.kbv.api.domain.KbvResponsesAuditExtension.EXPERIAN_IIQ_RESPONSE;
+import static uk.gov.di.ipv.cri.kbv.api.domain.KbvResponsesAuditExtension.createAuditEventExtensions;
 
 public class QuestionHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -279,7 +281,7 @@ public class QuestionHandler
         auditService.sendAuditEvent(
                 AuditEventType.RESPONSE_RECEIVED,
                 new AuditEventContext(requestHeaders, sessionItem),
-                this.kbvService.createAuditEventExtensions(questionsResponse));
+                Map.of(EXPERIAN_IIQ_RESPONSE, createAuditEventExtensions(questionsResponse)));
     }
 
     private Map<String, String> getComponentId() {

--- a/lambdas/question/src/test/java/uk.gov.di.ipv.cri.kbv.api.handler/QuestionHandlerTest.java
+++ b/lambdas/question/src/test/java/uk.gov.di.ipv.cri.kbv.api.handler/QuestionHandlerTest.java
@@ -438,12 +438,14 @@ class QuestionHandlerTest {
             QuestionState questionState = mock(QuestionState.class);
             SessionItem sessionItem = mock(SessionItem.class);
             Map<String, String> requestHeaders = new HashMap<>();
-
+            KbvResult kbvResult = mock(KbvResult.class);
             QuestionsResponse questionsResponse = mock(QuestionsResponse.class);
+
             when(kbvItem.getSessionId()).thenReturn(sessionId);
             when(questionsResponse.getStatus()).thenReturn(expectedOutcome);
             when(questionsResponse.getAuthReference()).thenReturn("an auth ref no");
             when(questionsResponse.getUniqueReference()).thenReturn("a urn");
+            when(questionsResponse.getResults()).thenReturn(kbvResult);
 
             when(mockKBVGateway.getQuestions(any(QuestionRequest.class)))
                     .thenReturn(questionsResponse);
@@ -609,8 +611,10 @@ class QuestionHandlerTest {
         questionsResponse.setAuthReference("authrefno");
         questionsResponse.setUniqueReference("urn");
         questionsResponse.setQuestions(kbvQuestions);
+
         KbvResult kbvResult = new KbvResult();
         kbvResult.setAuthenticationResult("Authentication successful");
+
         questionsResponse.setResults(kbvResult);
 
         return questionsResponse;

--- a/lambdas/question/src/test/java/uk.gov.di.ipv.cri.kbv.api.handler/QuestionHandlerTest.java
+++ b/lambdas/question/src/test/java/uk.gov.di.ipv.cri.kbv.api.handler/QuestionHandlerTest.java
@@ -32,6 +32,7 @@ import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.kbv.api.domain.KBVItem;
 import uk.gov.di.ipv.cri.kbv.api.domain.KbvQuestion;
 import uk.gov.di.ipv.cri.kbv.api.domain.KbvQuestionOptions;
+import uk.gov.di.ipv.cri.kbv.api.domain.KbvResult;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionAnswer;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionRequest;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionState;
@@ -139,9 +140,6 @@ class QuestionHandlerTest {
                             new KbvQuestion[] {getQuestionOne(), getQuestionTwo()});
 
             doReturn(experianQuestionResponse).when(spyKBVService).getQuestions(any());
-            doReturn(Map.of("experianIiqResponse", outcome))
-                    .when(spyKBVService)
-                    .createAuditEventExtensions(experianQuestionResponse);
 
             when(mockObjectMapper.writeValueAsString(any())).thenReturn(expectedQuestion);
             when(mockConfigurationService.getParameterValue(IIQ_STRATEGY_PARAM_NAME))
@@ -536,7 +534,6 @@ class QuestionHandlerTest {
                 throws IOException, SqsException {
             QuestionState questionState = new QuestionState();
             PersonIdentityDetailed personIdentity = mock(PersonIdentityDetailed.class);
-            Map<String, String> outcome = Map.of("outcome", "Authentication successful");
 
             KBVItem kbvItem = new KBVItem();
             UUID sessionId = UUID.randomUUID();
@@ -546,14 +543,12 @@ class QuestionHandlerTest {
                     .thenReturn(personIdentity);
             QuestionsResponse experianQuestionResponse = getExperianQuestionResponse();
             doReturn(experianQuestionResponse).when(spyKBVService).getQuestions(any());
-            doReturn(Map.of("experianIiqResponse", outcome))
-                    .when(spyKBVService)
-                    .createAuditEventExtensions(experianQuestionResponse);
 
             when(mockConfigurationService.getParameterValue(IIQ_STRATEGY_PARAM_NAME))
                     .thenReturn("3 out of 4");
             when(mockConfigurationService.getVerifiableCredentialIssuer())
                     .thenReturn("kbv-component-id");
+
             KbvQuestion nextQuestionFromExperian =
                     questionHandler.processQuestionRequest(
                             questionState, kbvItem, mock(SessionItem.class), new HashMap<>());
@@ -614,6 +609,9 @@ class QuestionHandlerTest {
         questionsResponse.setAuthReference("authrefno");
         questionsResponse.setUniqueReference("urn");
         questionsResponse.setQuestions(kbvQuestions);
+        KbvResult kbvResult = new KbvResult();
+        kbvResult.setAuthenticationResult("Authentication successful");
+        questionsResponse.setResults(kbvResult);
 
         return questionsResponse;
     }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/KbvResponsesAuditExtension.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/KbvResponsesAuditExtension.java
@@ -1,0 +1,43 @@
+package uk.gov.di.ipv.cri.kbv.api.domain;
+
+import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public class KbvResponsesAuditExtension {
+    public static final String EXPERIAN_IIQ_RESPONSE = "experianIiqResponse";
+
+    @ExcludeFromGeneratedCoverageReport
+    private KbvResponsesAuditExtension() {}
+
+    public static Map<String, Object> createAuditEventExtensions(
+            QuestionsResponse questionsResponse) {
+        Map<String, Object> contextEntries = new HashMap<>();
+
+        if (Objects.nonNull(questionsResponse) && Objects.nonNull(questionsResponse.getStatus())) {
+            contextEntries.put("outcome", questionsResponse.getStatus());
+
+            if (Objects.nonNull(questionsResponse.getResults())
+                    && Objects.nonNull(questionsResponse.getResults().getAnswerSummary())) {
+                KbvQuestionAnswerSummary answerSummary =
+                        questionsResponse.getResults().getAnswerSummary();
+                addQuestionSummaryData(contextEntries, answerSummary);
+            }
+        }
+
+        return contextEntries;
+    }
+
+    private static void addQuestionSummaryData(
+            Map<String, Object> contextEntries, KbvQuestionAnswerSummary questionSummary) {
+        if (Objects.nonNull(questionSummary)) {
+            contextEntries.put("totalQuestionsAsked", questionSummary.getQuestionsAsked());
+            contextEntries.put(
+                    "totalQuestionsAnsweredCorrect", questionSummary.getAnsweredCorrect());
+            contextEntries.put(
+                    "totalQuestionsAnsweredIncorrect", questionSummary.getAnsweredIncorrect());
+        }
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/KbvResponsesAuditExtension.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/KbvResponsesAuditExtension.java
@@ -2,6 +2,7 @@ package uk.gov.di.ipv.cri.kbv.api.domain;
 
 import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -14,24 +15,32 @@ public class KbvResponsesAuditExtension {
 
     public static Map<String, Object> createAuditEventExtensions(
             QuestionsResponse questionsResponse) {
-        Map<String, Object> contextEntries = new HashMap<>();
 
-        if (Objects.nonNull(questionsResponse) && Objects.nonNull(questionsResponse.getStatus())) {
-            contextEntries.put("outcome", questionsResponse.getStatus());
+        if (Objects.nonNull(questionsResponse)
+                && Objects.nonNull(questionsResponse.getStatus())
+                && Objects.nonNull(questionsResponse.getResults())) {
 
-            if (Objects.nonNull(questionsResponse.getResults())
-                    && Objects.nonNull(questionsResponse.getResults().getAnswerSummary())) {
-                KbvQuestionAnswerSummary answerSummary =
-                        questionsResponse.getResults().getAnswerSummary();
-                addQuestionSummaryData(contextEntries, answerSummary);
-            }
+            return createAuditEventExtensions(
+                    questionsResponse.getStatus(),
+                    questionsResponse.getResults().getAnswerSummary());
         }
-
-        return contextEntries;
+        return Collections.emptyMap();
     }
 
-    private static void addQuestionSummaryData(
-            Map<String, Object> contextEntries, KbvQuestionAnswerSummary questionSummary) {
+    public static Map<String, Object> createAuditEventExtensions(
+            String status, KbvQuestionAnswerSummary questionSummary) {
+
+        return Objects.nonNull((status))
+                ? getKbvResponsesSummaryEntries(status, questionSummary)
+                : Collections.emptyMap();
+    }
+
+    private static Map<String, Object> getKbvResponsesSummaryEntries(
+            String status, KbvQuestionAnswerSummary questionSummary) {
+
+        Map<String, Object> contextEntries = new HashMap<>();
+        contextEntries.put("outcome", status);
+
         if (Objects.nonNull(questionSummary)) {
             contextEntries.put("totalQuestionsAsked", questionSummary.getQuestionsAsked());
             contextEntries.put(
@@ -39,5 +48,6 @@ public class KbvResponsesAuditExtension {
             contextEntries.put(
                     "totalQuestionsAnsweredIncorrect", questionSummary.getAnsweredIncorrect());
         }
+        return contextEntries;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/QuestionsResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/QuestionsResponse.java
@@ -60,7 +60,7 @@ public class QuestionsResponse {
     }
 
     public String getStatus() {
-        return results.getAuthenticationResult();
+        return Objects.nonNull(results) ? results.getAuthenticationResult() : null;
     }
 
     public void setResults(KbvResult results) {

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/KBVService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/KBVService.java
@@ -1,14 +1,9 @@
 package uk.gov.di.ipv.cri.kbv.api.service;
 
-import uk.gov.di.ipv.cri.kbv.api.domain.KbvQuestionAnswerSummary;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionAnswerRequest;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionRequest;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionsResponse;
 import uk.gov.di.ipv.cri.kbv.api.gateway.KBVGateway;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
 
 public class KBVService {
     private final KBVGateway kbvGateway;
@@ -23,21 +18,5 @@ public class KBVService {
 
     public QuestionsResponse submitAnswers(QuestionAnswerRequest answers) {
         return kbvGateway.submitAnswers(answers);
-    }
-
-    public Map<String, Object> createAuditEventExtensions(QuestionsResponse questionsResponse) {
-        Map<String, Object> contextEntries = new HashMap<>();
-        contextEntries.put("outcome", questionsResponse.getStatus());
-        if (Objects.nonNull(questionsResponse.getResults())
-                && Objects.nonNull(questionsResponse.getResults().getAnswerSummary())) {
-            KbvQuestionAnswerSummary questionSummary =
-                    questionsResponse.getResults().getAnswerSummary();
-            contextEntries.put("totalQuestionsAsked", questionSummary.getQuestionsAsked());
-            contextEntries.put(
-                    "totalQuestionsAnsweredCorrect", questionSummary.getAnsweredCorrect());
-            contextEntries.put(
-                    "totalQuestionsAnsweredIncorrect", questionSummary.getAnsweredIncorrect());
-        }
-        return Map.of("experianIiqResponse", contextEntries);
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/domain/KbvResponsesAuditExtensionTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/domain/KbvResponsesAuditExtensionTest.java
@@ -20,11 +20,21 @@ class KbvResponsesAuditExtensionTest {
         assertEquals(Collections.emptyMap(), createAuditEventExtensions(questionResponse));
     }
 
+    @Test
+    void shouldReturnEmptyContextEntriesWhenKbvItemIsEmpty() {
+        KBVItem kbvItem = new KBVItem();
+
+        assertEquals(
+                Collections.emptyMap(),
+                createAuditEventExtensions(
+                        kbvItem.getStatus(), kbvItem.getQuestionAnswerResultSummary()));
+    }
+
     @ParameterizedTest(
             name =
                     "{index} => authenticationResult={0}, answeredCorrectly={1}, answeredInCorrectly={2}, totalQuestionsAsked={3}")
     @CsvSource({"Authenticated, 3, 1, 4", "Not Authenticated, 2, 2, 4"})
-    void shouldReturnContextEntriesWithSummarizedKbvQuestionResponses(
+    void shouldReturnContextEntriesWithSummarizedKbvResponseFromQuestionResponse(
             String authenticationResult,
             int answeredCorrectly,
             int answeredInCorrectly,
@@ -43,5 +53,42 @@ class KbvResponsesAuditExtensionTest {
                         "totalQuestionsAnsweredIncorrect", answeredInCorrectly,
                         "outcome", authenticationResult),
                 createAuditEventExtensions(questionResponses));
+    }
+
+    @ParameterizedTest(
+            name =
+                    "{index} => authenticationResult={0}, answeredCorrectly={1}, answeredInCorrectly={2}, totalQuestionsAsked={3}")
+    @CsvSource({"Authenticated, 3, 1, 4", "Not Authenticated, 2, 2, 4"})
+    void shouldReturnContextEntriesWithSummarizedKbvResultsFromKbvItem(
+            String authenticationResult,
+            int answeredCorrectly,
+            int answeredInCorrectly,
+            int totalQuestionsAsked) {
+
+        KBVItem kbvItem = new KBVItem();
+        kbvItem.setStatus(authenticationResult);
+        kbvItem.setQuestionAnswerResultSummary(
+                getKbvQuestionAnswerSummary(
+                        answeredCorrectly, answeredInCorrectly, totalQuestionsAsked));
+
+        assertEquals(
+                Map.of(
+                        "totalQuestionsAnsweredCorrect", answeredCorrectly,
+                        "totalQuestionsAsked", totalQuestionsAsked,
+                        "totalQuestionsAnsweredIncorrect", answeredInCorrectly,
+                        "outcome", authenticationResult),
+                createAuditEventExtensions(
+                        kbvItem.getStatus(), kbvItem.getQuestionAnswerResultSummary()));
+    }
+
+    @Test
+    void shouldReturnContextEntriesWithKbvResultsOutcomeWhenNoResultSummary() {
+        KBVItem kbvItem = new KBVItem();
+        kbvItem.setStatus("Not Authenticated");
+
+        assertEquals(
+                Map.of("outcome", "Not Authenticated"),
+                createAuditEventExtensions(
+                        kbvItem.getStatus(), kbvItem.getQuestionAnswerResultSummary()));
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/domain/KbvResponsesAuditExtensionTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/domain/KbvResponsesAuditExtensionTest.java
@@ -1,0 +1,47 @@
+package uk.gov.di.ipv.cri.kbv.api.domain;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static uk.gov.di.ipv.cri.kbv.api.domain.KbvResponsesAuditExtension.createAuditEventExtensions;
+import static uk.gov.di.ipv.cri.kbv.api.util.TestDataCreator.getKbvQuestionAnswerSummary;
+import static uk.gov.di.ipv.cri.kbv.api.util.TestDataCreator.getQuestionResponseWithResults;
+
+class KbvResponsesAuditExtensionTest {
+    @Test
+    void shouldReturnEmptyContextEntriesWhenQuestionResponseIsEmpty() {
+        QuestionsResponse questionResponse = new QuestionsResponse();
+
+        assertEquals(Collections.emptyMap(), createAuditEventExtensions(questionResponse));
+    }
+
+    @ParameterizedTest(
+            name =
+                    "{index} => authenticationResult={0}, answeredCorrectly={1}, answeredInCorrectly={2}, totalQuestionsAsked={3}")
+    @CsvSource({"Authenticated, 3, 1, 4", "Not Authenticated, 2, 2, 4"})
+    void shouldReturnContextEntriesWithSummarizedKbvQuestionResponses(
+            String authenticationResult,
+            int answeredCorrectly,
+            int answeredInCorrectly,
+            int totalQuestionsAsked) {
+
+        QuestionsResponse questionResponses =
+                getQuestionResponseWithResults(
+                        authenticationResult,
+                        getKbvQuestionAnswerSummary(
+                                answeredCorrectly, answeredInCorrectly, totalQuestionsAsked));
+
+        assertEquals(
+                Map.of(
+                        "totalQuestionsAnsweredCorrect", answeredCorrectly,
+                        "totalQuestionsAsked", totalQuestionsAsked,
+                        "totalQuestionsAnsweredIncorrect", answeredInCorrectly,
+                        "outcome", authenticationResult),
+                createAuditEventExtensions(questionResponses));
+    }
+}

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/util/TestDataCreator.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/util/TestDataCreator.java
@@ -4,10 +4,13 @@ import uk.gov.di.ipv.cri.common.library.domain.personidentity.Address;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.AddressType;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentity;
 import uk.gov.di.ipv.cri.kbv.api.domain.KbvQuestion;
+import uk.gov.di.ipv.cri.kbv.api.domain.KbvQuestionAnswerSummary;
 import uk.gov.di.ipv.cri.kbv.api.domain.KbvQuestionOptions;
+import uk.gov.di.ipv.cri.kbv.api.domain.KbvResult;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionAnswer;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionAnswerRequest;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionRequest;
+import uk.gov.di.ipv.cri.kbv.api.domain.QuestionState;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionsResponse;
 
 import java.time.LocalDate;
@@ -131,5 +134,31 @@ public class TestDataCreator {
         question.setQuestionOptions(questionOptions);
 
         return question;
+    }
+
+    public static QuestionState getQuestionState(KbvQuestion[] kbvQuestions) {
+        QuestionState questionState = new QuestionState();
+        questionState.setQAPairs(kbvQuestions);
+        return questionState;
+    }
+
+    public static KbvQuestionAnswerSummary getKbvQuestionAnswerSummary(
+            int answeredCorrect, int answeredIncorrect, int totalQuestionsAsked) {
+        KbvQuestionAnswerSummary kbvQuestionAnswerSummary = new KbvQuestionAnswerSummary();
+        kbvQuestionAnswerSummary.setAnsweredCorrect(answeredCorrect);
+        kbvQuestionAnswerSummary.setAnsweredIncorrect(answeredIncorrect);
+        kbvQuestionAnswerSummary.setQuestionsAsked(totalQuestionsAsked);
+        return kbvQuestionAnswerSummary;
+    }
+
+    public static QuestionsResponse getQuestionResponseWithResults(
+            String authenticationResult, KbvQuestionAnswerSummary kbvQuestionAnswerSummary) {
+        QuestionsResponse questionsResponse = new QuestionsResponse();
+        KbvResult kbvResult = new KbvResult();
+        kbvResult.setNextTransId(new String[] {"END"});
+        kbvResult.setAuthenticationResult(authenticationResult);
+        kbvResult.setAnswerSummary(kbvQuestionAnswerSummary);
+        questionsResponse.setResults(kbvResult);
+        return questionsResponse;
     }
 }


### PR DESCRIPTION
## Proposed changes

Modify  event IPV_KBV_CRI_VC_ISSUED event to capture outcome of questions

Before: 

```
{
    "timestamp": 1685458522,
    "event_name": "IPV_KBV_CRI_VC_ISSUED",
    "component_id": "https://review-k.dev.account.gov.uk",
    "user": {
        "user_id": "urn:fdc:gov.uk:2022:36509924-997d-40db-8eb1-7b7d9588d6d0",
        "ip_address": "xx.xxx.x.x",
        "session_id": "d853a50d-c913-4466-9f20-9b902bfa7fa9",
        "persistent_session_id": "03ab21b9-df3d-4a41-9750-8219d661bc0c",
        "govuk_signin_journey_id": "7a0xx9d2-4494-4a82-8xx8-5e6bd471e31b"
    },
    "extensions": {
        "evidence": [
            {
                "txn": "8FCLCRTCZQ",
                "verificationScore": 2,
                "checkDetails": [
                    {
                        "checkMethod": "kbv",
                        "kbvResponseMode": "multiple_choice",
                        "kbvQuality": 2
                    },
                    {
                        "checkMethod": "kbv",
                        "kbvResponseMode": "multiple_choice",
                        "kbvQuality": 3
                    },
                    {
                        "checkMethod": "kbv",
                        "kbvResponseMode": "multiple_choice",
                        "kbvQuality": 3
                    }
                ],
                "type": "IdentityCheck"
            }
        ],
        "iss": "https://review-k.dev.account.gov.uk"
    }
}
```

After:

```
{
  "timestamp": 1707146722,
  "event_name": "IPV_KBV_CRI_VC_ISSUED",
  "component_id": "https://review-k.dev.account.gov.uk",
  "user": {
    "user_id": "urn:fdc:gov.uk:2022:ff271697-9f8c-4ae6-b5b1-0a2a1246a4c1",
    "ip_address": "xxx.xxx.xxx.xx",
    "session_id": "f4d4c60c-04b4-49bc-8514-cdbc33c0183d",
    "persistent_session_id": "830XX60e-2203-4e5d-9e01-538aXXXe960c",
    "govuk_signin_journey_id": "567XXXe70-e1c7-4a97-ad83-634dfbXX9cc3"
  },
  "extensions": {
    "experianIiqResponse": {
      "totalQuestionsAnsweredCorrect": 3,
      "totalQuestionsAsked": 4,
      "totalQuestionsAnsweredIncorrect": 1,
      "outcome": "Authenticated"
    },
    "iss": "https://review-k.dev.account.gov.uk",
    "evidence": [
      {
        "txn": "9BSSCJXBQ6",
        "verificationScore": 2,
        "checkDetails": [
          {
            "checkMethod": "kbv",
            "kbvResponseMode": "multiple_choice",
            "kbvQuality": 2
          },
          {
            "checkMethod": "kbv",
            "kbvResponseMode": "multiple_choice",
            "kbvQuality": 2
          },
          {
            "checkMethod": "kbv",
            "kbvResponseMode": "multiple_choice",
            "kbvQuality": 3
          }
        ],
        "failedCheckDetails": [
          {
            "checkMethod": "kbv",
            "kbvResponseMode": "multiple_choice"
          }
        ],
        "type": "IdentityCheck"
      }
    ]
  }
}

```

### What changed

There is an intention to share the VC issued event across to the RP’s in the audit event stream as part of the shared signals stream. In order to minimize the number of events being sent across to the RP’s , the outcome of the number of questions asked and whether they were correct or incorrect is added to the IPV_KBV_CRI_VC_ISSUED event payload


- [OJ-2241](https://govukverify.atlassian.net/browse/OJ-2241)

## Check

### Other considerations

- update confluence documentation

[OJ-2241]: https://govukverify.atlassian.net/browse/OJ-2241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ