### PR TITLE
OJ-2612: Use correct verification score in VC (Approach 2)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ ext {
 		mockito					 : "4.3.1",
 		glassfish_version        : "3.0.3",
 		powertools_version       : "1.12.3",
-		cri_common_lib           : "2.1.0",
+		cri_common_lib           : "2.2.0",
 	]
 }
 

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/Evidence.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/Evidence.java
@@ -2,6 +2,8 @@ package uk.gov.di.ipv.cri.kbv.api.domain;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import uk.gov.di.ipv.cri.common.library.persistence.item.EvidenceRequest;
+import uk.gov.di.ipv.cri.kbv.api.util.EvidenceUtils;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class Evidence {
@@ -30,6 +32,10 @@ public class Evidence {
 
     public void setVerificationScore(Integer verificationScore) {
         this.verificationScore = verificationScore;
+    }
+
+    public void setVerificationScore(EvidenceRequest evidenceRequest) {
+        this.verificationScore = EvidenceUtils.getVerificationScoreForPass(evidenceRequest);
     }
 
     public void setCi(ContraIndicator[] ci) {

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/IssueCredentialHandler.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/IssueCredentialHandler.java
@@ -109,7 +109,7 @@ public class IssueCredentialHandler
 
             SignedJWT signedJWT =
                     verifiableCredentialService.generateSignedVerifiableCredentialJwt(
-                            sessionItem.getSubject(), personIdentity, kbvItem, sessionItem);
+                            sessionItem, personIdentity, kbvItem);
             auditService.sendAuditEvent(
                     AuditEventType.VC_ISSUED,
                     new AuditEventContext(input.getHeaders(), sessionItem),

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/IssueCredentialHandler.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/IssueCredentialHandler.java
@@ -109,11 +109,11 @@ public class IssueCredentialHandler
 
             SignedJWT signedJWT =
                     verifiableCredentialService.generateSignedVerifiableCredentialJwt(
-                            sessionItem.getSubject(), personIdentity, kbvItem);
+                            sessionItem.getSubject(), personIdentity, kbvItem, sessionItem);
             auditService.sendAuditEvent(
                     AuditEventType.VC_ISSUED,
                     new AuditEventContext(input.getHeaders(), sessionItem),
-                    verifiableCredentialService.getAuditEventExtensions(kbvItem));
+                    verifiableCredentialService.getAuditEventExtensions(kbvItem, sessionItem));
             eventProbe.counterMetric(KBV_CREDENTIAL_ISSUER);
             auditService.sendAuditEvent(
                     AuditEventType.END, new AuditEventContext(input.getHeaders(), sessionItem));

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/IssueCredentialHandler.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/IssueCredentialHandler.java
@@ -113,7 +113,8 @@ public class IssueCredentialHandler
             auditService.sendAuditEvent(
                     AuditEventType.VC_ISSUED,
                     new AuditEventContext(input.getHeaders(), sessionItem),
-                    verifiableCredentialService.getAuditEventExtensions(kbvItem, sessionItem));
+                    verifiableCredentialService.getAuditEventExtensions(
+                            kbvItem, sessionItem.getEvidenceRequest()));
             eventProbe.counterMetric(KBV_CREDENTIAL_ISSUER);
             auditService.sendAuditEvent(
                     AuditEventType.END, new AuditEventContext(input.getHeaders(), sessionItem));

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactory.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactory.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import uk.gov.di.ipv.cri.common.library.persistence.item.EvidenceRequest;
 import uk.gov.di.ipv.cri.common.library.persistence.item.SessionItem;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.kbv.api.domain.CheckDetail;
@@ -56,7 +57,8 @@ public class EvidenceFactory {
             evidence.setFailedCheckDetails(createFailedCheckDetails(kbvItem));
         }
         if (VC_THIRD_PARTY_KBV_CHECK_PASS.equalsIgnoreCase(kbvItem.getStatus())) {
-            evidence.setVerificationScore(getVerificationScoreFromSession(sessionItem));
+            evidence.setVerificationScore(
+                    getVerificationScoreForPass(sessionItem.getEvidenceRequest()));
             logVcScore("pass");
         } else {
             evidence.setVerificationScore(VC_FAIL_EVIDENCE_SCORE);
@@ -69,11 +71,11 @@ public class EvidenceFactory {
         return new Map[] {objectMapper.convertValue(evidence, Map.class)};
     }
 
-    private int getVerificationScoreFromSession(SessionItem sessionItem) {
-        if (Objects.isNull(sessionItem) || Objects.isNull(sessionItem.getEvidenceRequest())) {
+    private int getVerificationScoreForPass(EvidenceRequest evidenceRequest) {
+        if (Objects.isNull(evidenceRequest)) {
             return VC_PASS_EVIDENCE_SCORE;
         }
-        int verificationScore = sessionItem.getEvidenceRequest().getVerificationScore();
+        int verificationScore = evidenceRequest.getVerificationScore();
         return verificationScore > 0 ? verificationScore : VC_PASS_EVIDENCE_SCORE;
     }
 

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactory.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactory.java
@@ -14,7 +14,6 @@ import uk.gov.di.ipv.cri.kbv.api.domain.KbvQuality;
 import uk.gov.di.ipv.cri.kbv.api.domain.KbvQuestion;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionAnswerPair;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionState;
-import uk.gov.di.ipv.cri.kbv.api.util.EvidenceUtils;
 
 import java.util.Collection;
 import java.util.Map;
@@ -56,8 +55,7 @@ public class EvidenceFactory {
             evidence.setFailedCheckDetails(createFailedCheckDetails(kbvItem));
         }
         if (VC_THIRD_PARTY_KBV_CHECK_PASS.equalsIgnoreCase(kbvItem.getStatus())) {
-            evidence.setVerificationScore(
-                    EvidenceUtils.getVerificationScoreForPass(evidenceRequest));
+            evidence.setVerificationScore(evidenceRequest);
             logVcScore("pass");
         } else {
             evidence.setVerificationScore(VC_FAIL_EVIDENCE_SCORE);

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/VerifiableCredentialService.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/VerifiableCredentialService.java
@@ -11,6 +11,7 @@ import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverage
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.Address;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.BirthDate;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentityDetailed;
+import uk.gov.di.ipv.cri.common.library.persistence.item.EvidenceRequest;
 import uk.gov.di.ipv.cri.common.library.persistence.item.SessionItem;
 import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
@@ -98,19 +99,20 @@ public class VerifiableCredentialService {
                                         personIdentity.getNames(),
                                         VC_BIRTHDATE_KEY,
                                         convertBirthDates(personIdentity.getBirthDates())))
-                        .verifiableCredentialEvidence(evidenceFactory.create(kbvItem, sessionItem))
+                        .verifiableCredentialEvidence(
+                                evidenceFactory.create(kbvItem, sessionItem.getEvidenceRequest()))
                         .build();
 
         return signedJwtFactory.createSignedJwt(claimsSet);
     }
 
-    public Map<String, Object> getAuditEventExtensions(KBVItem kbvItem, SessionItem sessionItem)
-            throws JsonProcessingException {
+    public Map<String, Object> getAuditEventExtensions(
+            KBVItem kbvItem, EvidenceRequest evidenceRequest) throws JsonProcessingException {
         return Map.of(
                 ISSUER,
                 configurationService.getVerifiableCredentialIssuer(),
                 VC_EVIDENCE_KEY,
-                evidenceFactory.create(kbvItem, sessionItem),
+                evidenceFactory.create(kbvItem, evidenceRequest),
                 EXPERIAN_IIQ_RESPONSE,
                 createAuditEventExtensions(
                         kbvItem.getStatus(), kbvItem.getQuestionAnswerResultSummary()));

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/VerifiableCredentialService.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/VerifiableCredentialService.java
@@ -80,17 +80,14 @@ public class VerifiableCredentialService {
 
     @Tracing
     public SignedJWT generateSignedVerifiableCredentialJwt(
-            String subject,
-            PersonIdentityDetailed personIdentity,
-            KBVItem kbvItem,
-            SessionItem sessionItem)
+            SessionItem sessionItem, PersonIdentityDetailed personIdentity, KBVItem kbvItem)
             throws JOSEException, JsonProcessingException {
         long jwtTtl = this.configurationService.getMaxJwtTtl();
         ChronoUnit jwtTtlUnit =
                 ChronoUnit.valueOf(this.configurationService.getParameterValue("JwtTtlUnit"));
         var claimsSet =
                 this.vcClaimsSetBuilder
-                        .subject(subject)
+                        .subject(sessionItem.getSubject())
                         .timeToLive(jwtTtl, jwtTtlUnit)
                         .verifiableCredentialType(KBV_CREDENTIAL_TYPE)
                         .verifiableCredentialSubject(

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/VerifiableCredentialService.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/VerifiableCredentialService.java
@@ -11,6 +11,7 @@ import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverage
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.Address;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.BirthDate;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentityDetailed;
+import uk.gov.di.ipv.cri.common.library.persistence.item.SessionItem;
 import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.common.library.util.KMSSigner;
@@ -79,7 +80,10 @@ public class VerifiableCredentialService {
 
     @Tracing
     public SignedJWT generateSignedVerifiableCredentialJwt(
-            String subject, PersonIdentityDetailed personIdentity, KBVItem kbvItem)
+            String subject,
+            PersonIdentityDetailed personIdentity,
+            KBVItem kbvItem,
+            SessionItem sessionItem)
             throws JOSEException, JsonProcessingException {
         long jwtTtl = this.configurationService.getMaxJwtTtl();
         ChronoUnit jwtTtlUnit =
@@ -97,19 +101,19 @@ public class VerifiableCredentialService {
                                         personIdentity.getNames(),
                                         VC_BIRTHDATE_KEY,
                                         convertBirthDates(personIdentity.getBirthDates())))
-                        .verifiableCredentialEvidence(evidenceFactory.create(kbvItem))
+                        .verifiableCredentialEvidence(evidenceFactory.create(kbvItem, sessionItem))
                         .build();
 
         return signedJwtFactory.createSignedJwt(claimsSet);
     }
 
-    public Map<String, Object> getAuditEventExtensions(KBVItem kbvItem)
+    public Map<String, Object> getAuditEventExtensions(KBVItem kbvItem, SessionItem sessionItem)
             throws JsonProcessingException {
         return Map.of(
                 ISSUER,
                 configurationService.getVerifiableCredentialIssuer(),
                 VC_EVIDENCE_KEY,
-                evidenceFactory.create(kbvItem),
+                evidenceFactory.create(kbvItem, sessionItem),
                 EXPERIAN_IIQ_RESPONSE,
                 createAuditEventExtensions(
                         kbvItem.getStatus(), kbvItem.getQuestionAnswerResultSummary()));

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/handler/IssueCredentialHandlerTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/handler/IssueCredentialHandlerTest.java
@@ -109,7 +109,8 @@ class IssueCredentialHandlerTest {
         when(mockKBVStorageService.getKBVItem(SESSION_ID)).thenReturn(kbvItem);
         when(mockPersonIdentityService.getPersonIdentityDetailed(SESSION_ID))
                 .thenReturn(personIdentity);
-        when(mockVerifiableCredentialService.getAuditEventExtensions(kbvItem, sessionItem))
+        when(mockVerifiableCredentialService.getAuditEventExtensions(
+                        kbvItem, sessionItem.getEvidenceRequest()))
                 .thenReturn(auditEventExtensions);
         when(mockVerifiableCredentialService.generateSignedVerifiableCredentialJwt(
                         sessionItem, personIdentity, kbvItem))

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/handler/IssueCredentialHandlerTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/handler/IssueCredentialHandlerTest.java
@@ -112,7 +112,7 @@ class IssueCredentialHandlerTest {
         when(mockVerifiableCredentialService.getAuditEventExtensions(kbvItem, sessionItem))
                 .thenReturn(auditEventExtensions);
         when(mockVerifiableCredentialService.generateSignedVerifiableCredentialJwt(
-                        SUBJECT, personIdentity, kbvItem, sessionItem))
+                        sessionItem, personIdentity, kbvItem))
                 .thenReturn(mock(SignedJWT.class));
 
         APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
@@ -120,8 +120,7 @@ class IssueCredentialHandlerTest {
         verify(mockSessionService).getSessionByAccessToken(accessToken);
         verify(mockKBVStorageService).getKBVItem(SESSION_ID);
         verify(mockVerifiableCredentialService)
-                .generateSignedVerifiableCredentialJwt(
-                        SUBJECT, personIdentity, kbvItem, sessionItem);
+                .generateSignedVerifiableCredentialJwt(sessionItem, personIdentity, kbvItem);
         verify(mockEventProbe).counterMetric(KBV_CREDENTIAL_ISSUER);
         verify(mockAuditService)
                 .sendAuditEvent(
@@ -167,7 +166,7 @@ class IssueCredentialHandlerTest {
         when(mockPersonIdentityService.getPersonIdentityDetailed(SESSION_ID))
                 .thenReturn(personIdentity);
         when(mockVerifiableCredentialService.generateSignedVerifiableCredentialJwt(
-                        SUBJECT, personIdentity, kbvItem, sessionItem))
+                        sessionItem, personIdentity, kbvItem))
                 .thenThrow(unExpectedJOSEException);
 
         APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
@@ -175,8 +174,7 @@ class IssueCredentialHandlerTest {
         verify(mockSessionService).getSessionByAccessToken(accessToken);
         verify(mockKBVStorageService).getKBVItem(SESSION_ID);
         verify(mockVerifiableCredentialService)
-                .generateSignedVerifiableCredentialJwt(
-                        SUBJECT, personIdentity, kbvItem, sessionItem);
+                .generateSignedVerifiableCredentialJwt(sessionItem, personIdentity, kbvItem);
         verify(mockEventProbe).log(Level.ERROR, unExpectedJOSEException);
         verify(mockEventProbe).counterMetric(KBV_CREDENTIAL_ISSUER, 0d);
         verifyNoMoreInteractions(mockVerifiableCredentialService);

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/handler/IssueCredentialHandlerTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/handler/IssueCredentialHandlerTest.java
@@ -109,10 +109,10 @@ class IssueCredentialHandlerTest {
         when(mockKBVStorageService.getKBVItem(SESSION_ID)).thenReturn(kbvItem);
         when(mockPersonIdentityService.getPersonIdentityDetailed(SESSION_ID))
                 .thenReturn(personIdentity);
-        when(mockVerifiableCredentialService.getAuditEventExtensions(kbvItem))
+        when(mockVerifiableCredentialService.getAuditEventExtensions(kbvItem, sessionItem))
                 .thenReturn(auditEventExtensions);
         when(mockVerifiableCredentialService.generateSignedVerifiableCredentialJwt(
-                        SUBJECT, personIdentity, kbvItem))
+                        SUBJECT, personIdentity, kbvItem, sessionItem))
                 .thenReturn(mock(SignedJWT.class));
 
         APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
@@ -120,7 +120,8 @@ class IssueCredentialHandlerTest {
         verify(mockSessionService).getSessionByAccessToken(accessToken);
         verify(mockKBVStorageService).getKBVItem(SESSION_ID);
         verify(mockVerifiableCredentialService)
-                .generateSignedVerifiableCredentialJwt(SUBJECT, personIdentity, kbvItem);
+                .generateSignedVerifiableCredentialJwt(
+                        SUBJECT, personIdentity, kbvItem, sessionItem);
         verify(mockEventProbe).counterMetric(KBV_CREDENTIAL_ISSUER);
         verify(mockAuditService)
                 .sendAuditEvent(
@@ -166,7 +167,7 @@ class IssueCredentialHandlerTest {
         when(mockPersonIdentityService.getPersonIdentityDetailed(SESSION_ID))
                 .thenReturn(personIdentity);
         when(mockVerifiableCredentialService.generateSignedVerifiableCredentialJwt(
-                        SUBJECT, personIdentity, kbvItem))
+                        SUBJECT, personIdentity, kbvItem, sessionItem))
                 .thenThrow(unExpectedJOSEException);
 
         APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
@@ -174,7 +175,8 @@ class IssueCredentialHandlerTest {
         verify(mockSessionService).getSessionByAccessToken(accessToken);
         verify(mockKBVStorageService).getKBVItem(SESSION_ID);
         verify(mockVerifiableCredentialService)
-                .generateSignedVerifiableCredentialJwt(SUBJECT, personIdentity, kbvItem);
+                .generateSignedVerifiableCredentialJwt(
+                        SUBJECT, personIdentity, kbvItem, sessionItem);
         verify(mockEventProbe).log(Level.ERROR, unExpectedJOSEException);
         verify(mockEventProbe).counterMetric(KBV_CREDENTIAL_ISSUER, 0d);
         verifyNoMoreInteractions(mockVerifiableCredentialService);

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactoryTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactoryTest.java
@@ -35,7 +35,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class EvidenceFactoryTest implements TestFixtures {

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactoryTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactoryTest.java
@@ -6,11 +6,15 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.cri.common.library.persistence.item.EvidenceRequest;
+import uk.gov.di.ipv.cri.common.library.persistence.item.SessionItem;
+import uk.gov.di.ipv.cri.common.library.service.SessionService;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.kbv.api.domain.CheckDetail;
 import uk.gov.di.ipv.cri.kbv.api.domain.ContraIndicator;
@@ -24,14 +28,14 @@ import uk.gov.di.ipv.cri.kbv.api.service.fixtures.TestFixtures;
 
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class EvidenceFactoryTest implements TestFixtures {
@@ -42,6 +46,8 @@ class EvidenceFactoryTest implements TestFixtures {
                     .registerModule(new Jdk8Module())
                     .registerModule(new JavaTimeModule());
     @Mock private EventProbe mockEventProbe;
+    @Mock private SessionItem mockSessionItem;
+    @Mock private SessionService mockSessionService;
 
     @BeforeEach
     void setUp() {
@@ -63,7 +69,7 @@ class EvidenceFactoryTest implements TestFixtures {
                     .when(mockEventProbe)
                     .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
 
-            var result = evidenceFactory.create(kbvItem);
+            var result = evidenceFactory.create(kbvItem, mockSessionItem);
 
             verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
             assertEquals(
@@ -84,7 +90,7 @@ class EvidenceFactoryTest implements TestFixtures {
                     .when(mockEventProbe)
                     .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
 
-            var result = evidenceFactory.create(kbvItem);
+            var result = evidenceFactory.create(kbvItem, mockSessionItem);
 
             verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
             assertEquals(
@@ -107,7 +113,7 @@ class EvidenceFactoryTest implements TestFixtures {
                     .when(mockEventProbe)
                     .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
 
-            var result = evidenceFactory.create(kbvItem);
+            var result = evidenceFactory.create(kbvItem, mockSessionItem);
 
             verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
             assertEquals(
@@ -127,7 +133,7 @@ class EvidenceFactoryTest implements TestFixtures {
                     .when(mockEventProbe)
                     .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
 
-            var result = evidenceFactory.create(kbvItem);
+            var result = evidenceFactory.create(kbvItem, mockSessionItem);
             verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
 
             assertEquals(
@@ -140,13 +146,53 @@ class EvidenceFactoryTest implements TestFixtures {
     @Nested
     class EvidenceCheckDetails {
         @Test
+        @DisplayName("should use the verification score from session item if present")
+        void shouldHaveAVerificationScoreOfOne() throws JsonProcessingException {
+            KBVItem kbvItem = getKbvItem();
+            UUID sessionId = UUID.randomUUID();
+            kbvItem.setSessionId(sessionId);
+            kbvItem.setStatus("authenticated");
+            kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(3, 3, 0));
+            setKbvItemQuestionState(kbvItem, "First", "Second", "Third");
+
+            SessionItem sessionItem = new SessionItem();
+            EvidenceRequest evidenceRequest = new EvidenceRequest();
+            evidenceRequest.setVerificationScore(1);
+            sessionItem.setEvidenceRequest(evidenceRequest);
+
+            var result = evidenceFactory.create(kbvItem, sessionItem);
+
+            assertEquals(
+                    evidenceRequest.getVerificationScore(),
+                    getEvidenceAsMap(result).get("verificationScore"));
+        }
+
+        @Test
+        @DisplayName(
+                "should have the verification score of 2 if score in session item is not present")
+        void shouldHaveAVerificationScoreOfTwoWhenMissingScore() throws JsonProcessingException {
+            KBVItem kbvItem = getKbvItem();
+            UUID sessionId = UUID.randomUUID();
+            kbvItem.setSessionId(sessionId);
+            kbvItem.setStatus("authenticated");
+            kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(3, 3, 0));
+            setKbvItemQuestionState(kbvItem, "First", "Second", "Third");
+
+            SessionItem sessionItem = new SessionItem();
+
+            var result = evidenceFactory.create(kbvItem, sessionItem);
+
+            assertEquals(2, getEvidenceAsMap(result).get("verificationScore"));
+        }
+
+        @Test
         void shouldContainCheckDetailsWhenKbvPasses() throws JsonProcessingException {
             KBVItem kbvItem = getKbvItem();
             kbvItem.setStatus("authenticated");
             kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(3, 3, 0));
             setKbvItemQuestionState(kbvItem, "First", "Second", "Third");
 
-            var result = evidenceFactory.create(kbvItem);
+            var result = evidenceFactory.create(kbvItem, mockSessionItem);
 
             verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
             assertNotNull(getEvidenceAsMap(result).get("checkDetails"));
@@ -159,7 +205,7 @@ class EvidenceFactoryTest implements TestFixtures {
             kbvItem.setStatus("authenticated");
             kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(3, 3, 0));
             setKbvItemQuestionState(kbvItem, "First", "Second", "Third");
-            var result = evidenceFactory.create(kbvItem);
+            var result = evidenceFactory.create(kbvItem, mockSessionItem);
 
             verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
             var checkDetailsResults = getEvidenceAsMap(result).get("checkDetails");
@@ -214,7 +260,7 @@ class EvidenceFactoryTest implements TestFixtures {
                                     "{\"First\":4,\"Second\": 5, \"Third\": 9, \"Fourth\": 9}",
                                     Map.class));
 
-            var result = evidenceFactory.create(kbvItem);
+            var result = evidenceFactory.create(kbvItem, mockSessionItem);
 
             verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
             var checkDetailsResults = getEvidenceAsMap(result).get("checkDetails");
@@ -270,7 +316,7 @@ class EvidenceFactoryTest implements TestFixtures {
                                     "{\"First\":4,\"Second\": 5, \"Third\": 9, \"Fourth\": 8}",
                                     Map.class));
 
-            var result = evidenceFactory.create(kbvItem);
+            var result = evidenceFactory.create(kbvItem, mockSessionItem);
 
             verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
             var checkDetailsResults = getEvidenceAsMap(result).get("checkDetails");
@@ -299,7 +345,7 @@ class EvidenceFactoryTest implements TestFixtures {
                     .when(mockEventProbe)
                     .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
 
-            var result = evidenceFactory.create(kbvItem);
+            var result = evidenceFactory.create(kbvItem, mockSessionItem);
 
             verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
             var failedCheckDetailsResultsNode = getEvidenceAsMap(result).get("failedCheckDetails");
@@ -340,7 +386,7 @@ class EvidenceFactoryTest implements TestFixtures {
                     .when(mockEventProbe)
                     .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
 
-            var result = evidenceFactory.create(kbvItem);
+            var result = evidenceFactory.create(kbvItem, mockSessionItem);
 
             verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
             var failedCheckDetailsResults = getEvidenceAsMap(result).get("failedCheckDetails");
@@ -362,7 +408,7 @@ class EvidenceFactoryTest implements TestFixtures {
                     .when(mockEventProbe)
                     .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
 
-            var result = evidenceFactory.create(kbvItem);
+            var result = evidenceFactory.create(kbvItem, mockSessionItem);
 
             verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
             var failedCheckDetailsResults = getEvidenceAsMap(result).get("failedCheckDetails");
@@ -382,7 +428,7 @@ class EvidenceFactoryTest implements TestFixtures {
                     .when(mockEventProbe)
                     .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
 
-            var result = evidenceFactory.create(kbvItem);
+            var result = evidenceFactory.create(kbvItem, mockSessionItem);
             verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
 
             assertEquals(
@@ -406,7 +452,8 @@ class EvidenceFactoryTest implements TestFixtures {
 
             IllegalStateException thrown =
                     assertThrows(
-                            IllegalStateException.class, () -> evidenceFactory.create(kbvItem));
+                            IllegalStateException.class,
+                            () -> evidenceFactory.create(kbvItem, mockSessionItem));
 
             assertEquals("QuestionId: NA may not be present in Mapping", thrown.getMessage());
         }

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactoryTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactoryTest.java
@@ -14,7 +14,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.cri.common.library.persistence.item.EvidenceRequest;
 import uk.gov.di.ipv.cri.common.library.persistence.item.SessionItem;
-import uk.gov.di.ipv.cri.common.library.service.SessionService;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.kbv.api.domain.CheckDetail;
 import uk.gov.di.ipv.cri.kbv.api.domain.ContraIndicator;
@@ -48,8 +47,7 @@ class EvidenceFactoryTest implements TestFixtures {
                     .registerModule(new Jdk8Module())
                     .registerModule(new JavaTimeModule());
     @Mock private EventProbe mockEventProbe;
-    @Mock private SessionItem mockSessionItem;
-    @Mock private SessionService mockSessionService;
+    @Mock private EvidenceRequest mockEvidenceRequest;
 
     @BeforeEach
     void setUp() {
@@ -71,7 +69,7 @@ class EvidenceFactoryTest implements TestFixtures {
                     .when(mockEventProbe)
                     .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
 
-            var result = evidenceFactory.create(kbvItem, mockSessionItem);
+            var result = evidenceFactory.create(kbvItem, mockEvidenceRequest);
 
             verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
             assertEquals(
@@ -92,7 +90,7 @@ class EvidenceFactoryTest implements TestFixtures {
                     .when(mockEventProbe)
                     .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
 
-            var result = evidenceFactory.create(kbvItem, mockSessionItem);
+            var result = evidenceFactory.create(kbvItem, mockEvidenceRequest);
 
             verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
             assertEquals(
@@ -115,7 +113,7 @@ class EvidenceFactoryTest implements TestFixtures {
                     .when(mockEventProbe)
                     .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
 
-            var result = evidenceFactory.create(kbvItem, mockSessionItem);
+            var result = evidenceFactory.create(kbvItem, mockEvidenceRequest);
 
             verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
             assertEquals(
@@ -135,7 +133,7 @@ class EvidenceFactoryTest implements TestFixtures {
                     .when(mockEventProbe)
                     .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
 
-            var result = evidenceFactory.create(kbvItem, mockSessionItem);
+            var result = evidenceFactory.create(kbvItem, mockEvidenceRequest);
             verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
 
             assertEquals(
@@ -164,7 +162,7 @@ class EvidenceFactoryTest implements TestFixtures {
             evidenceRequest.setVerificationScore(0);
             sessionItem.setEvidenceRequest(evidenceRequest);
 
-            var result = evidenceFactory.create(kbvItem, sessionItem);
+            var result = evidenceFactory.create(kbvItem, evidenceRequest);
             assertEquals(VC_PASS_EVIDENCE_SCORE, getEvidenceAsMap(result).get("verificationScore"));
         }
 
@@ -183,7 +181,7 @@ class EvidenceFactoryTest implements TestFixtures {
             evidenceRequest.setVerificationScore(1);
             sessionItem.setEvidenceRequest(evidenceRequest);
 
-            var result = evidenceFactory.create(kbvItem, sessionItem);
+            var result = evidenceFactory.create(kbvItem, evidenceRequest);
 
             assertEquals(
                     evidenceRequest.getVerificationScore(),
@@ -203,7 +201,7 @@ class EvidenceFactoryTest implements TestFixtures {
 
             SessionItem sessionItem = new SessionItem();
 
-            var result = evidenceFactory.create(kbvItem, sessionItem);
+            var result = evidenceFactory.create(kbvItem, sessionItem.getEvidenceRequest());
 
             assertEquals(2, getEvidenceAsMap(result).get("verificationScore"));
         }
@@ -215,7 +213,7 @@ class EvidenceFactoryTest implements TestFixtures {
             kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(3, 3, 0));
             setKbvItemQuestionState(kbvItem, "First", "Second", "Third");
 
-            var result = evidenceFactory.create(kbvItem, mockSessionItem);
+            var result = evidenceFactory.create(kbvItem, mockEvidenceRequest);
 
             verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
             assertNotNull(getEvidenceAsMap(result).get("checkDetails"));
@@ -228,7 +226,7 @@ class EvidenceFactoryTest implements TestFixtures {
             kbvItem.setStatus("authenticated");
             kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(3, 3, 0));
             setKbvItemQuestionState(kbvItem, "First", "Second", "Third");
-            var result = evidenceFactory.create(kbvItem, mockSessionItem);
+            var result = evidenceFactory.create(kbvItem, mockEvidenceRequest);
 
             verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
             var checkDetailsResults = getEvidenceAsMap(result).get("checkDetails");
@@ -283,7 +281,7 @@ class EvidenceFactoryTest implements TestFixtures {
                                     "{\"First\":4,\"Second\": 5, \"Third\": 9, \"Fourth\": 9}",
                                     Map.class));
 
-            var result = evidenceFactory.create(kbvItem, mockSessionItem);
+            var result = evidenceFactory.create(kbvItem, mockEvidenceRequest);
 
             verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
             var checkDetailsResults = getEvidenceAsMap(result).get("checkDetails");
@@ -339,7 +337,7 @@ class EvidenceFactoryTest implements TestFixtures {
                                     "{\"First\":4,\"Second\": 5, \"Third\": 9, \"Fourth\": 8}",
                                     Map.class));
 
-            var result = evidenceFactory.create(kbvItem, mockSessionItem);
+            var result = evidenceFactory.create(kbvItem, mockEvidenceRequest);
 
             verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
             var checkDetailsResults = getEvidenceAsMap(result).get("checkDetails");
@@ -368,7 +366,7 @@ class EvidenceFactoryTest implements TestFixtures {
                     .when(mockEventProbe)
                     .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
 
-            var result = evidenceFactory.create(kbvItem, mockSessionItem);
+            var result = evidenceFactory.create(kbvItem, mockEvidenceRequest);
 
             verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
             var failedCheckDetailsResultsNode = getEvidenceAsMap(result).get("failedCheckDetails");
@@ -409,7 +407,7 @@ class EvidenceFactoryTest implements TestFixtures {
                     .when(mockEventProbe)
                     .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
 
-            var result = evidenceFactory.create(kbvItem, mockSessionItem);
+            var result = evidenceFactory.create(kbvItem, mockEvidenceRequest);
 
             verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
             var failedCheckDetailsResults = getEvidenceAsMap(result).get("failedCheckDetails");
@@ -431,7 +429,7 @@ class EvidenceFactoryTest implements TestFixtures {
                     .when(mockEventProbe)
                     .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
 
-            var result = evidenceFactory.create(kbvItem, mockSessionItem);
+            var result = evidenceFactory.create(kbvItem, mockEvidenceRequest);
 
             verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
             var failedCheckDetailsResults = getEvidenceAsMap(result).get("failedCheckDetails");
@@ -451,7 +449,7 @@ class EvidenceFactoryTest implements TestFixtures {
                     .when(mockEventProbe)
                     .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
 
-            var result = evidenceFactory.create(kbvItem, mockSessionItem);
+            var result = evidenceFactory.create(kbvItem, mockEvidenceRequest);
             verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
 
             assertEquals(
@@ -476,7 +474,7 @@ class EvidenceFactoryTest implements TestFixtures {
             IllegalStateException thrown =
                     assertThrows(
                             IllegalStateException.class,
-                            () -> evidenceFactory.create(kbvItem, mockSessionItem));
+                            () -> evidenceFactory.create(kbvItem, mockEvidenceRequest));
 
             assertEquals("QuestionId: NA may not be present in Mapping", thrown.getMessage());
         }

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactoryTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactoryTest.java
@@ -37,6 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
+import static uk.gov.di.ipv.cri.kbv.api.domain.VerifiableCredentialConstants.VC_PASS_EVIDENCE_SCORE;
 
 @ExtendWith(MockitoExtension.class)
 class EvidenceFactoryTest implements TestFixtures {
@@ -146,6 +147,27 @@ class EvidenceFactoryTest implements TestFixtures {
 
     @Nested
     class EvidenceCheckDetails {
+
+        @Test
+        @DisplayName(
+                "should use the default verification if verification score from session item is 0")
+        void shouldHaveAVerificationScoreOfZero() throws JsonProcessingException {
+            KBVItem kbvItem = getKbvItem();
+            UUID sessionId = UUID.randomUUID();
+            kbvItem.setSessionId(sessionId);
+            kbvItem.setStatus("authenticated");
+            kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(3, 3, 0));
+            setKbvItemQuestionState(kbvItem, "First", "Second", "Third");
+
+            SessionItem sessionItem = new SessionItem();
+            EvidenceRequest evidenceRequest = new EvidenceRequest();
+            evidenceRequest.setVerificationScore(0);
+            sessionItem.setEvidenceRequest(evidenceRequest);
+
+            var result = evidenceFactory.create(kbvItem, sessionItem);
+            assertEquals(VC_PASS_EVIDENCE_SCORE, getEvidenceAsMap(result).get("verificationScore"));
+        }
+
         @Test
         @DisplayName("should use the verification score from session item if present")
         void shouldHaveAVerificationScoreOfOne() throws JsonProcessingException {

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/VerifiableCredentialServiceTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/VerifiableCredentialServiceTest.java
@@ -120,6 +120,8 @@ class VerifiableCredentialServiceTest {
                             objectMapper,
                             mockVcClaimSetBuilder,
                             spyEvidenceFactory);
+            mockSessionItem = new SessionItem();
+            mockSessionItem.setSubject(SUBJECT);
 
             initMockVCClaimSetBuilder();
 
@@ -135,7 +137,7 @@ class VerifiableCredentialServiceTest {
 
             SignedJWT signedJWT =
                     verifiableCredentialService.generateSignedVerifiableCredentialJwt(
-                            SUBJECT, personIdentity, kbvItem, mockSessionItem);
+                            mockSessionItem, personIdentity, kbvItem);
 
             assertTrue(
                     signedJWT.verify(new ECDSAVerifier(ECKey.parse(TestFixtures.EC_PUBLIC_JWK_1))));
@@ -173,6 +175,8 @@ class VerifiableCredentialServiceTest {
                             objectMapper,
                             mockVcClaimSetBuilder,
                             spyEvidenceFactory);
+            mockSessionItem = new SessionItem();
+            mockSessionItem.setSubject(SUBJECT);
 
             KBVItem kbvItem = new KBVItem();
             kbvItem.setStatus(status);
@@ -181,7 +185,7 @@ class VerifiableCredentialServiceTest {
             when(mockVcClaimSetBuilder.build()).thenReturn(TEST_CLAIMS_SET);
 
             verifiableCredentialService.generateSignedVerifiableCredentialJwt(
-                    SUBJECT, createPersonIdentity(), kbvItem, mockSessionItem);
+                    mockSessionItem, createPersonIdentity(), kbvItem);
 
             verify(mockVcClaimSetBuilder)
                     .verifiableCredentialEvidence(mapArrayArgumentCaptor.capture());

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/VerifiableCredentialServiceTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/VerifiableCredentialServiceTest.java
@@ -145,7 +145,7 @@ class VerifiableCredentialServiceTest {
             verify(mockConfigurationService).getMaxJwtTtl();
             verify(mockVcClaimSetBuilder).subject(SUBJECT);
             verify(mockVcClaimSetBuilder).verifiableCredentialType(KBV_CREDENTIAL_TYPE);
-            verify(spyEvidenceFactory).create(kbvItem, mockSessionItem);
+            verify(spyEvidenceFactory).create(kbvItem, null);
 
             makeEvidenceClaimsAssertions(
                     expectedVerificationScore, expectedContraIndicator, kbvItem.getAuthRefNo());
@@ -190,7 +190,7 @@ class VerifiableCredentialServiceTest {
             verify(mockVcClaimSetBuilder)
                     .verifiableCredentialEvidence(mapArrayArgumentCaptor.capture());
             verify(signedJWTFactory).createSignedJwt(TEST_CLAIMS_SET);
-            verify(spyEvidenceFactory).create(kbvItem, mockSessionItem);
+            verify(spyEvidenceFactory).create(kbvItem, null);
             Map<String, Object> evidenceItems = mapArrayArgumentCaptor.getValue()[0];
             assertEquals(kbvItem.getAuthRefNo(), evidenceItems.get("txn"));
             assertEquals(expectedVerificationScore, evidenceItems.get("verificationScore"));
@@ -250,12 +250,12 @@ class VerifiableCredentialServiceTest {
             };
 
             when(mockConfigurationService.getVerifiableCredentialIssuer()).thenReturn(issuer);
-            doReturn(evidence).when(spyEvidenceFactory).create(kbvItem, mockSessionItem);
+            doReturn(evidence).when(spyEvidenceFactory).create(kbvItem, null);
 
             var auditEventExtensions =
-                    verifiableCredentialService.getAuditEventExtensions(kbvItem, mockSessionItem);
+                    verifiableCredentialService.getAuditEventExtensions(kbvItem, null);
 
-            verify(spyEvidenceFactory).create(kbvItem, mockSessionItem);
+            verify(spyEvidenceFactory).create(kbvItem, null);
             assertEquals(
                     auditEventExtensions,
                     Map.of(

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/util/EvidenceUtils.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/util/EvidenceUtils.java
@@ -7,6 +7,10 @@ import java.util.Objects;
 public class EvidenceUtils {
     private static final int VC_PASS_EVIDENCE_SCORE = 2;
 
+    private EvidenceUtils() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+
     public static int getVerificationScoreForPass(EvidenceRequest evidenceRequest) {
         if (Objects.isNull(evidenceRequest)) {
             return VC_PASS_EVIDENCE_SCORE;

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/util/EvidenceUtils.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/util/EvidenceUtils.java
@@ -1,0 +1,17 @@
+package uk.gov.di.ipv.cri.kbv.api.util;
+
+import uk.gov.di.ipv.cri.common.library.persistence.item.EvidenceRequest;
+
+import java.util.Objects;
+
+public class EvidenceUtils {
+    private static final int VC_PASS_EVIDENCE_SCORE = 2;
+
+    public static int getVerificationScoreForPass(EvidenceRequest evidenceRequest) {
+        if (Objects.isNull(evidenceRequest)) {
+            return VC_PASS_EVIDENCE_SCORE;
+        }
+        int verificationScore = evidenceRequest.getVerificationScore();
+        return verificationScore > 0 ? verificationScore : VC_PASS_EVIDENCE_SCORE;
+    }
+}

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/util/EvidenceUtilsTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/util/EvidenceUtilsTest.java
@@ -1,0 +1,28 @@
+package uk.gov.di.ipv.cri.kbv.api.util;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.di.ipv.cri.common.library.persistence.item.EvidenceRequest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class EvidenceUtilsTest {
+
+    @Test
+    void shouldGiveScoreOfTwoWhenNull() {
+        assertEquals(2, EvidenceUtils.getVerificationScoreForPass(null));
+    }
+
+    @Test
+    void shouldGiveScoreOfTwoWhenZero() {
+        EvidenceRequest evidenceRequest = new EvidenceRequest();
+        evidenceRequest.setVerificationScore(0);
+        assertEquals(2, EvidenceUtils.getVerificationScoreForPass(evidenceRequest));
+    }
+
+    @Test
+    void shouldGiveScoreWhenGivenScoreGreaterThan0() {
+        EvidenceRequest evidenceRequest = new EvidenceRequest();
+        evidenceRequest.setVerificationScore(100);
+        assertEquals(100, EvidenceUtils.getVerificationScoreForPass(evidenceRequest));
+    }
+}


### PR DESCRIPTION
## Proposed changes

This is approach 2 passing the SessionItem

### What changed
The `verification_score` property within a VC is now fetched from the SessionItem in DynamoDB. If there is no evidence block in the session item then the default value of 2 will be used.

### Why did it change
We now have multiple levels of confidence that has to be accurately reflected in the VC.

### Issue tracking
- [OJ-2612](https://govukverify.atlassian.net/browse/OJ-2612)


[OJ-2612]: https://govukverify.atlassian.net/browse/OJ-2612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ