### PR TITLE
OJ-2606: Changed StrategyMapping param to a json string to support multiple st…

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -139,11 +139,11 @@ Mappings:
 
   IIQAPIStrategyMapping:
     Environment:
-      dev: 3 out of 4 prioritised
-      build: 3 out of 4 prioritised
-      staging: 3 out of 4 prioritised
-      integration: 3 out of 4 prioritised
-      production: 3 out of 4 prioritised
+      dev: "{\"2\": \"3 out of 4 prioritised\"}"
+      build: "{\"2\": \"3 out of 4 prioritised\"}"
+      staging: "{\"2\": \"3 out of 4 prioritised\"}"
+      integration: "{\"2\": \"3 out of 4 prioritised\"}"
+      production: "{\"2\": \"3 out of 4 prioritised\"}"
 
   IIQOperatorIdMapping:
     Environment:
@@ -405,6 +405,7 @@ Resources:
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/SessionTtl"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/PersonIdentityTableName"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/verifiable-credential/issuer"
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/di-ipv-cri-kbv-api/strengthScore"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/KBVTableName"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/IIQDatabaseMode"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/IIQStrategy"

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: "2010-09-09"
-Transform: "AWS::Serverless-2016-10-31"
+Transform: [AWS::Serverless-2016-10-31, AWS::LanguageExtensions]
 Description: "Digital Identity IPV CRI KBV API"
 
 Parameters:
@@ -136,14 +136,6 @@ Mappings:
       staging: Static
       integration: Static
       production: Normal
-
-  IIQAPIStrategyMapping:
-    Environment:
-      dev: "{\"2\": \"3 out of 4 prioritised\"}"
-      build: "{\"2\": \"3 out of 4 prioritised\"}"
-      staging: "{\"2\": \"3 out of 4 prioritised\"}"
-      integration: "{\"2\": \"3 out of 4 prioritised\"}"
-      production: "{\"2\": \"3 out of 4 prioritised\"}"
 
   IIQOperatorIdMapping:
     Environment:
@@ -405,7 +397,6 @@ Resources:
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/SessionTtl"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/PersonIdentityTableName"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/verifiable-credential/issuer"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/di-ipv-cri-kbv-api/strengthScore"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/KBVTableName"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/IIQDatabaseMode"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/IIQStrategy"
@@ -740,7 +731,9 @@ Resources:
     Properties:
       Name: !Sub "/${AWS::StackName}/IIQStrategy"
       Type: String
-      Value: !FindInMap [ IIQAPIStrategyMapping, Environment, !Ref 'Environment' ]
+      Value:
+        Fn::ToJsonString:
+          "2": "3 out of 4 prioritised"
       Description: Strategy to be used for Experian KBV Questions. Example - 3 of 4
 
   IIQOperatorIdParameter:

--- a/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/exception/InvalidStrategyScoreException.java
+++ b/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/exception/InvalidStrategyScoreException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.ipv.cri.kbv.api.exception;
+
+public class InvalidStrategyScoreException extends RuntimeException {
+    public InvalidStrategyScoreException(String message) {
+        super(message);
+    }
+}

--- a/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionHandler.java
+++ b/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionHandler.java
@@ -59,11 +59,11 @@ public class QuestionHandler
     public static final String HEADER_SESSION_ID = "session-id";
     public static final String LAMBDA_NAME = "get_question";
     public static final String ERROR_KEY = "error";
-    public static final String VERIFICATION_SCORE_PARAM_NAME = "di-ipv-cri-kbv-api/strengthScore";
     public static final String IIQ_STRATEGY_PARAM_NAME = "IIQStrategy";
     private static final String IIQ_OPERATOR_ID_PARAM_NAME = "IIQOperatorId";
     public static final String METRIC_DIMENSION_QUESTION_ID = "kbv_question_id";
     public static final String METRIC_DIMENSION_QUESTION_STRATEGY = "question_strategy";
+    private static final String SESSION_VERIFICATION_SCORE = "2";
     private final ObjectMapper objectMapper;
     private final KBVStorageService kbvStorageService;
     private final PersonIdentityService personIdentityService;
@@ -255,13 +255,11 @@ public class QuestionHandler
 
     private String retrieveQuestionStrategy()
             throws JsonProcessingException, InvalidStrategyScoreException {
-        var verificationScoreParam =
-                this.configurationService.getCommonParameterValue(VERIFICATION_SCORE_PARAM_NAME);
         var strategyParam = this.configurationService.getParameterValue(IIQ_STRATEGY_PARAM_NAME);
 
         Map<String, String> strategyMap =
                 objectMapper.readValue(strategyParam, new TypeReference<>() {});
-        String strategy = strategyMap.get(verificationScoreParam);
+        String strategy = strategyMap.get(SESSION_VERIFICATION_SCORE);
         LOGGER.info("Using IIQStrategy: {}", strategy);
         if (strategy == null) {
             throw new InvalidStrategyScoreException(

--- a/lambdas/question/src/test/java/uk.gov.di.ipv.cri.kbv.api.handler/QuestionHandlerTest.java
+++ b/lambdas/question/src/test/java/uk.gov.di.ipv.cri.kbv.api.handler/QuestionHandlerTest.java
@@ -79,7 +79,7 @@ import static uk.gov.di.ipv.cri.kbv.api.handler.QuestionHandler.IIQ_STRATEGY_PAR
 import static uk.gov.di.ipv.cri.kbv.api.handler.QuestionHandler.LAMBDA_NAME;
 import static uk.gov.di.ipv.cri.kbv.api.handler.QuestionHandler.METRIC_DIMENSION_QUESTION_ID;
 import static uk.gov.di.ipv.cri.kbv.api.handler.QuestionHandler.METRIC_DIMENSION_QUESTION_STRATEGY;
-import static uk.gov.di.ipv.cri.kbv.api.handler.QuestionHandler.STRENGTH_SCORE_PARAM_NAME;
+import static uk.gov.di.ipv.cri.kbv.api.handler.QuestionHandler.VERIFICATION_SCORE_PARAM_NAME;
 
 @ExtendWith(MockitoExtension.class)
 class QuestionHandlerTest {
@@ -155,7 +155,7 @@ class QuestionHandlerTest {
             doReturn(experianQuestionResponse).when(spyKBVService).getQuestions(any());
 
             when(mockObjectMapper.writeValueAsString(any())).thenReturn(expectedQuestion);
-            when(mockConfigurationService.getCommonParameterValue(STRENGTH_SCORE_PARAM_NAME))
+            when(mockConfigurationService.getCommonParameterValue(VERIFICATION_SCORE_PARAM_NAME))
                     .thenReturn("2");
             when(mockConfigurationService.getParameterValue(IIQ_STRATEGY_PARAM_NAME))
                     .thenReturn(MOCK_IIQ_STRATEGY_PARAM_VALUE);
@@ -283,7 +283,7 @@ class QuestionHandlerTest {
             when(mockObjectMapper.readValue(kbvItem.getQuestionState(), QuestionState.class))
                     .thenReturn(questionStateMock);
 
-            when(mockConfigurationService.getCommonParameterValue(STRENGTH_SCORE_PARAM_NAME))
+            when(mockConfigurationService.getCommonParameterValue(VERIFICATION_SCORE_PARAM_NAME))
                     .thenReturn("2");
             when(mockConfigurationService.getParameterValue(IIQ_STRATEGY_PARAM_NAME))
                     .thenReturn(MOCK_IIQ_STRATEGY_PARAM_VALUE);
@@ -474,7 +474,7 @@ class QuestionHandlerTest {
 
             when(mockKBVGateway.getQuestions(any(QuestionRequest.class)))
                     .thenReturn(questionsResponse);
-            when(mockConfigurationService.getCommonParameterValue(STRENGTH_SCORE_PARAM_NAME))
+            when(mockConfigurationService.getCommonParameterValue(VERIFICATION_SCORE_PARAM_NAME))
                     .thenReturn("2");
             when(mockConfigurationService.getParameterValue(IIQ_STRATEGY_PARAM_NAME))
                     .thenReturn(MOCK_IIQ_STRATEGY_PARAM_VALUE);
@@ -577,7 +577,7 @@ class QuestionHandlerTest {
             QuestionsResponse experianQuestionResponse = getExperianQuestionResponse();
             doReturn(experianQuestionResponse).when(spyKBVService).getQuestions(any());
 
-            when(mockConfigurationService.getCommonParameterValue(STRENGTH_SCORE_PARAM_NAME))
+            when(mockConfigurationService.getCommonParameterValue(VERIFICATION_SCORE_PARAM_NAME))
                     .thenReturn("2");
             when(mockConfigurationService.getParameterValue(IIQ_STRATEGY_PARAM_NAME))
                     .thenReturn(MOCK_IIQ_STRATEGY_PARAM_VALUE);
@@ -604,7 +604,7 @@ class QuestionHandlerTest {
             SessionItem sessionItem = mock(SessionItem.class);
             Map<String, String> requestHeaders = new HashMap<>();
 
-            when(mockConfigurationService.getCommonParameterValue(STRENGTH_SCORE_PARAM_NAME))
+            when(mockConfigurationService.getCommonParameterValue(VERIFICATION_SCORE_PARAM_NAME))
                     .thenReturn("2");
             when(mockConfigurationService.getParameterValue(IIQ_STRATEGY_PARAM_NAME))
                     .thenReturn(MOCK_IIQ_STRATEGY_PARAM_VALUE);
@@ -655,7 +655,7 @@ class QuestionHandlerTest {
                     .when(spyKBVService)
                     .getQuestions(any(QuestionRequest.class));
 
-            when(mockConfigurationService.getCommonParameterValue(STRENGTH_SCORE_PARAM_NAME))
+            when(mockConfigurationService.getCommonParameterValue(VERIFICATION_SCORE_PARAM_NAME))
                     .thenReturn("2");
             when(mockConfigurationService.getParameterValue(IIQ_STRATEGY_PARAM_NAME))
                     .thenReturn(MOCK_IIQ_STRATEGY_PARAM_VALUE);
@@ -706,7 +706,7 @@ class QuestionHandlerTest {
                     .when(spyKBVService)
                     .getQuestions(any(QuestionRequest.class));
 
-            when(mockConfigurationService.getCommonParameterValue(STRENGTH_SCORE_PARAM_NAME))
+            when(mockConfigurationService.getCommonParameterValue(VERIFICATION_SCORE_PARAM_NAME))
                     .thenReturn("2");
             when(mockConfigurationService.getParameterValue(IIQ_STRATEGY_PARAM_NAME))
                     .thenReturn(MOCK_IIQ_STRATEGY_PARAM_VALUE);
@@ -754,7 +754,7 @@ class QuestionHandlerTest {
                     .when(spyKBVService)
                     .getQuestions(any(QuestionRequest.class));
 
-            when(mockConfigurationService.getCommonParameterValue(STRENGTH_SCORE_PARAM_NAME))
+            when(mockConfigurationService.getCommonParameterValue(VERIFICATION_SCORE_PARAM_NAME))
                     .thenReturn("2");
             when(mockConfigurationService.getParameterValue(IIQ_STRATEGY_PARAM_NAME))
                     .thenReturn(MOCK_IIQ_STRATEGY_PARAM_VALUE);

--- a/lambdas/question/src/test/java/uk.gov.di.ipv.cri.kbv.api.handler/QuestionHandlerTest.java
+++ b/lambdas/question/src/test/java/uk.gov.di.ipv.cri.kbv.api.handler/QuestionHandlerTest.java
@@ -79,12 +79,11 @@ import static uk.gov.di.ipv.cri.kbv.api.handler.QuestionHandler.IIQ_STRATEGY_PAR
 import static uk.gov.di.ipv.cri.kbv.api.handler.QuestionHandler.LAMBDA_NAME;
 import static uk.gov.di.ipv.cri.kbv.api.handler.QuestionHandler.METRIC_DIMENSION_QUESTION_ID;
 import static uk.gov.di.ipv.cri.kbv.api.handler.QuestionHandler.METRIC_DIMENSION_QUESTION_STRATEGY;
-import static uk.gov.di.ipv.cri.kbv.api.handler.QuestionHandler.VERIFICATION_SCORE_PARAM_NAME;
 
 @ExtendWith(MockitoExtension.class)
 class QuestionHandlerTest {
     private static final String MOCK_IIQ_STRATEGY_PARAM_VALUE =
-            "\"2\": \"3 out of 4 prioritised\"}";
+            "{\"2\": \"3 out of 4 prioritised\"}";
     private static final Map<String, String> MOCK_IIQ_STRATEGY_MAPPED_VALUE =
             Map.of("2", "3 out of 4 prioritised");
 
@@ -155,8 +154,6 @@ class QuestionHandlerTest {
             doReturn(experianQuestionResponse).when(spyKBVService).getQuestions(any());
 
             when(mockObjectMapper.writeValueAsString(any())).thenReturn(expectedQuestion);
-            when(mockConfigurationService.getCommonParameterValue(VERIFICATION_SCORE_PARAM_NAME))
-                    .thenReturn("2");
             when(mockConfigurationService.getParameterValue(IIQ_STRATEGY_PARAM_NAME))
                     .thenReturn(MOCK_IIQ_STRATEGY_PARAM_VALUE);
             when(mockObjectMapper.readValue(
@@ -283,8 +280,6 @@ class QuestionHandlerTest {
             when(mockObjectMapper.readValue(kbvItem.getQuestionState(), QuestionState.class))
                     .thenReturn(questionStateMock);
 
-            when(mockConfigurationService.getCommonParameterValue(VERIFICATION_SCORE_PARAM_NAME))
-                    .thenReturn("2");
             when(mockConfigurationService.getParameterValue(IIQ_STRATEGY_PARAM_NAME))
                     .thenReturn(MOCK_IIQ_STRATEGY_PARAM_VALUE);
             when(mockObjectMapper.readValue(
@@ -474,8 +469,6 @@ class QuestionHandlerTest {
 
             when(mockKBVGateway.getQuestions(any(QuestionRequest.class)))
                     .thenReturn(questionsResponse);
-            when(mockConfigurationService.getCommonParameterValue(VERIFICATION_SCORE_PARAM_NAME))
-                    .thenReturn("2");
             when(mockConfigurationService.getParameterValue(IIQ_STRATEGY_PARAM_NAME))
                     .thenReturn(MOCK_IIQ_STRATEGY_PARAM_VALUE);
             when(mockObjectMapper.readValue(
@@ -577,8 +570,6 @@ class QuestionHandlerTest {
             QuestionsResponse experianQuestionResponse = getExperianQuestionResponse();
             doReturn(experianQuestionResponse).when(spyKBVService).getQuestions(any());
 
-            when(mockConfigurationService.getCommonParameterValue(VERIFICATION_SCORE_PARAM_NAME))
-                    .thenReturn("2");
             when(mockConfigurationService.getParameterValue(IIQ_STRATEGY_PARAM_NAME))
                     .thenReturn(MOCK_IIQ_STRATEGY_PARAM_VALUE);
             when(mockObjectMapper.readValue(
@@ -604,8 +595,6 @@ class QuestionHandlerTest {
             SessionItem sessionItem = mock(SessionItem.class);
             Map<String, String> requestHeaders = new HashMap<>();
 
-            when(mockConfigurationService.getCommonParameterValue(VERIFICATION_SCORE_PARAM_NAME))
-                    .thenReturn("2");
             when(mockConfigurationService.getParameterValue(IIQ_STRATEGY_PARAM_NAME))
                     .thenReturn(MOCK_IIQ_STRATEGY_PARAM_VALUE);
             when(mockObjectMapper.readValue(
@@ -655,8 +644,6 @@ class QuestionHandlerTest {
                     .when(spyKBVService)
                     .getQuestions(any(QuestionRequest.class));
 
-            when(mockConfigurationService.getCommonParameterValue(VERIFICATION_SCORE_PARAM_NAME))
-                    .thenReturn("2");
             when(mockConfigurationService.getParameterValue(IIQ_STRATEGY_PARAM_NAME))
                     .thenReturn(MOCK_IIQ_STRATEGY_PARAM_VALUE);
             when(mockObjectMapper.readValue(
@@ -706,8 +693,6 @@ class QuestionHandlerTest {
                     .when(spyKBVService)
                     .getQuestions(any(QuestionRequest.class));
 
-            when(mockConfigurationService.getCommonParameterValue(VERIFICATION_SCORE_PARAM_NAME))
-                    .thenReturn("2");
             when(mockConfigurationService.getParameterValue(IIQ_STRATEGY_PARAM_NAME))
                     .thenReturn(MOCK_IIQ_STRATEGY_PARAM_VALUE);
             when(mockObjectMapper.readValue(
@@ -754,8 +739,6 @@ class QuestionHandlerTest {
                     .when(spyKBVService)
                     .getQuestions(any(QuestionRequest.class));
 
-            when(mockConfigurationService.getCommonParameterValue(VERIFICATION_SCORE_PARAM_NAME))
-                    .thenReturn("2");
             when(mockConfigurationService.getParameterValue(IIQ_STRATEGY_PARAM_NAME))
                     .thenReturn(MOCK_IIQ_STRATEGY_PARAM_VALUE);
             when(mockObjectMapper.readValue(

--- a/lambdas/question/src/test/java/uk.gov.di.ipv.cri.kbv.api.handler/QuestionHandlerTest.java
+++ b/lambdas/question/src/test/java/uk.gov.di.ipv.cri.kbv.api.handler/QuestionHandlerTest.java
@@ -3,6 +3,8 @@ package uk.gov.di.ipv.cri.kbv.api.handler;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.logging.log4j.Level;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,12 +39,14 @@ import uk.gov.di.ipv.cri.kbv.api.domain.QuestionAnswer;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionRequest;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionState;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionsResponse;
+import uk.gov.di.ipv.cri.kbv.api.exception.InvalidStrategyScoreException;
 import uk.gov.di.ipv.cri.kbv.api.exception.QuestionNotFoundException;
 import uk.gov.di.ipv.cri.kbv.api.gateway.KBVGateway;
 import uk.gov.di.ipv.cri.kbv.api.service.KBVService;
 import uk.gov.di.ipv.cri.kbv.api.service.KBVStorageService;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -75,9 +79,15 @@ import static uk.gov.di.ipv.cri.kbv.api.handler.QuestionHandler.IIQ_STRATEGY_PAR
 import static uk.gov.di.ipv.cri.kbv.api.handler.QuestionHandler.LAMBDA_NAME;
 import static uk.gov.di.ipv.cri.kbv.api.handler.QuestionHandler.METRIC_DIMENSION_QUESTION_ID;
 import static uk.gov.di.ipv.cri.kbv.api.handler.QuestionHandler.METRIC_DIMENSION_QUESTION_STRATEGY;
+import static uk.gov.di.ipv.cri.kbv.api.handler.QuestionHandler.STRENGTH_SCORE_PARAM_NAME;
 
 @ExtendWith(MockitoExtension.class)
 class QuestionHandlerTest {
+    private static final String MOCK_IIQ_STRATEGY_PARAM_VALUE =
+            "\"2\": \"3 out of 4 prioritised\"}";
+    private static final Map<String, String> MOCK_IIQ_STRATEGY_MAPPED_VALUE =
+            Map.of("2", "3 out of 4 prioritised");
+
     private QuestionHandler questionHandler;
     @Mock private ObjectMapper mockObjectMapper;
     @Mock private KBVStorageService mockKBVStorageService;
@@ -145,8 +155,13 @@ class QuestionHandlerTest {
             doReturn(experianQuestionResponse).when(spyKBVService).getQuestions(any());
 
             when(mockObjectMapper.writeValueAsString(any())).thenReturn(expectedQuestion);
+            when(mockConfigurationService.getCommonParameterValue(STRENGTH_SCORE_PARAM_NAME))
+                    .thenReturn("2");
             when(mockConfigurationService.getParameterValue(IIQ_STRATEGY_PARAM_NAME))
-                    .thenReturn("3 out of 4");
+                    .thenReturn(MOCK_IIQ_STRATEGY_PARAM_VALUE);
+            when(mockObjectMapper.readValue(
+                            anyString(), Mockito.<TypeReference<Map<String, String>>>any()))
+                    .thenReturn(MOCK_IIQ_STRATEGY_MAPPED_VALUE);
             String expectedComponentId = "kbv-component-id";
             when(mockConfigurationService.getVerifiableCredentialIssuer())
                     .thenReturn(expectedComponentId);
@@ -179,7 +194,8 @@ class QuestionHandlerTest {
             verify(mockObjectMapper).writeValueAsString(any());
             verify(mockEventProbe).counterMetric(LAMBDA_NAME);
             verify(mockEventProbe)
-                    .addDimensions(Map.of(METRIC_DIMENSION_QUESTION_STRATEGY, "3 out of 4"));
+                    .addDimensions(
+                            Map.of(METRIC_DIMENSION_QUESTION_STRATEGY, "3 out of 4 prioritised"));
             verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_QUESTION_ID, "Q00015"));
             verifyNoMoreInteractions(mockEventProbe);
 
@@ -267,8 +283,13 @@ class QuestionHandlerTest {
             when(mockObjectMapper.readValue(kbvItem.getQuestionState(), QuestionState.class))
                     .thenReturn(questionStateMock);
 
+            when(mockConfigurationService.getCommonParameterValue(STRENGTH_SCORE_PARAM_NAME))
+                    .thenReturn("2");
             when(mockConfigurationService.getParameterValue(IIQ_STRATEGY_PARAM_NAME))
-                    .thenReturn("3 out of 4");
+                    .thenReturn(MOCK_IIQ_STRATEGY_PARAM_VALUE);
+            when(mockObjectMapper.readValue(
+                            anyString(), Mockito.<TypeReference<Map<String, String>>>any()))
+                    .thenReturn(MOCK_IIQ_STRATEGY_MAPPED_VALUE);
             when(mockConfigurationService.getVerifiableCredentialIssuer())
                     .thenReturn("kbv-component-id");
 
@@ -287,7 +308,8 @@ class QuestionHandlerTest {
             verify(mockConfigurationService).getParameterValue("IIQOperatorId");
             verify(mockEventProbe).counterMetric(LAMBDA_NAME, 0d);
             verify(mockEventProbe)
-                    .addDimensions(Map.of(METRIC_DIMENSION_QUESTION_STRATEGY, "3 out of 4"));
+                    .addDimensions(
+                            Map.of(METRIC_DIMENSION_QUESTION_STRATEGY, "3 out of 4 prioritised"));
             verifyNoMoreInteractions(mockEventProbe);
         }
 
@@ -434,7 +456,7 @@ class QuestionHandlerTest {
     class ProcessQuestionRequest {
         @Test
         void shouldThrowQuestionNotFoundExceptionWhenQuestionStateAndKbvItemEmptyObjects()
-                throws SqsException {
+                throws SqsException, JsonProcessingException {
             String expectedOutcome = "Insufficient Questions (Unable to Authenticate)";
             UUID sessionId = UUID.randomUUID();
             KBVItem kbvItem = mock(KBVItem.class);
@@ -452,8 +474,13 @@ class QuestionHandlerTest {
 
             when(mockKBVGateway.getQuestions(any(QuestionRequest.class)))
                     .thenReturn(questionsResponse);
+            when(mockConfigurationService.getCommonParameterValue(STRENGTH_SCORE_PARAM_NAME))
+                    .thenReturn("2");
             when(mockConfigurationService.getParameterValue(IIQ_STRATEGY_PARAM_NAME))
-                    .thenReturn("3 out of 4");
+                    .thenReturn(MOCK_IIQ_STRATEGY_PARAM_VALUE);
+            when(mockObjectMapper.readValue(
+                            anyString(), Mockito.<TypeReference<Map<String, String>>>any()))
+                    .thenReturn(MOCK_IIQ_STRATEGY_MAPPED_VALUE);
             when(mockConfigurationService.getVerifiableCredentialIssuer())
                     .thenReturn("kbv-component-id");
 
@@ -471,7 +498,8 @@ class QuestionHandlerTest {
                             auditEventMap.capture());
             verify(mockKBVStorageService).save(kbvItem);
             verify(mockEventProbe)
-                    .addDimensions(Map.of(METRIC_DIMENSION_QUESTION_STRATEGY, "3 out of 4"));
+                    .addDimensions(
+                            Map.of(METRIC_DIMENSION_QUESTION_STRATEGY, "3 out of 4 prioritised"));
             verifyNoMoreInteractions(mockEventProbe);
             verify(kbvItem).setAuthRefNo("an auth ref no");
             verify(kbvItem).setUrn("a urn");
@@ -549,8 +577,13 @@ class QuestionHandlerTest {
             QuestionsResponse experianQuestionResponse = getExperianQuestionResponse();
             doReturn(experianQuestionResponse).when(spyKBVService).getQuestions(any());
 
+            when(mockConfigurationService.getCommonParameterValue(STRENGTH_SCORE_PARAM_NAME))
+                    .thenReturn("2");
             when(mockConfigurationService.getParameterValue(IIQ_STRATEGY_PARAM_NAME))
-                    .thenReturn("3 out of 4");
+                    .thenReturn(MOCK_IIQ_STRATEGY_PARAM_VALUE);
+            when(mockObjectMapper.readValue(
+                            anyString(), Mockito.<TypeReference<Map<String, String>>>any()))
+                    .thenReturn(MOCK_IIQ_STRATEGY_MAPPED_VALUE);
             when(mockConfigurationService.getVerifiableCredentialIssuer())
                     .thenReturn("kbv-component-id");
 
@@ -561,6 +594,37 @@ class QuestionHandlerTest {
             assertEquals(
                     nextQuestionFromExperian.getQuestionId(),
                     experianQuestionResponse.getQuestions()[0].getQuestionId());
+        }
+
+        @Test
+        void shouldReturnThrowInvalidStrategyScoreExceptionWhenTheScoreIsNotSupported()
+                throws JsonProcessingException {
+            KBVItem kbvItem = mock(KBVItem.class);
+            QuestionState questionState = mock(QuestionState.class);
+            SessionItem sessionItem = mock(SessionItem.class);
+            Map<String, String> requestHeaders = new HashMap<>();
+
+            when(mockConfigurationService.getCommonParameterValue(STRENGTH_SCORE_PARAM_NAME))
+                    .thenReturn("2");
+            when(mockConfigurationService.getParameterValue(IIQ_STRATEGY_PARAM_NAME))
+                    .thenReturn(MOCK_IIQ_STRATEGY_PARAM_VALUE);
+            when(mockObjectMapper.readValue(
+                            anyString(), Mockito.<TypeReference<Map<String, String>>>any()))
+                    .thenReturn(Collections.emptyMap());
+
+            InvalidStrategyScoreException expectedException =
+                    assertThrows(
+                            InvalidStrategyScoreException.class,
+                            () ->
+                                    questionHandler.processQuestionRequest(
+                                            questionState, kbvItem, sessionItem, requestHeaders),
+                            "No question strategy found for score provided");
+
+            assertEquals(
+                    "No question strategy found for score provided",
+                    expectedException.getMessage());
+
+            verify(mockConfigurationService).getParameterValue("IIQStrategy");
         }
     }
 
@@ -591,8 +655,13 @@ class QuestionHandlerTest {
                     .when(spyKBVService)
                     .getQuestions(any(QuestionRequest.class));
 
+            when(mockConfigurationService.getCommonParameterValue(STRENGTH_SCORE_PARAM_NAME))
+                    .thenReturn("2");
             when(mockConfigurationService.getParameterValue(IIQ_STRATEGY_PARAM_NAME))
-                    .thenReturn("3 out of 4");
+                    .thenReturn(MOCK_IIQ_STRATEGY_PARAM_VALUE);
+            when(mockObjectMapper.readValue(
+                            anyString(), Mockito.<TypeReference<Map<String, String>>>any()))
+                    .thenReturn(MOCK_IIQ_STRATEGY_MAPPED_VALUE);
             when(mockConfigurationService.getVerifiableCredentialIssuer())
                     .thenReturn("kbv-component-id");
 
@@ -637,8 +706,13 @@ class QuestionHandlerTest {
                     .when(spyKBVService)
                     .getQuestions(any(QuestionRequest.class));
 
+            when(mockConfigurationService.getCommonParameterValue(STRENGTH_SCORE_PARAM_NAME))
+                    .thenReturn("2");
             when(mockConfigurationService.getParameterValue(IIQ_STRATEGY_PARAM_NAME))
-                    .thenReturn("3 out of 4");
+                    .thenReturn(MOCK_IIQ_STRATEGY_PARAM_VALUE);
+            when(mockObjectMapper.readValue(
+                            anyString(), Mockito.<TypeReference<Map<String, String>>>any()))
+                    .thenReturn(MOCK_IIQ_STRATEGY_MAPPED_VALUE);
             when(mockConfigurationService.getVerifiableCredentialIssuer())
                     .thenReturn("kbv-component-id");
 
@@ -680,8 +754,13 @@ class QuestionHandlerTest {
                     .when(spyKBVService)
                     .getQuestions(any(QuestionRequest.class));
 
+            when(mockConfigurationService.getCommonParameterValue(STRENGTH_SCORE_PARAM_NAME))
+                    .thenReturn("2");
             when(mockConfigurationService.getParameterValue(IIQ_STRATEGY_PARAM_NAME))
-                    .thenReturn("3 out of 4");
+                    .thenReturn(MOCK_IIQ_STRATEGY_PARAM_VALUE);
+            when(mockObjectMapper.readValue(
+                            anyString(), Mockito.<TypeReference<Map<String, String>>>any()))
+                    .thenReturn(MOCK_IIQ_STRATEGY_MAPPED_VALUE);
             when(mockConfigurationService.getVerifiableCredentialIssuer())
                     .thenReturn("kbv-component-id");
 


### PR DESCRIPTION
…rategies

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

<!-- Describe the changes in detail - the "what"-->
- Changed IIQStrategy to JSON to enable adding more types.
- Add score param to question handler to enable using the score to request different question strategies. 
- Updated tests in the QuestionHandler for the above.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
As a developer,
I want to ensure the Experian KBV API strategy mapping supports multiple strategies,
so that it can handle both the existing Medium Confidence journey and the new Low Confidence journey.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-2606](https://govukverify.atlassian.net/browse/OJ-2606)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[OJ-2606]: https://govukverify.atlassian.net/browse/OJ-2606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ