### PR TITLE
OJ-2612: Add integration test scenario for low confidence journey

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ ext {
 		mockito					 : "4.3.1",
 		glassfish_version        : "3.0.3",
 		powertools_version       : "1.12.3",
-		cri_common_lib           : "2.2.0",
+		cri_common_lib           : "2.2.3",
 	]
 }
 

--- a/integration-tests/src/test/resources/features/KbvApiHappyPath.feature
+++ b/integration-tests/src/test/resources/features/KbvApiHappyPath.feature
@@ -98,3 +98,52 @@ Feature: 3 out of 4 strategy. User has 2 KBV questions. Tests are run against th
     And a valid JWT is returned in the response
     And a verification score of 2 is returned in the response
     And 10 events are deleted from the audit events SQS queue
+
+  @pre_merge_happy_evidence_requested
+  Scenario: User answers 2 questions correctly with evidence requested
+    Given user has the test-identity 197, verificationScore of 1 and strengthScore of 2 in the form of a signed JWT string
+
+    # Session
+    When user sends a POST request to session end point
+    Then user gets a session-id
+
+    # TXMA event
+    Then TXMA event is added to the SQS queue not containing device information header
+
+    # First question
+    When user sends a GET request to question endpoint
+    Then user gets status code 200
+    And user answers the question correctly
+    Then user gets status code 200
+
+    # Second question
+    When user sends a GET request to question endpoint
+    Then user gets status code 200
+    And user answers the question correctly
+    Then user gets status code 200
+
+    # Third question (will be removed when 2-out-3 strategy is implemented)
+    When user sends a GET request to question endpoint
+    Then user gets status code 200
+    And user answers the question correctly
+    Then user gets status code 200
+
+    When user sends a GET request to question endpoint when there are no questions left
+    Then user gets status code 204
+
+    # Authorization
+    When user sends a GET request to authorization end point
+    Then user gets status code 200
+    And a valid authorization code is returned in the response
+
+    # Access token
+    When user sends a POST request to token end point
+    Then user gets status code 200
+    And a valid access token code is returned in the response
+
+    # Credential issued
+    When user sends a POST request to credential issue endpoint with a valid access token
+    Then user gets status code 200
+    And a valid JWT is returned in the response
+    And a verification score of 1 is returned in the response
+    And 10 events are deleted from the audit events SQS queue

--- a/integration-tests/src/test/resources/features/KbvApiHappyPath.feature
+++ b/integration-tests/src/test/resources/features/KbvApiHappyPath.feature
@@ -101,7 +101,7 @@ Feature: 3 out of 4 strategy. User has 2 KBV questions. Tests are run against th
 
   @pre_merge_happy_evidence_requested
   Scenario: User answers 2 questions correctly with evidence requested
-    Given user has the test-identity 197, verificationScore of 1 and strengthScore of 2 in the form of a signed JWT string
+    Given user has the test-identity 197 and verificationScore of 1 in the form of a signed JWT string
 
     # Session
     When user sends a POST request to session end point


### PR DESCRIPTION


### What changed
Added another integration test scenario for going through the journey when the verificationScore is set to 1

### Why did it change
To enable testing for low confidence journey

- [OJ-2612](https://govukverify.atlassian.net/browse/OJ-2612)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[OJ-2612]: https://govukverify.atlassian.net/browse/OJ-2612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ