### PR TITLE
OJ-2545: Add CloudFront header tests

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -23,11 +23,15 @@ jobs:
     name: Run tests
     needs: deploy
     uses: ./.github/workflows/run-integration-tests.yml
+    permissions:
+      id-token: write
+      contents: read
     with:
       aws-region: ${{ needs.deploy.outputs.aws-region }}
       stack-name: ${{ needs.deploy.outputs.stack-name }}
       stack-outputs: ${{ needs.deploy.outputs.stack-outputs }}
     secrets:
+      aws_role_arn: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
       api-gateway-api-key: ${{ secrets.API_KEY_CRI_DEV }}
       ipv-core-stub-basic-auth-user: ${{ secrets.IPV_CORE_STUB_BASIC_AUTH_USER }}
       ipv-core-stub-basic-auth-pwd: ${{ secrets.IPV_CORE_STUB_BASIC_AUTH_PASSWORD }}

--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           gradle-version: 7.4.2
 

--- a/.github/workflows/post-merge-deploy-to-dev.yml
+++ b/.github/workflows/post-merge-deploy-to-dev.yml
@@ -36,7 +36,7 @@ jobs:
           version: 1.74.0
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           gradle-version: 7.4.2
 

--- a/.github/workflows/post-merge-package-for-build.yml
+++ b/.github/workflows/post-merge-package-for-build.yml
@@ -36,7 +36,7 @@ jobs:
           version: 1.74.0
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           gradle-version: 7.4.2
 

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -15,8 +15,8 @@ on:
 permissions: {}
 
 concurrency:
-  group: integration-tests-${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: true
+  group: integration-tests
+  cancel-in-progress: false
 
 jobs:
   run-tests:

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           gradle-version: 7.4.2
 

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -3,10 +3,11 @@ name: Integration tests
 on:
   workflow_call:
     inputs:
-      aws-region: { required: false, type: string }
+      aws-region: { required: true, type: string }
       stack-name: { required: true, type: string }
       stack-outputs: { required: true, type: string }
     secrets:
+      aws_role_arn: { required: true }
       api-gateway-api-key: { required: true }
       ipv-core-stub-basic-auth-pwd: { required: true }
       ipv-core-stub-basic-auth-user: { required: true }
@@ -23,6 +24,9 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     environment: di-ipv-cri-dev
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Pull repository
         uses: actions/checkout@v4
@@ -31,6 +35,12 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           gradle-version: 7.4.2
+
+      - name: Assume AWS Role
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.aws_role_arn }}
+          aws-region: ${{ inputs.aws-region }}
 
       - name: Run tests
         env:
@@ -45,4 +55,4 @@ jobs:
           IPV_CORE_STUB_CRI_ID: kbv-cri-dev
           DEFAULT_CLIENT_ID: ipv-core-stub-aws-build
           APIGW_API_KEY: ${{ secrets.api-gateway-api-key }}
-        run: ./gradlew integration-tests:cucumber
+        run: ./gradlew --no-daemon integration-tests:cucumber

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           gradle-version: 7.4.2
 

--- a/.github/workflows/scan-repo.yml
+++ b/.github/workflows/scan-repo.yml
@@ -32,7 +32,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           gradle-version: 7.4.2
 

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ hs_err_pid*
 .gradle
 /integration-tests/target/
 /integration-tests/bin/
+
+# Environment variables for local test running
+.env

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ ext {
 		mockito					 : "4.3.1",
 		glassfish_version        : "3.0.3",
 		powertools_version       : "1.12.3",
-		cri_common_lib           : "1.6.1",
+		cri_common_lib           : "2.1.0",
 	]
 }
 
@@ -69,7 +69,7 @@ subprojects {
 
 	dependencies {
 
-		aws platform('software.amazon.awssdk:bom:2.17.191')
+		aws platform('software.amazon.awssdk:bom:2.20.162')
 
 		dynamodb "software.amazon.awssdk:dynamodb",
 				"software.amazon.awssdk:dynamodb-enhanced"
@@ -77,7 +77,6 @@ subprojects {
 		lambda "software.amazon.awssdk:lambda",
 				"com.amazonaws:aws-lambda-java-events:${dependencyVersions.aws_lambda_events_version}"
 		//"org.apache.httpcomponents:httpclient:4.5.13"
-
 
 		sqs "software.amazon.awssdk:sqs"
 
@@ -105,7 +104,6 @@ subprojects {
 				"software.amazon.lambda:powertools-metrics:${dependencyVersions.powertools_version}",
 				"software.amazon.lambda:powertools-tracing:${dependencyVersions.powertools_version}",
 				"software.amazon.lambda:powertools-parameters:${dependencyVersions.powertools_version}"
-
 
 		tests "org.junit.jupiter:junit-jupiter-api:${dependencyVersions.junit}",
 				"org.junit.jupiter:junit-jupiter-params:${dependencyVersions.junit}",

--- a/deploy.sh
+++ b/deploy.sh
@@ -31,5 +31,6 @@ sam deploy --stack-name "$stack_name" \
   cri:deployment-source=manual \
   --parameter-overrides \
   Environment=dev \
+  SecretPrefix=pre-merge-test \
   ${common_stack_name:+CommonStackName=$common_stack_name} \
   ${secret_prefix:+SecretPrefix=$secret_prefix}

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -23,9 +23,9 @@ Parameters:
     Type: String
     Default: "none"
   SecretPrefix:
-    Type: String
-    Default: "none"
     Description: Secrets name prefix
+    Type: String
+    Default: ""
   AuditEventNamePrefix:
     Description: "The audit event name prefix"
     Type: AWS::SSM::Parameter::Value<String>
@@ -37,34 +37,23 @@ Parameters:
   CommonStackName:
     Description: "The name of the stack containing the common CRI lambdas/infra"
     Type: String
-    Default: "common-cri-api"
+    Default: common-cri-api
+  TxmaStackName:
+    Description: "The stack containing the TXMA infrastructure"
+    Type: String
+    Default: txma-infrastructure
 
 Conditions:
-  UseCodeSigningConfigArn:
-    Fn::Not:
-      - Fn::Equals:
-          - !Ref CodeSigningConfigArn
-          - "none"
+  UseCodeSigningConfigArn: !Not [!Equals [!Ref CodeSigningConfigArn, "none"]]
+  UsePermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundary, "none"]]
   IsStubEnvironment: !Or
     - !Equals [ !Ref Environment, dev]
     - !Equals [ !Ref Environment, build ]
     - !Equals [ !Ref Environment, staging ]
     - !Equals [ !Ref Environment, integration ]
-  IsDevEnvironment: !Equals
-    - !Ref Environment
-    - dev
-  IsNotDevEnvironment: !Not
-    - Condition: IsDevEnvironment
-  UsePermissionsBoundary:
-    Fn::Not:
-      - Fn::Equals:
-          - !Ref PermissionsBoundary
-          - "none"
-  UseSecretPrefix:
-    Fn::Not:
-      - Fn::Equals:
-        - !Ref SecretPrefix
-        - "none"
+  IsDevEnvironment: !Equals [!Ref Environment, dev]
+  IsNotDevEnvironment: !Not [!Condition IsDevEnvironment]
+  UseSecretPrefix: !Not [!Equals [!Ref SecretPrefix, ""]]
 
 Globals:
   Function:
@@ -387,7 +376,8 @@ Resources:
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-question"
-          SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
+          SQS_AUDIT_EVENT_QUEUE_URL:
+            Fn::ImportValue: !Sub ${TxmaStackName}-AuditEventQueueUrl
       Policies:
         - AWSLambdaBasicExecutionRole
         - AWSXrayWriteOnlyAccess
@@ -402,7 +392,8 @@ Resources:
         - DynamoDBReadPolicy:
             TableName: !Sub "{{resolve:ssm:/${CommonStackName}/PersonIdentityTableName}}"
         - SQSSendMessagePolicy:
-            QueueName: !ImportValue AuditEventQueueName
+            QueueName:
+              Fn::ImportValue: !Sub ${TxmaStackName}-AuditEventQueueName
         - KMSDecryptPolicy:
             KeyId: !ImportValue core-infrastructure-CriDecryptionKey1Id
         - Statement:
@@ -436,10 +427,10 @@ Resources:
             - Sid: auditEventQueueKmsEncryptionKeyPermission
               Effect: Allow
               Action:
-                - 'kms:Decrypt'
-                - 'kms:GenerateDataKey'
+                - kms:Decrypt
+                - kms:GenerateDataKey
               Resource:
-                - !ImportValue AuditEventQueueEncryptionKeyArn
+                Fn::ImportValue: !Sub ${TxmaStackName}-AuditEventQueueEncryptionKeyArn
 
   KBVQuestionFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -463,7 +454,8 @@ Resources:
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-answer"
-          SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
+          SQS_AUDIT_EVENT_QUEUE_URL:
+            Fn::ImportValue: !Sub ${TxmaStackName}-AuditEventQueueUrl
       Policies:
         - AWSLambdaBasicExecutionRole
         - AWSXrayWriteOnlyAccess
@@ -476,7 +468,8 @@ Resources:
         - DynamoDBWritePolicy:
             TableName: !Sub "{{resolve:ssm:/${CommonStackName}/SessionTableName}}"
         - SQSSendMessagePolicy:
-            QueueName: !ImportValue AuditEventQueueName
+            QueueName:
+              Fn::ImportValue: !Sub ${TxmaStackName}-AuditEventQueueName
         - KMSDecryptPolicy:
             KeyId: !ImportValue core-infrastructure-CriDecryptionKey1Id
         - Statement:
@@ -508,10 +501,10 @@ Resources:
             - Sid: auditEventQueueKmsEncryptionKeyPermission
               Effect: Allow
               Action:
-                - 'kms:Decrypt'
-                - 'kms:GenerateDataKey'
+                - kms:Decrypt
+                - kms:GenerateDataKey
               Resource:
-                - !ImportValue AuditEventQueueEncryptionKeyArn
+                Fn::ImportValue: !Sub ${TxmaStackName}-AuditEventQueueEncryptionKeyArn
 
   KBVAnswerFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -535,12 +528,14 @@ Resources:
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-abandon"
-          SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
+          SQS_AUDIT_EVENT_QUEUE_URL:
+            Fn::ImportValue: !Sub ${TxmaStackName}-AuditEventQueueUrl
       Policies:
         - AWSLambdaBasicExecutionRole
         - AWSXrayWriteOnlyAccess
         - SQSSendMessagePolicy:
-            QueueName: !ImportValue AuditEventQueueName
+            QueueName:
+              Fn::ImportValue: !Sub ${TxmaStackName}-AuditEventQueueName
         - DynamoDBReadPolicy:
             TableName: !Ref KBVTable
         - DynamoDBWritePolicy:
@@ -561,10 +556,10 @@ Resources:
             - Sid: auditEventQueueKmsEncryptionKeyPermission
               Effect: Allow
               Action:
-                - 'kms:Decrypt'
-                - 'kms:GenerateDataKey'
+                - kms:Decrypt
+                - kms:GenerateDataKey
               Resource:
-                - !ImportValue AuditEventQueueEncryptionKeyArn
+                Fn::ImportValue: !Sub ${TxmaStackName}-AuditEventQueueEncryptionKeyArn
 
   KBVAbandonFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -588,7 +583,8 @@ Resources:
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-issuecredential"
-          SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
+          SQS_AUDIT_EVENT_QUEUE_URL:
+            Fn::ImportValue: !Sub ${TxmaStackName}-AuditEventQueueUrl
       Policies:
         - AWSLambdaBasicExecutionRole
         - AWSXrayWriteOnlyAccess
@@ -604,7 +600,8 @@ Resources:
               - "kms:Sign"
             Resource: !ImportValue core-infrastructure-CriVcSigningKey1Arn
         - SQSSendMessagePolicy:
-            QueueName: !ImportValue AuditEventQueueName
+            QueueName:
+              Fn::ImportValue: !Sub ${TxmaStackName}-AuditEventQueueName
         - Statement:
             Effect: Allow
             Action:
@@ -626,7 +623,7 @@ Resources:
               - kms:Decrypt
               - kms:GenerateDataKey
             Resource:
-              - !ImportValue AuditEventQueueEncryptionKeyArn
+              Fn::ImportValue: !Sub ${TxmaStackName}-AuditEventQueueEncryptionKeyArn
 
   IssueCredentialFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -643,7 +640,7 @@ Resources:
       LogGroupName: !Ref IssueCredentialFunctionLogGroup
 
   KBVTable:
-    Type: "AWS::DynamoDB::Table"
+    Type: AWS::DynamoDB::Table
     Properties:
       TableName: !Sub "kbv-${AWS::StackName}"
       BillingMode: "PAY_PER_REQUEST"
@@ -914,11 +911,6 @@ Resources:
             Stat: Sum
 
 Outputs:
-
-  StackName:
-    Description: "CloudFormation stack name"
-    Value: !Sub "${AWS::StackName}"
-
   PublicKBVApiGatewayId:
     Description: "API GatewayID of the public KBV CRI API"
     Value: !Sub "${PublicKBVApi}"

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -4,7 +4,6 @@ plugins {
 }
 
 repositories {
-	mavenLocal()
 	maven {
 		url = uri('https://repo.maven.apache.org/maven2/')
 	}
@@ -20,8 +19,7 @@ ext {
 }
 
 dependencies {
-
-	implementation project(":lib")
+	testImplementation project(":lib")
 
 	testImplementation(testFixtures("uk.gov.account:cri-common-lib:${dependencyVersions.cri_common_lib}"))
 	testImplementation "io.cucumber:cucumber-java:$cucumberVersion"
@@ -41,6 +39,7 @@ configurations {
 }
 
 def tags = findProperty('tags') == null ? 'not @Ignore' : "${findProperty('tags')} and not @Ignore"
+
 test {
 	systemProperty "cucumber.filter.tags", System.getProperty("cucumber.filter.tags")
 	systemProperty "cucumber.options", System.properties.getProperty("cucumber.options")

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -33,6 +33,11 @@ dependencies {
 }
 
 configurations {
+	testImplementation {
+		// Disable instrumentation for local integration test clients
+		exclude group: "com.amazonaws", module: "aws-xray-recorder-sdk-aws-sdk-v2-instrumentor"
+	}
+
 	cucumberRuntime {
 		extendsFrom testImplementation
 	}

--- a/integration-tests/src/test/java/gov/uk/kbv/api/client/KbvApiClient.java
+++ b/integration-tests/src/test/java/gov/uk/kbv/api/client/KbvApiClient.java
@@ -75,7 +75,7 @@ public class KbvApiClient {
                                                 this.clientConfigurationService.createUriPath(
                                                         "question"))
                                         .build())
-                        .timeout(Duration.ofSeconds(20))
+                        .timeout(Duration.ofSeconds(40))
                         .header(HttpHeaders.ACCEPT, JSON_MIME_MEDIA_TYPE)
                         .header(HttpHeaders.SESSION_ID, sessionId)
                         .GET()

--- a/integration-tests/src/test/resources/features/KbvApiAbandonPath.feature
+++ b/integration-tests/src/test/resources/features/KbvApiAbandonPath.feature
@@ -5,35 +5,37 @@ Feature: 3 out of 4 strategy. User has 2 KBV questions. Tests are run against th
   Scenario: User abandons first question
     Given user has the test-identity 197 in the form of a signed JWT string
 
-    #Session
+    # Session
     When user sends a POST request to session end point
     Then user gets a session-id
 
-    #First Question
-    When user sends a GET request to question end point
+    # First question
+    When user sends a GET request to question endpoint
     Then user gets status code 200
 
-    #Abandon
+    # Abandon
     When user chooses to abandon the question
     Then user gets status code 200
+    And 5 events are deleted from the audit events SQS queue
 
   Scenario: User abandons second question
     Given user has the test-identity 197 in the form of a signed JWT string
 
-    #Session
+    # Session
     When user sends a POST request to session end point
     Then user gets a session-id
 
-    #First Question
-    When user sends a GET request to question end point
+    # First question
+    When user sends a GET request to question endpoint
     Then user gets status code 200
     And user answers the question correctly
     Then user gets status code 200
 
-    #Second Question
-    When user sends a GET request to question end point
+    # Second question
+    When user sends a GET request to question endpoint
     Then user gets status code 200
 
-    #Abandon
+    # Abandon
     When user chooses to abandon the question
     Then user gets status code 200
+    And 5 events are deleted from the audit events SQS queue

--- a/integration-tests/src/test/resources/features/KbvApiHappyPath.feature
+++ b/integration-tests/src/test/resources/features/KbvApiHappyPath.feature
@@ -1,47 +1,100 @@
 Feature: 3 out of 4 strategy. User has 2 KBV questions. Tests are run against the KBV Stub.
   User answers the two questions correctly and gets valid JWT from the credential issuer
 
-  @pre_merge_happy
-  Scenario: User answers 2 questions correctly
+  @pre_merge_happy_with_device_information_header
+  Scenario: User answers 2 questions correctly with device information header
     Given user has the test-identity 197 in the form of a signed JWT string
 
-    #Session
-    When user sends a POST request to session end point
+    # Session
+    When user sends a POST request to session end point with txma header
     Then user gets a session-id
 
-    #First Question
-    When user sends a GET request to question end point
+    # TXMA event
+    Then TXMA event is added to the SQS queue containing device information header
+
+    # First question
+    When user sends a GET request to question endpoint
     Then user gets status code 200
     And user answers the question correctly
     Then user gets status code 200
 
-    #Second Question
-    When user sends a GET request to question end point
+    # Second question
+    When user sends a GET request to question endpoint
     Then user gets status code 200
     And user answers the question correctly
     Then user gets status code 200
 
-    #Third Question
-    When user sends a GET request to question end point
+    # Third question
+    When user sends a GET request to question endpoint
     Then user gets status code 200
     And user answers the question correctly
     Then user gets status code 200
 
-    When user sends a GET request to question end point when there are no questions left
+    When user sends a GET request to question endpoint when there are no questions left
     Then user gets status code 204
 
-    #Authorization
+    # Authorization
     When user sends a GET request to authorization end point
     Then user gets status code 200
     And a valid authorization code is returned in the response
 
-    #Access Token
+    # Access token
     When user sends a POST request to token end point
     Then user gets status code 200
     And a valid access token code is returned in the response
 
-    #Credential Issue
-    When user sends a POST request to Credential Issue end point with a valid access token
+    # Credential issued
+    When user sends a POST request to credential issue endpoint with a valid access token
     Then user gets status code 200
     And a valid JWT is returned in the response
     And a verification score of 2 is returned in the response
+    And 10 events are deleted from the audit events SQS queue
+
+  @pre_merge_happy
+  Scenario: User answers 2 questions correctly
+    Given user has the test-identity 197 in the form of a signed JWT string
+
+    # Session
+    When user sends a POST request to session end point
+    Then user gets a session-id
+
+    # TXMA event
+    Then TXMA event is added to the SQS queue not containing device information header
+
+    # First question
+    When user sends a GET request to question endpoint
+    Then user gets status code 200
+    And user answers the question correctly
+    Then user gets status code 200
+
+    # Second question
+    When user sends a GET request to question endpoint
+    Then user gets status code 200
+    And user answers the question correctly
+    Then user gets status code 200
+
+    # Third question
+    When user sends a GET request to question endpoint
+    Then user gets status code 200
+    And user answers the question correctly
+    Then user gets status code 200
+
+    When user sends a GET request to question endpoint when there are no questions left
+    Then user gets status code 204
+
+    # Authorization
+    When user sends a GET request to authorization end point
+    Then user gets status code 200
+    And a valid authorization code is returned in the response
+
+    # Access token
+    When user sends a POST request to token end point
+    Then user gets status code 200
+    And a valid access token code is returned in the response
+
+    # Credential issued
+    When user sends a POST request to credential issue endpoint with a valid access token
+    Then user gets status code 200
+    And a valid JWT is returned in the response
+    And a verification score of 2 is returned in the response
+    And 10 events are deleted from the audit events SQS queue

--- a/integration-tests/src/test/resources/features/KbvApiUnhappyPath.feature
+++ b/integration-tests/src/test/resources/features/KbvApiUnhappyPath.feature
@@ -5,36 +5,37 @@ Feature: 3 out of 4 strategy. User has 2 KBV questions. Tests are run against th
   Scenario: User answers 2 questions incorrectly
     Given user has the test-identity 197 in the form of a signed JWT string
 
-    #Session
+    # Session
     When user sends a POST request to session end point
     Then user gets a session-id
 
-     #First Question
-    When user sends a GET request to question end point
+    # First question
+    When user sends a GET request to question endpoint
     Then user gets status code 200
     And user answers the question incorrectly
     Then user gets status code 200
 
-    #Second Question
-    When user sends a GET request to question end point
+    # Second question
+    When user sends a GET request to question endpoint
     Then user gets status code 200
     And user answers the question incorrectly
     Then user gets status code 200
 
-    When user sends a GET request to question end point when there are no questions left
+    When user sends a GET request to question endpoint when there are no questions left
     Then user gets status code 204
 
-    #Authorization
+    # Authorization
     When user sends a GET request to authorization end point
     Then user gets status code 200
     And a valid authorization code is returned in the response
 
-    #Access Token
+    # Access token
     When user sends a POST request to token end point
     Then user gets status code 200
     And a valid access token code is returned in the response
 
-    #Credential Issue
-    When user sends a POST request to Credential Issue end point with a valid access token
+    # Credential issue
+    When user sends a POST request to credential issue endpoint with a valid access token
     Then user gets status code 200
     And a verification score of 0 is returned in the response
+    And 8 events are deleted from the audit events SQS queue


### PR DESCRIPTION
**OJ-2545: Add CloudFront integration tests**

**Tests**
- Check for the device information header in the CRI start message
- Use the SQS and CloudFormation helpers from common-lib
- Update GHA to run the new integration tests
   Run integration tests sequentially between PRs to avoid SQS concurrency issues.
- Use `JsonPointer` to make assertions for JSON objects
- Exclude the XRay package so tests can run wihtout having to intialise XRay tracing and segments
- Upgrade the version of the common-lib to get the SQS and CF helper
  Update the AWS SDK version to match.

**Fixes**
- Use prefixed TxMA exports
  The non-prefixed exports are deprecated and will be removed in the future.
- Use the correct secret prefix for local developer stacks
- Ignore `.env` file to allow to set env vars for local integration tests