### PR TITLE
OJ-2277  Add event IPV_KBV_CRI_ABANDONED

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -535,9 +535,12 @@ Resources:
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-abandon"
+          SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
       Policies:
         - AWSLambdaBasicExecutionRole
         - AWSXrayWriteOnlyAccess
+        - SQSSendMessagePolicy:
+            QueueName: !ImportValue AuditEventQueueName
         - DynamoDBReadPolicy:
             TableName: !Ref KBVTable
         - DynamoDBWritePolicy:
@@ -553,6 +556,15 @@ Resources:
             Resource:
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/SessionTableName"
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/KBVTableName"
+              - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/verifiable-credential/issuer"
+        - Statement:
+            - Sid: auditEventQueueKmsEncryptionKeyPermission
+              Effect: Allow
+              Action:
+                - 'kms:Decrypt'
+                - 'kms:GenerateDataKey'
+              Resource:
+                - !ImportValue AuditEventQueueEncryptionKeyArn
 
   KBVAbandonFunctionLogGroup:
     Type: AWS::Logs::LogGroup

--- a/lambdas/abandon/build.gradle
+++ b/lambdas/abandon/build.gradle
@@ -8,7 +8,8 @@ dependencies {
 	implementation project(":lib"),
 			configurations.cri_common_lib,
 			configurations.aws,
-			configurations.lambda
+			configurations.lambda,
+			configurations.sqs
 
 	aspect configurations.powertools
 	testImplementation configurations.tests

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/IIQAuditEventType.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/IIQAuditEventType.java
@@ -1,9 +1,13 @@
 package uk.gov.di.ipv.cri.kbv.api.domain;
 
+import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+@ExcludeFromGeneratedCoverageReport
 public enum IIQAuditEventType {
     EXPERIAN_IIQ_STARTED, // Generated once after the very first successful request i.e
     // (IPV_KBV_CRI_REQUEST_SENT) to Experian for KBV (Knowledge Based
     // Verification) CRI. Signals an event that can be used for billing
+    ABANDONED, // An event for when a user explicit abandons an Experian KBV journey.
     THIN_FILE_ENCOUNTERED // A Thin File event (Insufficient questions); occurs when a user has 2 or
     // less
     // s questions


### PR DESCRIPTION
[OJ-2277] Add event IPV_KBV_CRI_ABANDONED
https://govukverify.atlassian.net/browse/OJ-2277

## Proposed changes

### What changed

creating permissions to allow sending of sqs messages, audit Queue permissions and verifiable-credential
updating Gradle configurations
implemented auditing into AbandonKbvHandler, and updated the IIQAuditEventType to contain the abandoned type.

### Why did it change

to allow the data analytics team to correctly calculate metrics

### Issue tracking
- [OJ-2277](https://govukverify.atlassian.net/browse/OJ-2277)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[OJ-2277]: https://govukverify.atlassian.net/browse/OJ-2277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OJ-2277]: https://govukverify.atlassian.net/browse/OJ-2277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ