### PR TITLE
OJ-2612: Use correct verification score in VC (Approach 1)

### DIFF
--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/IssueCredentialHandler.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/IssueCredentialHandler.java
@@ -75,10 +75,10 @@ public class IssueCredentialHandler
 
     @ExcludeFromGeneratedCoverageReport
     public IssueCredentialHandler() throws JsonProcessingException {
-        this.verifiableCredentialService = new VerifiableCredentialService();
         ConfigurationService configurationService = new ConfigurationService();
         this.kbvStorageService = new KBVStorageService(configurationService);
         this.sessionService = new SessionService();
+        this.verifiableCredentialService = new VerifiableCredentialService(sessionService);
         this.eventProbe = new EventProbe();
         this.auditService =
                 new AuditService(

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactory.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactory.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import uk.gov.di.ipv.cri.common.library.service.SessionService;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.kbv.api.domain.CheckDetail;
 import uk.gov.di.ipv.cri.kbv.api.domain.ContraIndicator;
@@ -36,14 +37,17 @@ public class EvidenceFactory {
     private final EventProbe eventProbe;
     private final ObjectMapper objectMapper;
     private final Map<String, Integer> kbvQualityMapping;
+    private final SessionService sessionService;
 
     public EvidenceFactory(
             ObjectMapper objectMapper,
             EventProbe eventProbe,
-            Map<String, Integer> kbvQualityMapping) {
+            Map<String, Integer> kbvQualityMapping,
+            SessionService sessionService) {
         this.objectMapper = objectMapper;
         this.eventProbe = eventProbe;
         this.kbvQualityMapping = kbvQualityMapping;
+        this.sessionService = sessionService;
     }
 
     public Object[] create(KBVItem kbvItem) throws JsonProcessingException {

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactory.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactory.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import uk.gov.di.ipv.cri.common.library.persistence.item.SessionItem;
 import uk.gov.di.ipv.cri.common.library.service.SessionService;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.kbv.api.domain.CheckDetail;
@@ -58,7 +59,15 @@ public class EvidenceFactory {
             evidence.setFailedCheckDetails(createFailedCheckDetails(kbvItem));
         }
         if (VC_THIRD_PARTY_KBV_CHECK_PASS.equalsIgnoreCase(kbvItem.getStatus())) {
-            evidence.setVerificationScore(VC_PASS_EVIDENCE_SCORE);
+            SessionItem sessionItem = sessionService.getSession(kbvItem.getSessionId().toString());
+            int verificationScore = VC_PASS_EVIDENCE_SCORE;
+            if (Objects.nonNull(sessionItem) && Objects.nonNull(sessionItem.getEvidence())) {
+                Integer score = sessionItem.getEvidence().getVerificationScore();
+                if (score > 0) {
+                    verificationScore = score;
+                }
+            }
+            evidence.setVerificationScore(verificationScore);
             logVcScore("pass");
         } else {
             evidence.setVerificationScore(VC_FAIL_EVIDENCE_SCORE);

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/VerifiableCredentialService.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/VerifiableCredentialService.java
@@ -43,7 +43,8 @@ public class VerifiableCredentialService {
     private final EvidenceFactory evidenceFactory;
 
     @ExcludeFromGeneratedCoverageReport
-    public VerifiableCredentialService(SessionService sessionService) throws JsonProcessingException {
+    public VerifiableCredentialService(SessionService sessionService)
+            throws JsonProcessingException {
         this.configurationService = new ConfigurationService();
         this.signedJwtFactory =
                 new SignedJWTFactory(
@@ -59,7 +60,8 @@ public class VerifiableCredentialService {
         final Map<String, Integer> kbvQualityMapping =
                 objectMapper.readValue(kbvQualitySecretValue, Map.class);
         this.evidenceFactory =
-                new EvidenceFactory(this.objectMapper, new EventProbe(), kbvQualityMapping);
+                new EvidenceFactory(
+                        this.objectMapper, new EventProbe(), kbvQualityMapping, sessionService);
         this.vcClaimsSetBuilder =
                 new VerifiableCredentialClaimsSetBuilder(
                         this.configurationService, Clock.systemUTC());

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/VerifiableCredentialService.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/VerifiableCredentialService.java
@@ -12,6 +12,7 @@ import uk.gov.di.ipv.cri.common.library.domain.personidentity.Address;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.BirthDate;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentityDetailed;
 import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
+import uk.gov.di.ipv.cri.common.library.service.SessionService;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.common.library.util.KMSSigner;
 import uk.gov.di.ipv.cri.common.library.util.SignedJWTFactory;
@@ -42,7 +43,7 @@ public class VerifiableCredentialService {
     private final EvidenceFactory evidenceFactory;
 
     @ExcludeFromGeneratedCoverageReport
-    public VerifiableCredentialService() throws JsonProcessingException {
+    public VerifiableCredentialService(SessionService sessionService) throws JsonProcessingException {
         this.configurationService = new ConfigurationService();
         this.signedJwtFactory =
                 new SignedJWTFactory(

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactoryTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactoryTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.cri.common.library.service.SessionService;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.kbv.api.domain.CheckDetail;
 import uk.gov.di.ipv.cri.kbv.api.domain.ContraIndicator;
@@ -42,12 +43,16 @@ class EvidenceFactoryTest implements TestFixtures {
                     .registerModule(new Jdk8Module())
                     .registerModule(new JavaTimeModule());
     @Mock private EventProbe mockEventProbe;
+    @Mock private SessionService mockSessionService;
 
     @BeforeEach
     void setUp() {
         evidenceFactory =
                 new EvidenceFactory(
-                        objectMapper, mockEventProbe, KBV_QUESTION_QUALITY_MAPPING_SERIALIZED);
+                        objectMapper,
+                        mockEventProbe,
+                        KBV_QUESTION_QUALITY_MAPPING_SERIALIZED,
+                        mockSessionService);
     }
 
     @Nested
@@ -212,7 +217,8 @@ class EvidenceFactoryTest implements TestFixtures {
                             mockEventProbe,
                             objectMapper.readValue(
                                     "{\"First\":4,\"Second\": 5, \"Third\": 9, \"Fourth\": 9}",
-                                    Map.class));
+                                    Map.class),
+                            mockSessionService);
 
             var result = evidenceFactory.create(kbvItem);
 
@@ -268,7 +274,8 @@ class EvidenceFactoryTest implements TestFixtures {
                             mockEventProbe,
                             objectMapper.readValue(
                                     "{\"First\":4,\"Second\": 5, \"Third\": 9, \"Fourth\": 8}",
-                                    Map.class));
+                                    Map.class),
+                            mockSessionService);
 
             var result = evidenceFactory.create(kbvItem);
 

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/VerifiableCredentialServiceTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/VerifiableCredentialServiceTest.java
@@ -25,6 +25,7 @@ import uk.gov.di.ipv.cri.common.library.domain.personidentity.Name;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.NamePart;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentityDetailed;
 import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
+import uk.gov.di.ipv.cri.common.library.service.SessionService;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.common.library.util.SignedJWTFactory;
 import uk.gov.di.ipv.cri.common.library.util.VerifiableCredentialClaimsSetBuilder;
@@ -81,6 +82,7 @@ class VerifiableCredentialServiceTest {
     @Captor private ArgumentCaptor<Map<String, Object>[]> mapArrayArgumentCaptor;
     @Captor private ArgumentCaptor<Map<String, Object>> mapArgumentCaptor;
     private VerifiableCredentialService verifiableCredentialService;
+    @Mock private SessionService mockSessionService;
 
     @Nested
     class KbvVerifiableCredentialJwt implements TestFixtures {
@@ -110,7 +112,8 @@ class VerifiableCredentialServiceTest {
                             new EvidenceFactory(
                                     objectMapper,
                                     mockEventProbe,
-                                    KBV_QUESTION_QUALITY_MAPPING_SERIALIZED));
+                                    KBV_QUESTION_QUALITY_MAPPING_SERIALIZED,
+                                    mockSessionService));
             verifiableCredentialService =
                     new VerifiableCredentialService(
                             signedJwtFactory,
@@ -163,7 +166,8 @@ class VerifiableCredentialServiceTest {
                             new EvidenceFactory(
                                     objectMapper,
                                     mockEventProbe,
-                                    KBV_QUESTION_QUALITY_MAPPING_SERIALIZED));
+                                    KBV_QUESTION_QUALITY_MAPPING_SERIALIZED,
+                                    mockSessionService));
             verifiableCredentialService =
                     new VerifiableCredentialService(
                             signedJWTFactory,
@@ -204,7 +208,8 @@ class VerifiableCredentialServiceTest {
                             new EvidenceFactory(
                                     objectMapper,
                                     mockEventProbe,
-                                    KBV_QUESTION_QUALITY_MAPPING_SERIALIZED));
+                                    KBV_QUESTION_QUALITY_MAPPING_SERIALIZED,
+                                    mockSessionService));
             verifiableCredentialService =
                     new VerifiableCredentialService(
                             signedJWTFactory,


### PR DESCRIPTION
## Proposed changes

This is approach 1, passing the SessionService

### What changed
The `verification_score` property within a VC is now fetched from the SessionItem in DynamoDB. If there is no evidence block in the session item then the default value of 2 will be used.

### Why did it change
We now have multiple levels of confidence that has to be accurately reflected in the VC.

**Note**: This PR is not yet completed. This is because there's [another piece of work](https://govukverify.atlassian.net/browse/OJ-2607) to be able to fetch the evidence block from the session record that is being done in another ticket. Once that goes in, this PR needs to be rebased and the `getEvidence()` calls need to be updated to use the actual methods that have been created to return those results.

### Issue tracking
- [OJ-2612](https://govukverify.atlassian.net/browse/OJ-2612)


[OJ-2612]: https://govukverify.atlassian.net/browse/OJ-2612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ