### PR TITLE
OJ-2520: Implement Fix

### DIFF
--- a/lambdas/answer/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandler.java
+++ b/lambdas/answer/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandler.java
@@ -225,13 +225,7 @@ public class QuestionAnswerHandler
     private APIGatewayProxyResponseEvent handleException(
             int httpStatusCode, Throwable throwable, String errorMessage) {
         eventProbe.log(ERROR, throwable).counterMetric(LAMBDA_NAME, 0d);
-        return httpStatusCode == HttpStatusCode.NO_CONTENT
-                ? createNoContentResponse()
-                : ApiGatewayResponseGenerator.proxyJsonResponse(
-                        httpStatusCode, Map.of(ERROR_KEY, errorMessage));
-    }
-
-    private APIGatewayProxyResponseEvent createNoContentResponse() {
-        return new APIGatewayProxyResponseEvent().withStatusCode(HttpStatusCode.NO_CONTENT);
+        return ApiGatewayResponseGenerator.proxyJsonResponse(
+                httpStatusCode, Map.of(ERROR_KEY, errorMessage));
     }
 }

--- a/lambdas/answer/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandler.java
+++ b/lambdas/answer/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandler.java
@@ -47,7 +47,6 @@ import static uk.gov.di.ipv.cri.common.library.error.ErrorResponse.SESSION_NOT_F
 import static uk.gov.di.ipv.cri.kbv.api.domain.KbvResponsesAuditExtension.EXPERIAN_IIQ_RESPONSE;
 import static uk.gov.di.ipv.cri.kbv.api.domain.KbvResponsesAuditExtension.createAuditEventExtensions;
 
-@ExcludeFromGeneratedCoverageReport
 public class QuestionAnswerHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 

--- a/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionHandler.java
+++ b/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionHandler.java
@@ -197,12 +197,9 @@ public class QuestionHandler
             QuestionsResponse questionsResponse, QuestionState questionState) {
 
         if (questionsResponse != null && questionsResponse.hasQuestions()) {
-            StringBuilder questionResponseBuilder = new StringBuilder();
-            for (var item : questionsResponse.getQuestions()) {
-                questionResponseBuilder.append(item.getQuestionId()).append(",");
-            }
-            String questionResponseString = questionResponseBuilder.toString();
-            LOGGER.info("QUESTION HANDLER: questionId from 3rd-party {}", questionResponseString);
+            LOGGER.info(
+                    "QUESTION HANDLER: QuestionIds from 3rd-party {}",
+                    questionsResponse.getAllQuestionIds());
             questionState.setQAPairs(questionsResponse.getQuestions());
             return questionState.getNextQuestion();
         }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/QuestionAnswer.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/QuestionAnswer.java
@@ -4,6 +4,15 @@ public class QuestionAnswer {
     private String questionId;
     private String answer;
 
+    public QuestionAnswer() {
+        this(new QuestionAnswerPair());
+    }
+
+    public QuestionAnswer(QuestionAnswerPair questionAnswerPair) {
+        this.questionId = questionAnswerPair.getQuestion().getQuestionId();
+        this.answer = questionAnswerPair.getAnswer();
+    }
+
     public String getQuestionId() {
         return questionId;
     }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/QuestionAnswerPair.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/QuestionAnswerPair.java
@@ -5,7 +5,9 @@ public class QuestionAnswerPair {
     private KbvQuestion question;
     private String answer;
 
-    public QuestionAnswerPair() {}
+    public QuestionAnswerPair() {
+        this(new KbvQuestion());
+    }
 
     public QuestionAnswerPair(KbvQuestion question) {
         this.question = question;

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/QuestionAnswerRequest.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/QuestionAnswerRequest.java
@@ -1,11 +1,14 @@
 package uk.gov.di.ipv.cri.kbv.api.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class QuestionAnswerRequest {
     @NotBlank(message = "{questionAnswerRequest.urn.required}")
@@ -41,5 +44,12 @@ public class QuestionAnswerRequest {
 
     public List<QuestionAnswer> getQuestionAnswers() {
         return questionAnswers;
+    }
+
+    @JsonIgnore
+    public String getAllQuestionIdAnswered() {
+        return this.getQuestionAnswers().stream()
+                .map(QuestionAnswer::getQuestionId)
+                .collect(Collectors.joining(","));
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/QuestionState.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/QuestionState.java
@@ -125,15 +125,7 @@ public class QuestionState {
 
     @JsonIgnore
     public List<QuestionAnswer> getAnswers() {
-        return getQaPairs().stream()
-                .map(
-                        pair -> {
-                            QuestionAnswer questionAnswer = new QuestionAnswer();
-                            questionAnswer.setAnswer(pair.getAnswer());
-                            questionAnswer.setQuestionId(pair.getQuestion().getQuestionId());
-                            return questionAnswer;
-                        })
-                .collect(Collectors.toList());
+        return getQaPairs().stream().map(QuestionAnswer::new).collect(Collectors.toList());
     }
 
     @JsonIgnore

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/QuestionState.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/QuestionState.java
@@ -3,7 +3,6 @@ package uk.gov.di.ipv.cri.kbv.api.domain;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -15,7 +14,6 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-@ExcludeFromGeneratedCoverageReport
 public class QuestionState {
     private static final Logger LOGGER = LogManager.getLogger(QuestionState.class);
     private List<QuestionAnswerPair> qaPairs = new ArrayList<>();

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/QuestionsResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/QuestionsResponse.java
@@ -2,7 +2,9 @@ package uk.gov.di.ipv.cri.kbv.api.domain;
 
 import com.nimbusds.oauth2.sdk.util.StringUtils;
 
+import java.util.Arrays;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 public class QuestionsResponse {
     private String uniqueReference;
@@ -30,6 +32,12 @@ public class QuestionsResponse {
 
     public KbvQuestion[] getQuestions() {
         return questions;
+    }
+
+    public String getAllQuestionIds() {
+        return Arrays.stream(this.getQuestions())
+                .map(KbvQuestion::getQuestionId)
+                .collect(Collectors.joining(","));
     }
 
     public void setQuestions(KbvQuestion[] questions) {

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/domain/QuestionStateTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/domain/QuestionStateTest.java
@@ -7,12 +7,16 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.cri.kbv.api.util.TestDataCreator.getExperianQuestionResponse;
+import static uk.gov.di.ipv.cri.kbv.api.util.TestDataCreator.getQuestion;
 import static uk.gov.di.ipv.cri.kbv.api.util.TestDataCreator.getQuestionOne;
 import static uk.gov.di.ipv.cri.kbv.api.util.TestDataCreator.getQuestionTwo;
 
@@ -24,6 +28,55 @@ class QuestionStateTest {
     @BeforeEach
     void setUp() {
         questionState = new QuestionState();
+    }
+
+    @Test
+    void shouldReturnTrueWhenIthasAtLeastOneUnanswered() {
+        QuestionsResponse questionsResponse =
+                getExperianQuestionResponse(
+                        new KbvQuestion[] {getQuestion("Q00015"), getQuestion("Q00040")});
+
+        questionState.setQAPairs(questionsResponse.getQuestions());
+
+        assertTrue(questionState.hasAtLeastOneUnanswered());
+    }
+
+    @Test
+    void shouldReturnFalseWhenIthasAtLeastOneUnansweredIsFalse() {
+        QuestionsResponse questionsResponse =
+                getExperianQuestionResponse(
+                        new KbvQuestion[] {getQuestion("Q00015"), getQuestion("Q00040")});
+
+        questionState.setQAPairs(questionsResponse.getQuestions());
+
+        QuestionAnswer questionAnswer = new QuestionAnswer();
+        questionAnswer.setQuestionId("Q00015");
+        questionAnswer.setAnswer("Answered Q00015");
+        questionState.setAnswer(questionAnswer);
+
+        questionAnswer.setQuestionId("Q00040");
+        questionAnswer.setAnswer("Answered Q00015");
+        questionState.setAnswer(questionAnswer);
+
+        assertFalse(questionState.hasAtLeastOneUnanswered());
+        assertNotNull(questionState.getAnswers());
+        assertEquals(2, questionState.getAnswers().size());
+    }
+
+    @Test
+    void shouldReturnAllQaPairs() {
+        QuestionsResponse questionsResponse1 =
+                getExperianQuestionResponse(
+                        new KbvQuestion[] {getQuestion("Q00015"), getQuestion("Q00040")});
+        QuestionsResponse questionsResponse2 =
+                getExperianQuestionResponse(
+                        new KbvQuestion[] {getQuestion("Q00045"), getQuestion("Q00067")});
+
+        questionState.setQAPairs(questionsResponse1.getQuestions());
+        questionState.setQAPairs(questionsResponse2.getQuestions());
+
+        assertNotNull(questionState.getAllQaPairs());
+        assertEquals(2, questionState.getAllQaPairs().size());
     }
 
     @Test
@@ -97,6 +150,52 @@ class QuestionStateTest {
 
         assertTrue(questionState.allQuestionBatchSizesMatch(2));
         assertEquals(4, questionState.getQuestionIdsFromQAPairs().count());
+    }
+
+    @Test
+    void shouldReturnAllQaPairsWhenNewQuestionsAreSetInBatchesOf2And2() {
+        QuestionsResponse questionsResponse1 =
+                getExperianQuestionResponse(
+                        new KbvQuestion[] {getQuestion("Q00015"), getQuestion("Q00040")});
+        QuestionsResponse questionsResponse2 =
+                getExperianQuestionResponse(
+                        new KbvQuestion[] {getQuestion("Q00045"), getQuestion("Q00067")});
+
+        questionState.setQAPairs(questionsResponse1.getQuestions());
+        questionState.setQAPairs(questionsResponse2.getQuestions());
+
+        assertTrue(questionState.allQuestionBatchSizesMatch(2));
+
+        assertAll(
+                () -> {
+                    assertEquals("Q00015,Q00040,Q00045,Q00067", questionState.getAllQaPairsIds());
+                    assertEquals("Q00045,Q00067", questionState.getQaPairsIds());
+                });
+    }
+
+    @Test
+    void shouldReturnNextQuestionWhenCurrentQuestionIsAnswered() {
+        QuestionsResponse questionsResponse =
+                getExperianQuestionResponse(
+                        new KbvQuestion[] {getQuestion("Q00015"), getQuestion("Q00040")});
+
+        questionState.setQAPairs(questionsResponse.getQuestions());
+
+        QuestionAnswer questionAnswer = new QuestionAnswer();
+        questionAnswer.setQuestionId("Q00015");
+        questionAnswer.setAnswer("Answered Q00015");
+        questionState.setAnswer(questionAnswer);
+
+        assertEquals("Q00040", questionState.getNextQuestion().get().getQuestionId());
+    }
+
+    @Test
+    void shouldThrowIllegalStateExceptionWhenAnUnknownQuestionIsAnswered() {
+        QuestionAnswer questionAnswer = new QuestionAnswer();
+        questionAnswer.setQuestionId("Q00015");
+        questionAnswer.setAnswer("Answered Q00015");
+
+        assertThrows(IllegalStateException.class, () -> questionState.setAnswer(questionAnswer));
     }
 
     @Test

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/util/TestDataCreator.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/util/TestDataCreator.java
@@ -136,6 +136,18 @@ public class TestDataCreator {
         return question;
     }
 
+    public static KbvQuestion getQuestion(String questionId) {
+        KbvQuestionOptions questionOptions = new KbvQuestionOptions();
+        questionOptions.setIdentifier(questionId);
+        questionOptions.setFieldType("G");
+
+        KbvQuestion question = new KbvQuestion();
+        question.setQuestionId(questionId);
+        question.setQuestionOptions(questionOptions);
+
+        return question;
+    }
+
     public static QuestionState getQuestionState(KbvQuestion[] kbvQuestions) {
         QuestionState questionState = new QuestionState();
         questionState.setQAPairs(kbvQuestions);


### PR DESCRIPTION
## Proposed changes

When Resubmission occurs,  the next question should be return instead of an exception.
If there is no recorded store for an the answered question throw the IllegalStateException.

### What changed

Logging revealed likelyhood of resubmissions i.e could be because of the following:

- The user pressed the back button and the state did not update causing them to see the previous question again.
- They re-submitted the KBV answer because the page could have been slow
- Lost connection during submission
- Duplicated the browser tab so the previous question was still available to them

### How

When attempting the to save an answer, for resubmission it is logged instead of throwing an error nothing is done further
https://github.com/govuk-one-login/ipv-cri-kbv-api/blob/main/lambdas/answer/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandler.java#L240 will be true
The code here https://github.com/govuk-one-login/ipv-cri-kbv-api/blob/main/lambdas/answer/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandler.java#L167
will be called

### Why did it change

An IllegalStateException was thrown when resubmission occurs, however user should just be presented the next question

- [OJ-2520](https://govukverify.atlassian.net/browse/OJ-2520)


[OJ-2520]: https://govukverify.atlassian.net/browse/OJ-2520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ