### PR TITLE
OJ-2612: use dynamo verification score

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/exception/InvalidStrategyScoreException.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/exception/InvalidStrategyScoreException.java
@@ -4,4 +4,8 @@ public class InvalidStrategyScoreException extends RuntimeException {
     public InvalidStrategyScoreException(String message) {
         super(message);
     }
+
+    public InvalidStrategyScoreException() {
+        this("No question strategy found for score provided");
+    }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/KbvConfigService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/KbvConfigService.java
@@ -1,0 +1,41 @@
+package uk.gov.di.ipv.cri.kbv.api.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
+import uk.gov.di.ipv.cri.kbv.api.exception.InvalidStrategyScoreException;
+
+import java.util.Map;
+
+import static java.util.Optional.ofNullable;
+
+public class KbvConfigService {
+    private static final Logger LOGGER = LogManager.getLogger(KbvConfigService.class);
+    public static final String IIQ_STRATEGY_PARAM_NAME = "IIQStrategy";
+    private final ConfigurationService configuration;
+    private final ObjectMapper objectMapper;
+
+    public KbvConfigService(ObjectMapper objectMapper, ConfigurationService configurationService) {
+        this.configuration = configurationService;
+        this.objectMapper = objectMapper;
+    }
+
+    public ConfigurationService configService() {
+        return configuration;
+    }
+
+    public String getKbvQuestionStrategy(int verificationScore) throws JsonProcessingException {
+        var strategyParam = this.configuration.getParameterValue(IIQ_STRATEGY_PARAM_NAME);
+
+        Map<String, String> strategyMap =
+                objectMapper.readValue(strategyParam, new TypeReference<>() {});
+        String strategy =
+                ofNullable(strategyMap.get(String.valueOf(verificationScore)))
+                        .orElseThrow(InvalidStrategyScoreException::new);
+        LOGGER.info("Using IIQStrategy: {}", strategy);
+        return strategy;
+    }
+}

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/KbvConfigServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/KbvConfigServiceTest.java
@@ -1,0 +1,108 @@
+package uk.gov.di.ipv.cri.kbv.api.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.cri.common.library.persistence.item.EvidenceRequest;
+import uk.gov.di.ipv.cri.common.library.persistence.item.SessionItem;
+import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
+import uk.gov.di.ipv.cri.kbv.api.exception.InvalidStrategyScoreException;
+import uk.gov.di.ipv.cri.kbv.api.util.EvidenceUtils;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.cri.kbv.api.service.KbvConfigService.IIQ_STRATEGY_PARAM_NAME;
+
+@ExtendWith(MockitoExtension.class)
+class KbvConfigServiceTest {
+    private static final String MOCK_IIQ_STRATEGY_PARAM_VALUE =
+            "{\"2\": \"3 out of 4 prioritised\"}";
+    private static final Map<String, String> MOCK_IIQ_STRATEGY_MAPPED_VALUE =
+            Map.of("2", "3 out of 4 prioritised");
+    @Mock private ConfigurationService mockConfigurationService;
+    @Mock private ObjectMapper mockObjectMapper;
+    @InjectMocks KbvConfigService kbvConfigService;
+
+    @Test
+    void shouldReturnUnderlyingCommonConfiguration() {
+        assertNotNull(kbvConfigService.configService());
+    }
+
+    @Test
+    void shouldReturnConfiguredKbvStrategyWhenVerificationScoreIsNotSetOnSessionItem()
+            throws JsonProcessingException {
+        SessionItem sessionItem = new SessionItem();
+
+        when(mockConfigurationService.getParameterValue(IIQ_STRATEGY_PARAM_NAME))
+                .thenReturn(MOCK_IIQ_STRATEGY_PARAM_VALUE);
+        when(mockObjectMapper.readValue(
+                        anyString(), Mockito.<TypeReference<Map<String, String>>>any()))
+                .thenReturn(MOCK_IIQ_STRATEGY_MAPPED_VALUE);
+
+        var strategy =
+                kbvConfigService.getKbvQuestionStrategy(
+                        EvidenceUtils.getVerificationScoreForPass(
+                                sessionItem.getEvidenceRequest()));
+
+        assertEquals("3 out of 4 prioritised", strategy);
+    }
+
+    @Test
+    void shouldReturnConfiguredKbvStrategyWhenVerificationScoreIsExplicitlySetOnSessionItem()
+            throws JsonProcessingException {
+        SessionItem sessionItem = new SessionItem();
+        EvidenceRequest evidenceRequest = new EvidenceRequest();
+        evidenceRequest.setVerificationScore(2);
+        sessionItem.setEvidenceRequest(evidenceRequest);
+
+        when(mockConfigurationService.getParameterValue(IIQ_STRATEGY_PARAM_NAME))
+                .thenReturn(MOCK_IIQ_STRATEGY_PARAM_VALUE);
+        when(mockObjectMapper.readValue(
+                        anyString(), Mockito.<TypeReference<Map<String, String>>>any()))
+                .thenReturn(MOCK_IIQ_STRATEGY_MAPPED_VALUE);
+
+        var strategy =
+                kbvConfigService.getKbvQuestionStrategy(
+                        EvidenceUtils.getVerificationScoreForPass(
+                                sessionItem.getEvidenceRequest()));
+
+        assertEquals("3 out of 4 prioritised", strategy);
+    }
+
+    @Test
+    void throwsErrorWhenKbvStrategyIsNotConfiguredForGivenVerificationScoreSetOnSessionItem()
+            throws JsonProcessingException {
+        SessionItem sessionItem = new SessionItem();
+        EvidenceRequest evidenceRequest = new EvidenceRequest();
+        evidenceRequest.setVerificationScore(1);
+        sessionItem.setEvidenceRequest(evidenceRequest);
+
+        when(mockConfigurationService.getParameterValue(IIQ_STRATEGY_PARAM_NAME))
+                .thenReturn(MOCK_IIQ_STRATEGY_PARAM_VALUE);
+        when(mockObjectMapper.readValue(
+                        anyString(), Mockito.<TypeReference<Map<String, String>>>any()))
+                .thenReturn(MOCK_IIQ_STRATEGY_MAPPED_VALUE);
+
+        int verificationScore =
+                EvidenceUtils.getVerificationScoreForPass(sessionItem.getEvidenceRequest());
+
+        InvalidStrategyScoreException expectedException =
+                assertThrows(
+                        InvalidStrategyScoreException.class,
+                        () -> kbvConfigService.getKbvQuestionStrategy(verificationScore),
+                        "No question strategy found for score provided");
+        assertEquals(
+                "No question strategy found for score provided", expectedException.getMessage());
+    }
+}


### PR DESCRIPTION
## Proposed changes

The KBV Question handler currently hard codes the verification score, to read the configuration in order to retrieve the question strategy see https://github.com/govuk-one-login/ipv-cri-kbv-api/pull/345. This was because the evidenceRequest was not exposed by the Java code initially see https://github.com/govuk-one-login/ipv-cri-lib/pull/504

The configurationService has been wrapped and the common methods can be accessed by creating an instance of the KbvConfigService and then calling the underlying method i.e.

```
KbvConfigService config = new KbvConfigService(new ObjectMapper(), new ConfigurationService);
config.configService().getParameterValue
```

KbvConfigService exposes a new method `getKbvQuestionStrategy` which uses the evidenceRequest in conjunction with the EvidenceUtil to get the stored value from dynamodb if available or defaults to 2

KbvConfigService and the new method `getKbvQuestionStrategy` will be used in the EvidenceFactory on another story

- [OJ-2612](https://govukverify.atlassian.net/browse/OJ-2612)


[OJ-2612]: https://govukverify.atlassian.net/browse/OJ-2612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ