### PR TITLE
OJ-2643: add low confidence unit test (part 1)

### DIFF
--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactory.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactory.java
@@ -97,7 +97,7 @@ public class EvidenceFactory {
              * second batch, and they were answered correctly. We can sort by quality and remove any
              * additional question(s)
              */
-            if (questionState.allQuestionBatchSizesMatch(2)) {
+            if (questionState.isQuestionReceivedBatchCountEqualTo(2)) {
                 return createCheckDetailsBySortingOnKbvQuality(kbvItem, questionState);
             }
             /**

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactory.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactory.java
@@ -14,6 +14,8 @@ import uk.gov.di.ipv.cri.kbv.api.domain.KbvQuality;
 import uk.gov.di.ipv.cri.kbv.api.domain.KbvQuestion;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionAnswerPair;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionState;
+import uk.gov.di.ipv.cri.kbv.api.strategy.KbvStrategyParser;
+import uk.gov.di.ipv.cri.kbv.api.strategy.Strategy;
 
 import java.util.Collection;
 import java.util.Map;
@@ -35,7 +37,20 @@ public class EvidenceFactory {
     private static final int UNSUITABLE_QUESTION_QUALITY = 0;
     private final EventProbe eventProbe;
     private final ObjectMapper objectMapper;
+    private String kbvQuestionStrategy;
     private final Map<String, Integer> kbvQualityMapping;
+
+    void setKbvQuestionStrategy(String questionStrategy) {
+        this.kbvQuestionStrategy = questionStrategy;
+    }
+
+    public String getKbvQuestionStrategy() {
+        return this.kbvQuestionStrategy;
+    }
+
+    public Map<String, Integer> getKbvQualityMapping() {
+        return kbvQualityMapping;
+    }
 
     public EvidenceFactory(
             ObjectMapper objectMapper,
@@ -44,6 +59,7 @@ public class EvidenceFactory {
         this.objectMapper = objectMapper;
         this.eventProbe = eventProbe;
         this.kbvQualityMapping = kbvQualityMapping;
+        this.kbvQuestionStrategy = "3 out of 4 Prioritised";
     }
 
     public Object[] create(KBVItem kbvItem, EvidenceRequest evidenceRequest)
@@ -139,7 +155,7 @@ public class EvidenceFactory {
     }
 
     private int getKbvQuality(String questionId) {
-        return kbvQualityMapping.entrySet().stream()
+        return this.getKbvQualityMapping().entrySet().stream()
                 .filter(item -> questionId.equals(item.getKey()))
                 .map(Map.Entry::getValue)
                 .map(this::mapKbvQuality)
@@ -167,9 +183,11 @@ public class EvidenceFactory {
     }
 
     private boolean hasPassedWithOneIncorrectAnswer(KBVItem kbvItem) {
+        KbvStrategyParser parser = new KbvStrategyParser(this.getKbvQuestionStrategy());
+        Strategy strategy = parser.parse();
         return Objects.nonNull(kbvItem.getQuestionAnswerResultSummary())
-                && kbvItem.getQuestionAnswerResultSummary().getQuestionsAsked() == 4
-                && kbvItem.getQuestionAnswerResultSummary().getAnsweredCorrect() == 3;
+                && kbvItem.getQuestionAnswerResultSummary().getQuestionsAsked() == strategy.max()
+                && kbvItem.getQuestionAnswerResultSummary().getAnsweredCorrect() == strategy.min();
     }
 
     private boolean hasTooManyIncorrectAnswers(KBVItem kbvItem) {

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactoryTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactoryTest.java
@@ -10,6 +10,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.cri.common.library.persistence.item.EvidenceRequest;
@@ -18,7 +21,6 @@ import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.kbv.api.domain.CheckDetail;
 import uk.gov.di.ipv.cri.kbv.api.domain.ContraIndicator;
 import uk.gov.di.ipv.cri.kbv.api.domain.KBVItem;
-import uk.gov.di.ipv.cri.kbv.api.domain.KbvQuality;
 import uk.gov.di.ipv.cri.kbv.api.domain.KbvQuestion;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionAnswer;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionState;
@@ -36,6 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static uk.gov.di.ipv.cri.kbv.api.domain.VerifiableCredentialConstants.VC_PASS_EVIDENCE_SCORE;
 
 @ExtendWith(MockitoExtension.class)
@@ -58,341 +61,921 @@ class EvidenceFactoryTest implements TestFixtures {
 
     @Nested
     class EvidenceVerificationScore {
-        @Test
-        void shouldPassWhenKbvItemStatusIsAuthenticated() throws JsonProcessingException {
-            KBVItem kbvItem = getKbvItem();
-            kbvItem.setStatus("authenticated");
-            kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(3, 3, 0));
-            setKbvItemQuestionState(kbvItem, "First", "Second", "Third");
+        @Nested
+        class ThreeOutOfFourPrioritisedKbvQuestionStrategy {
+            @Test
+            @DisplayName(
+                    "KBV passes using the default pass verification of 2 if verification score from session item is a Zero")
+            void hasAVerificationScoreOfTwoIfVerificationScoreIsZero()
+                    throws JsonProcessingException {
+                KBVItem kbvItem = getKbvItem();
+                UUID sessionId = UUID.randomUUID();
+                kbvItem.setSessionId(sessionId);
+                kbvItem.setStatus("authenticated");
+                kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(3, 3, 0));
+                setKbvItemQuestionState(kbvItem, "First", "Second", "Third");
 
-            doNothing()
-                    .when(mockEventProbe)
-                    .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
+                SessionItem sessionItem = new SessionItem();
+                EvidenceRequest evidenceRequest = new EvidenceRequest();
+                evidenceRequest.setVerificationScore(0);
+                sessionItem.setEvidenceRequest(evidenceRequest);
 
-            var result = evidenceFactory.create(kbvItem, mockEvidenceRequest);
+                doNothing()
+                        .when(mockEventProbe)
+                        .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
 
-            verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
-            assertEquals(
-                    VerifiableCredentialConstants.VC_PASS_EVIDENCE_SCORE,
-                    getEvidenceAsMap(result).get("verificationScore"));
-            assertNull(getEvidenceAsMap(result).get("ci"));
+                var result = evidenceFactory.create(kbvItem, evidenceRequest);
+
+                verify(mockEventProbe)
+                        .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
+
+                assertEquals("3 out of 4 Prioritised", evidenceFactory.getKbvQuestionStrategy());
+                assertEquals(
+                        VC_PASS_EVIDENCE_SCORE, getEvidenceAsMap(result).get("verificationScore"));
+                assertNull(getEvidenceAsMap(result).get("ci"));
+            }
+
+            @ParameterizedTest
+            @DisplayName(
+                    "KBV passes using the actual verification score from session item if present")
+            @CsvSource({"1", "2"})
+            void hasAVerificationScoreOf(int score) throws JsonProcessingException {
+                KBVItem kbvItem = getKbvItem();
+                UUID sessionId = UUID.randomUUID();
+                kbvItem.setSessionId(sessionId);
+                kbvItem.setStatus("authenticated");
+                kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(3, 3, 0));
+                setKbvItemQuestionState(kbvItem, "First", "Second", "Third");
+
+                SessionItem sessionItem = new SessionItem();
+                EvidenceRequest evidenceRequest = new EvidenceRequest();
+                evidenceRequest.setVerificationScore(score);
+                sessionItem.setEvidenceRequest(evidenceRequest);
+
+                doNothing()
+                        .when(mockEventProbe)
+                        .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
+
+                var result = evidenceFactory.create(kbvItem, sessionItem.getEvidenceRequest());
+
+                verify(mockEventProbe)
+                        .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
+
+                assertEquals("3 out of 4 Prioritised", evidenceFactory.getKbvQuestionStrategy());
+                assertEquals(
+                        evidenceRequest.getVerificationScore(),
+                        getEvidenceAsMap(result).get("verificationScore"));
+            }
+
+            @Test
+            @DisplayName(
+                    "KBV passes using the default verification score of 2 if score in session item is absent")
+            void hasAVerificationScoreOfTwoWhenMissingScore() throws JsonProcessingException {
+                KBVItem kbvItem = getKbvItem();
+                UUID sessionId = UUID.randomUUID();
+                kbvItem.setSessionId(sessionId);
+                kbvItem.setStatus("authenticated");
+                kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(3, 3, 0));
+                setKbvItemQuestionState(kbvItem, "First", "Second", "Third");
+                SessionItem sessionItem = new SessionItem();
+
+                doNothing()
+                        .when(mockEventProbe)
+                        .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
+
+                var result = evidenceFactory.create(kbvItem, sessionItem.getEvidenceRequest());
+
+                verify(mockEventProbe)
+                        .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
+
+                assertEquals("3 out of 4 Prioritised", evidenceFactory.getKbvQuestionStrategy());
+                assertEquals(
+                        VC_PASS_EVIDENCE_SCORE, getEvidenceAsMap(result).get("verificationScore"));
+            }
+
+            @ParameterizedTest
+            @CsvSource({"3", "4", "5"})
+            @DisplayName("throws IllegalStateException if verification score is not supported")
+            void throwsIllegalStateExceptionWhenGivenValueGreaterThanTwo(int verificationScore)
+                    throws JsonProcessingException {
+                KBVItem kbvItem = getKbvItem();
+                UUID sessionId = UUID.randomUUID();
+                kbvItem.setSessionId(sessionId);
+                kbvItem.setStatus("authenticated");
+                kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(2, 2, 0));
+                setKbvItemQuestionState(kbvItem, "First", "Second");
+
+                SessionItem sessionItem = new SessionItem();
+                EvidenceRequest evidenceRequest = new EvidenceRequest();
+                evidenceRequest.setVerificationScore(verificationScore);
+                sessionItem.setEvidenceRequest(evidenceRequest);
+
+                Executable executable =
+                        () -> evidenceFactory.create(kbvItem, sessionItem.getEvidenceRequest());
+
+                IllegalStateException exception =
+                        assertThrows(IllegalStateException.class, executable);
+
+                verifyNoMoreInteractions(mockEventProbe);
+                assertEquals("3 out of 4 Prioritised", evidenceFactory.getKbvQuestionStrategy());
+                assertEquals(
+                        String.format("Verification Score %d is not supported", verificationScore),
+                        exception.getMessage());
+            }
+
+            @Test
+            @DisplayName("KBV fails with an unknown status no contraIndicator is returned")
+            void failsWhenKbvItemStatusIsAnyOtherValue() throws JsonProcessingException {
+                KBVItem kbvItem = getKbvItem();
+                kbvItem.setStatus("some unknown value");
+
+                doNothing()
+                        .when(mockEventProbe)
+                        .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
+
+                var result = evidenceFactory.create(kbvItem, mockEvidenceRequest);
+                verify(mockEventProbe)
+                        .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
+
+                assertEquals("3 out of 4 Prioritised", evidenceFactory.getKbvQuestionStrategy());
+                assertEquals(
+                        VerifiableCredentialConstants.VC_FAIL_EVIDENCE_SCORE,
+                        getEvidenceAsMap(result).get("verificationScore"));
+                assertNull(getEvidenceAsMap(result).get("ci"));
+            }
         }
 
-        @Test
-        void shouldFailAndReturnContraIndicatorWhenMultipleAnswersAreIncorrect()
-                throws JsonProcessingException {
-            KBVItem kbvItem = getKbvItem();
-            kbvItem.setStatus("not Authenticated");
-            kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(4, 2, 2));
-            setKbvItemQuestionState(kbvItem, "First", "Second", "Third", "Fourth");
+        @Nested
+        class TwoOutOfThreePrioritisedKbvQuestionStrategy {
+            @BeforeEach
+            void setUp() {
+                evidenceFactory =
+                        new EvidenceFactory(
+                                objectMapper,
+                                mockEventProbe,
+                                KBV_QUESTION_QUALITY_MAPPING_SERIALIZED);
+                evidenceFactory.setKbvQuestionStrategy("2 out of 3 Prioritised");
+            }
 
-            doNothing()
-                    .when(mockEventProbe)
-                    .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
+            @Test
+            @DisplayName(
+                    "KBV passes using the default pass verification of 2 if verification score from session item is Zero")
+            void hasAVerificationScoreOfTwoIfVerificationScoreIsZero()
+                    throws JsonProcessingException {
+                KBVItem kbvItem = getKbvItem();
+                UUID sessionId = UUID.randomUUID();
+                kbvItem.setSessionId(sessionId);
+                kbvItem.setStatus("authenticated");
+                kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(2, 2, 0));
+                setKbvItemQuestionState(kbvItem, "First", "Second");
 
-            var result = evidenceFactory.create(kbvItem, mockEvidenceRequest);
+                SessionItem sessionItem = new SessionItem();
+                EvidenceRequest evidenceRequest = new EvidenceRequest();
+                evidenceRequest.setVerificationScore(0);
+                sessionItem.setEvidenceRequest(evidenceRequest);
 
-            verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
-            assertEquals(
-                    VerifiableCredentialConstants.VC_FAIL_EVIDENCE_SCORE,
-                    getEvidenceAsMap(result).get("verificationScore"));
-            assertEquals(
-                    ContraIndicator.V03.toString(),
-                    ((List) getEvidenceAsMap(result).get("ci")).get(0));
+                doNothing()
+                        .when(mockEventProbe)
+                        .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
+                var result = evidenceFactory.create(kbvItem, evidenceRequest);
+                verify(mockEventProbe)
+                        .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
+
+                assertEquals("2 out of 3 Prioritised", evidenceFactory.getKbvQuestionStrategy());
+                assertEquals(
+                        VC_PASS_EVIDENCE_SCORE, getEvidenceAsMap(result).get("verificationScore"));
+                assertNull(getEvidenceAsMap(result).get("ci"));
+            }
+
+            @ParameterizedTest
+            @DisplayName(
+                    "KBV passes using the actual verification score from session item if present")
+            @CsvSource({"1", "2"})
+            void hasAVerificationScoreOf(int score) throws JsonProcessingException {
+                KBVItem kbvItem = getKbvItem();
+                UUID sessionId = UUID.randomUUID();
+                kbvItem.setSessionId(sessionId);
+                kbvItem.setStatus("authenticated");
+                kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(2, 2, 0));
+                setKbvItemQuestionState(kbvItem, "First", "Second");
+
+                SessionItem sessionItem = new SessionItem();
+                EvidenceRequest evidenceRequest = new EvidenceRequest();
+                evidenceRequest.setVerificationScore(score);
+                sessionItem.setEvidenceRequest(evidenceRequest);
+
+                doNothing()
+                        .when(mockEventProbe)
+                        .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
+
+                var result = evidenceFactory.create(kbvItem, sessionItem.getEvidenceRequest());
+
+                verify(mockEventProbe)
+                        .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
+
+                assertEquals("2 out of 3 Prioritised", evidenceFactory.getKbvQuestionStrategy());
+                assertEquals(
+                        evidenceRequest.getVerificationScore(),
+                        getEvidenceAsMap(result).get("verificationScore"));
+            }
+
+            @Test
+            @DisplayName(
+                    "KBV passes using the default verification score of 2 if score in session item is absent")
+            void hasAVerificationScoreOfTwoWhenMissingScore() throws JsonProcessingException {
+                KBVItem kbvItem = getKbvItem();
+                UUID sessionId = UUID.randomUUID();
+                kbvItem.setSessionId(sessionId);
+                kbvItem.setStatus("authenticated");
+                kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(2, 2, 0));
+                setKbvItemQuestionState(kbvItem, "First", "Second");
+
+                SessionItem sessionItem = new SessionItem();
+
+                doNothing()
+                        .when(mockEventProbe)
+                        .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
+
+                var result = evidenceFactory.create(kbvItem, sessionItem.getEvidenceRequest());
+
+                verify(mockEventProbe)
+                        .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
+
+                assertEquals("2 out of 3 Prioritised", evidenceFactory.getKbvQuestionStrategy());
+                assertEquals(
+                        VC_PASS_EVIDENCE_SCORE, getEvidenceAsMap(result).get("verificationScore"));
+            }
+
+            @ParameterizedTest
+            @CsvSource({"3", "4", "5"})
+            @DisplayName("throws IllegalStateException if verification score is not supported")
+            void throwsIllegalStateExceptionWhenGivenValueGreaterThanTwo(int verificationScore)
+                    throws JsonProcessingException {
+                KBVItem kbvItem = getKbvItem();
+                UUID sessionId = UUID.randomUUID();
+                kbvItem.setSessionId(sessionId);
+                kbvItem.setStatus("authenticated");
+                kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(2, 2, 0));
+                setKbvItemQuestionState(kbvItem, "First", "Second");
+
+                SessionItem sessionItem = new SessionItem();
+                EvidenceRequest evidenceRequest = new EvidenceRequest();
+                evidenceRequest.setVerificationScore(verificationScore);
+                sessionItem.setEvidenceRequest(evidenceRequest);
+
+                Executable executable =
+                        () -> evidenceFactory.create(kbvItem, sessionItem.getEvidenceRequest());
+
+                IllegalStateException exception =
+                        assertThrows(IllegalStateException.class, executable);
+
+                verifyNoMoreInteractions(mockEventProbe);
+                assertEquals("2 out of 3 Prioritised", evidenceFactory.getKbvQuestionStrategy());
+                assertEquals(
+                        String.format("Verification Score %d is not supported", verificationScore),
+                        exception.getMessage());
+            }
+
+            @Test
+            @DisplayName("KBV fails with an unknown status no contraIndicator is returned")
+            void failsWhenKbvItemStatusIsAnyOtherValue() throws JsonProcessingException {
+                KBVItem kbvItem = getKbvItem();
+                kbvItem.setStatus("some unknown value");
+
+                doNothing()
+                        .when(mockEventProbe)
+                        .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
+
+                var result = evidenceFactory.create(kbvItem, mockEvidenceRequest);
+                verify(mockEventProbe)
+                        .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
+
+                assertEquals(
+                        VerifiableCredentialConstants.VC_FAIL_EVIDENCE_SCORE,
+                        getEvidenceAsMap(result).get("verificationScore"));
+                assertNull(getEvidenceAsMap(result).get("ci"));
+            }
+        }
+    }
+
+    @Nested
+    class KbvAuthenticationStatus {
+        @Nested
+        class ThreeOutOfFourPrioritisedKbvQuestionStrategy {
+            @Test
+            @DisplayName(
+                    "KBV passes with 'Authenticated' status when 3 answers are correct out of 3 that are asked")
+            void passesWhenKbvItemStatusIsAuthenticated() throws JsonProcessingException {
+                KBVItem kbvItem = getKbvItem();
+                kbvItem.setStatus("authenticated");
+                kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(3, 3, 0));
+                setKbvItemQuestionState(kbvItem, "First", "Second", "Third");
+
+                doNothing()
+                        .when(mockEventProbe)
+                        .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
+
+                var result = evidenceFactory.create(kbvItem, mockEvidenceRequest);
+
+                verify(mockEventProbe)
+                        .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
+
+                assertEquals("3 out of 4 Prioritised", evidenceFactory.getKbvQuestionStrategy());
+                assertEquals(
+                        VerifiableCredentialConstants.VC_PASS_EVIDENCE_SCORE,
+                        getEvidenceAsMap(result).get("verificationScore"));
+                assertNull(getEvidenceAsMap(result).get("ci"));
+            }
+
+            @Test
+            @DisplayName(
+                    "KBV fails with 'not authenticated' status and has a contraIndicator when more than 1 answers are incorrect out of 4 asked")
+            void failsThenReturnsV03ContraIndicatorWhenMultipleAnswersAreIncorrect()
+                    throws JsonProcessingException {
+                KBVItem kbvItem = getKbvItem();
+                kbvItem.setStatus("not authenticated");
+                kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(4, 2, 2));
+                setKbvItemQuestionState(kbvItem, "First", "Second", "Third", "Fourth");
+
+                doNothing()
+                        .when(mockEventProbe)
+                        .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
+
+                var result = evidenceFactory.create(kbvItem, mockEvidenceRequest);
+
+                verify(mockEventProbe)
+                        .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
+
+                assertEquals("3 out of 4 Prioritised", evidenceFactory.getKbvQuestionStrategy());
+                assertEquals(
+                        VerifiableCredentialConstants.VC_FAIL_EVIDENCE_SCORE,
+                        getEvidenceAsMap(result).get("verificationScore"));
+                assertEquals(
+                        ContraIndicator.V03.toString(),
+                        ((List) getEvidenceAsMap(result).get("ci")).get(0));
+            }
+
+            @Test
+            @DisplayName(
+                    "KBV fails and returns with 'unable to authenticate' status and a contraIndicator when a user with exactly 3 KBV(s) with the 3rd-party received 2 questions and got one wrong and no further question can be received from 3rd party")
+            void
+                    failsThenReturnsAV03ContraIndicatorWhenAUserWithExactly3KbvWithThe3rdPartyGetsOneOfTwoQuestionsWrong()
+                            throws JsonProcessingException {
+                KBVItem kbvItem = getKbvItem();
+                kbvItem.setStatus("unable to authenticate");
+                kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(2, 1, 1));
+                setKbvItemQuestionState(kbvItem, "First", "Second");
+
+                doNothing()
+                        .when(mockEventProbe)
+                        .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
+
+                var result = evidenceFactory.create(kbvItem, mockEvidenceRequest);
+
+                verify(mockEventProbe)
+                        .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
+
+                assertEquals("3 out of 4 Prioritised", evidenceFactory.getKbvQuestionStrategy());
+                assertEquals(
+                        VerifiableCredentialConstants.VC_FAIL_EVIDENCE_SCORE,
+                        getEvidenceAsMap(result).get("verificationScore"));
+                assertEquals(
+                        ContraIndicator.V03.toString(),
+                        ((List) getEvidenceAsMap(result).get("ci")).get(0));
+            }
+
+            @Test
+            @DisplayName("KBV fails with an unknown status no contraIndicator is returned")
+            void failsWhenKbvItemStatusIsAnyOtherValue() throws JsonProcessingException {
+                KBVItem kbvItem = getKbvItem();
+                kbvItem.setStatus("some unknown value");
+
+                doNothing()
+                        .when(mockEventProbe)
+                        .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
+
+                var result = evidenceFactory.create(kbvItem, mockEvidenceRequest);
+                verify(mockEventProbe)
+                        .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
+
+                assertEquals(
+                        VerifiableCredentialConstants.VC_FAIL_EVIDENCE_SCORE,
+                        getEvidenceAsMap(result).get("verificationScore"));
+                assertNull(getEvidenceAsMap(result).get("ci"));
+            }
         }
 
-        @Test
-        void shouldFailAndReturnContraIndicatorWhenEnoughAnswersAreIncorrect()
-                throws JsonProcessingException {
-            KBVItem kbvItem = getKbvItem();
-            kbvItem.setStatus("unable to authenticate");
-            kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(3, 2, 1));
-            setKbvItemQuestionState(kbvItem, "First", "Second", "Third");
+        @Nested
+        class TwoOutOfThreePrioritisedKbvQuestionStrategy {
+            @BeforeEach
+            void setUp() {
+                evidenceFactory =
+                        new EvidenceFactory(
+                                objectMapper,
+                                mockEventProbe,
+                                KBV_QUESTION_QUALITY_MAPPING_SERIALIZED);
+                evidenceFactory.setKbvQuestionStrategy("2 out of 3 Prioritised");
+            }
 
-            doNothing()
-                    .when(mockEventProbe)
-                    .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
+            @Test
+            @DisplayName(
+                    "KBV passes with 'Authenticated' status when 2 answers are correct out of 2 that are asked")
+            void passesWhenKbvItemStatusIsAuthenticated() throws JsonProcessingException {
+                KBVItem kbvItem = getKbvItem();
+                kbvItem.setStatus("authenticated");
+                kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(2, 2, 0));
+                setKbvItemQuestionState(kbvItem, "First", "Second");
 
-            var result = evidenceFactory.create(kbvItem, mockEvidenceRequest);
+                doNothing()
+                        .when(mockEventProbe)
+                        .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
 
-            verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
-            assertEquals(
-                    VerifiableCredentialConstants.VC_FAIL_EVIDENCE_SCORE,
-                    getEvidenceAsMap(result).get("verificationScore"));
-            assertEquals(
-                    ContraIndicator.V03.toString(),
-                    ((List) getEvidenceAsMap(result).get("ci")).get(0));
-        }
+                var result = evidenceFactory.create(kbvItem, mockEvidenceRequest);
 
-        @Test
-        void shouldFailWhenKbvItemStatusIsAnyOtherValue() throws JsonProcessingException {
-            KBVItem kbvItem = getKbvItem();
-            kbvItem.setStatus("some unknown value");
+                verify(mockEventProbe)
+                        .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
 
-            doNothing()
-                    .when(mockEventProbe)
-                    .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
+                assertEquals("2 out of 3 Prioritised", evidenceFactory.getKbvQuestionStrategy());
+                assertEquals(
+                        VerifiableCredentialConstants.VC_PASS_EVIDENCE_SCORE,
+                        getEvidenceAsMap(result).get("verificationScore"));
+                assertNull(getEvidenceAsMap(result).get("ci"));
+            }
 
-            var result = evidenceFactory.create(kbvItem, mockEvidenceRequest);
-            verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
+            @Test
+            @DisplayName(
+                    "KBV fails with 'not authenticated' status and has a contraIndicator when more than 1 answers are incorrect out of 3 asked")
+            void failsThenReturnsV03ContraIndicatorWhenMultipleAnswersAreIncorrect()
+                    throws JsonProcessingException {
+                KBVItem kbvItem = getKbvItem();
+                kbvItem.setStatus("not authenticated");
+                kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(3, 1, 2));
+                setKbvItemQuestionState(kbvItem, "First", "Second", "Third");
 
-            assertEquals(
-                    VerifiableCredentialConstants.VC_FAIL_EVIDENCE_SCORE,
-                    getEvidenceAsMap(result).get("verificationScore"));
-            assertNull(getEvidenceAsMap(result).get("ci"));
+                doNothing()
+                        .when(mockEventProbe)
+                        .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
+
+                var result = evidenceFactory.create(kbvItem, mockEvidenceRequest);
+
+                verify(mockEventProbe)
+                        .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
+
+                assertEquals("2 out of 3 Prioritised", evidenceFactory.getKbvQuestionStrategy());
+                assertEquals(
+                        VerifiableCredentialConstants.VC_FAIL_EVIDENCE_SCORE,
+                        getEvidenceAsMap(result).get("verificationScore"));
+                assertEquals(
+                        ContraIndicator.V03.toString(),
+                        ((List) getEvidenceAsMap(result).get("ci")).get(0));
+            }
+
+            @Test
+            @DisplayName(
+                    "KBV fails and returns with 'unable to authenticate' status and a contraIndicator when a user with exactly 3 KBV with the 3rd-party received 2 questions and got one wrong and no further question can be received from 3rd party")
+            void
+                    failsThenReturnsAV03ContraIndicatorWhenAUserWithExactly3KbvWithThe3rdPartyGetsOneOfTwoQuestionsWrong()
+                            throws JsonProcessingException {
+                KBVItem kbvItem = getKbvItem();
+                kbvItem.setStatus("unable to authenticate");
+                kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(2, 1, 1));
+                setKbvItemQuestionState(kbvItem, "First", "Second");
+
+                doNothing()
+                        .when(mockEventProbe)
+                        .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
+
+                var result = evidenceFactory.create(kbvItem, mockEvidenceRequest);
+
+                verify(mockEventProbe)
+                        .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
+
+                assertEquals("2 out of 3 Prioritised", evidenceFactory.getKbvQuestionStrategy());
+                assertEquals(
+                        VerifiableCredentialConstants.VC_FAIL_EVIDENCE_SCORE,
+                        getEvidenceAsMap(result).get("verificationScore"));
+                assertEquals(
+                        ContraIndicator.V03.toString(),
+                        ((List) getEvidenceAsMap(result).get("ci")).get(0));
+            }
+
+            @Test
+            @DisplayName("KBV fails with an unknown status no contraIndicator is returned")
+            void failsWhenKbvItemStatusIsAnyOtherValue() throws JsonProcessingException {
+                KBVItem kbvItem = getKbvItem();
+                kbvItem.setStatus("some unknown value");
+
+                doNothing()
+                        .when(mockEventProbe)
+                        .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
+
+                var result = evidenceFactory.create(kbvItem, mockEvidenceRequest);
+                verify(mockEventProbe)
+                        .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
+
+                assertEquals(
+                        VerifiableCredentialConstants.VC_FAIL_EVIDENCE_SCORE,
+                        getEvidenceAsMap(result).get("verificationScore"));
+                assertNull(getEvidenceAsMap(result).get("ci"));
+            }
         }
     }
 
     @Nested
     class EvidenceCheckDetails {
+        @Nested
+        class ThreeOutOfFourPrioritisedKbvQuestionStrategy {
+            @Test
+            @DisplayName(
+                    "KBV passes and three check details are produced for all 3 answered out of 3 asked")
+            void shouldHaveThreeCheckDetailsItemsForThreeCorrectlyAnsweredQuestionsWhenKbvPasses()
+                    throws JsonProcessingException {
+                KBVItem kbvItem = getKbvItem();
+                kbvItem.setStatus("authenticated");
+                kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(3, 3, 0));
+                setKbvItemQuestionState(kbvItem, "First", "Second", "Third");
 
-        @Test
-        @DisplayName(
-                "should use the default verification if verification score from session item is 0")
-        void shouldHaveAVerificationScoreOfZero() throws JsonProcessingException {
-            KBVItem kbvItem = getKbvItem();
-            UUID sessionId = UUID.randomUUID();
-            kbvItem.setSessionId(sessionId);
-            kbvItem.setStatus("authenticated");
-            kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(3, 3, 0));
-            setKbvItemQuestionState(kbvItem, "First", "Second", "Third");
+                List<KbvQuestion> kbvQuestionsFirstSecond = getKbvQuestions("First", "Second");
+                List<QuestionAnswer> questionFirstSecondAnswers =
+                        getQuestionAnswers("First", "Second");
+                List<KbvQuestion> kbvQuestionsThird = getKbvQuestions("Third");
+                List<QuestionAnswer> questionThirdAnswers = getQuestionAnswers("Third");
+                QuestionState questionState = new QuestionState();
+                questionState.setQAPairs(kbvQuestionsFirstSecond.toArray(KbvQuestion[]::new));
+                questionState =
+                        loadKbvQuestionStateWithAnswers(
+                                questionState, kbvQuestionsFirstSecond, questionFirstSecondAnswers);
 
-            SessionItem sessionItem = new SessionItem();
-            EvidenceRequest evidenceRequest = new EvidenceRequest();
-            evidenceRequest.setVerificationScore(0);
-            sessionItem.setEvidenceRequest(evidenceRequest);
+                questionState.setQAPairs(kbvQuestionsThird.toArray(KbvQuestion[]::new));
+                questionState =
+                        loadKbvQuestionStateWithAnswers(
+                                questionState, kbvQuestionsThird, questionThirdAnswers);
 
-            var result = evidenceFactory.create(kbvItem, evidenceRequest);
-            assertEquals(VC_PASS_EVIDENCE_SCORE, getEvidenceAsMap(result).get("verificationScore"));
+                kbvItem.setQuestionState(new ObjectMapper().writeValueAsString(questionState));
+                evidenceFactory =
+                        new EvidenceFactory(
+                                objectMapper,
+                                mockEventProbe,
+                                objectMapper.readValue(
+                                        "{\"First\":9,\"Second\": 5, \"Third\": 4}", Map.class));
+
+                var result = evidenceFactory.create(kbvItem, mockEvidenceRequest);
+
+                verify(mockEventProbe)
+                        .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
+                var checkDetailsResults = getEvidenceAsMap(result).get("checkDetails");
+
+                var results =
+                        objectMapper.convertValue(
+                                checkDetailsResults, new TypeReference<List<CheckDetail>>() {});
+                assertEquals(3, results.size());
+                assertNotNull(checkDetailsResults);
+                assertNull(getEvidenceAsMap(result).get("failedCheckDetails"));
+                assertEquals("3 out of 4 Prioritised", evidenceFactory.getKbvQuestionStrategy());
+
+                assertAll(
+                        () -> {
+                            assertEquals("kbv", results.get(0).getCheckMethod());
+                            assertEquals(9, results.get(0).getKbvQuality());
+                            assertEquals("multiple_choice", results.get(0).getKbvResponseMode());
+                            assertEquals("kbv", results.get(1).getCheckMethod());
+                            assertEquals(5, results.get(1).getKbvQuality());
+                            assertEquals("multiple_choice", results.get(1).getKbvResponseMode());
+                            assertEquals("kbv", results.get(2).getCheckMethod());
+                            assertEquals(4, results.get(2).getKbvQuality());
+                            assertEquals("multiple_choice", results.get(2).getKbvResponseMode());
+                        });
+                assertEquals("3 out of 4 Prioritised", evidenceFactory.getKbvQuestionStrategy());
+                assertEquals(3, results.size());
+                assertEquals(9, results.get(0).getKbvQuality());
+                assertEquals(5, results.get(1).getKbvQuality());
+                assertEquals(4, results.get(2).getKbvQuality());
+            }
+
+            @Test
+            @DisplayName(
+                    "should create check details with the lowest 3 kbvQuality values, so we are excluding the highest kbvQuality value out of 4 possible question asked for which it's not known which is incorrect")
+            void shouldReturnLowerKbvQualityWhenOnlyOneQuestionWasInitiallyAnsweredCorrectly()
+                    throws JsonProcessingException {
+                KBVItem kbvItem = getKbvItem();
+                kbvItem.setStatus("authenticated");
+                kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(4, 3, 1));
+                List<KbvQuestion> kbvQuestionsFirstSecond = getKbvQuestions("First", "Second");
+                List<QuestionAnswer> questionFirstSecondAnswers =
+                        getQuestionAnswers("First", "Second");
+                List<KbvQuestion> kbvQuestionsThirdFourth = getKbvQuestions("Third", "Fourth");
+                List<QuestionAnswer> questionThirdFourthAnswers =
+                        getQuestionAnswers("Third", "Fourth");
+                QuestionState questionState = new QuestionState();
+                questionState.setQAPairs(kbvQuestionsFirstSecond.toArray(KbvQuestion[]::new));
+                questionState =
+                        loadKbvQuestionStateWithAnswers(
+                                questionState, kbvQuestionsFirstSecond, questionFirstSecondAnswers);
+
+                questionState.setQAPairs(kbvQuestionsThirdFourth.toArray(KbvQuestion[]::new));
+                questionState =
+                        loadKbvQuestionStateWithAnswers(
+                                questionState, kbvQuestionsThirdFourth, questionThirdFourthAnswers);
+
+                kbvItem.setQuestionState(new ObjectMapper().writeValueAsString(questionState));
+
+                evidenceFactory =
+                        new EvidenceFactory(
+                                objectMapper,
+                                mockEventProbe,
+                                objectMapper.readValue(
+                                        "{\"First\":9,\"Second\": 5, \"Third\": 4, \"Fourth\": 8}",
+                                        Map.class));
+
+                var result = evidenceFactory.create(kbvItem, mockEvidenceRequest);
+
+                verify(mockEventProbe)
+                        .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
+                var checkDetailsResults = getEvidenceAsMap(result).get("checkDetails");
+
+                var results =
+                        objectMapper.convertValue(
+                                checkDetailsResults, new TypeReference<List<CheckDetail>>() {});
+                assertNotNull(checkDetailsResults);
+                assertNotNull(getEvidenceAsMap(result).get("failedCheckDetails"));
+
+                assertEquals("3 out of 4 Prioritised", evidenceFactory.getKbvQuestionStrategy());
+                assertEquals(3, results.size());
+                assertEquals(4, results.get(0).getKbvQuality());
+                assertEquals(5, results.get(1).getKbvQuality());
+                assertEquals(8, results.get(2).getKbvQuality());
+            }
+
+            @Test
+            @DisplayName(
+                    "should create check details with 3 kbv quality mapped exactly to there questions since the 1st question of the next batch is wrong, it was excluded and all inclusions were mapped correctly")
+            void shouldReturnActualKbvQualityWhenInitialTwoQuestionsAreAnsweredCorrectly()
+                    throws JsonProcessingException {
+                KBVItem kbvItem = getKbvItem();
+                kbvItem.setStatus("authenticated");
+                kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(4, 3, 1));
+                List<KbvQuestion> kbvQuestionsFirstSecond = getKbvQuestions("First", "Second");
+                List<QuestionAnswer> questionFirstSecondAnswers =
+                        getQuestionAnswers("First", "Second");
+                List<KbvQuestion> kbvQuestionsThird = getKbvQuestions("Third");
+                List<QuestionAnswer> questionThirdAnswers = getQuestionAnswers("Third");
+                List<KbvQuestion> kbvQuestionsFourth = getKbvQuestions("Fourth");
+                List<QuestionAnswer> questionFourthAnswers = getQuestionAnswers("Fourth");
+
+                QuestionState questionState = new QuestionState();
+                questionState.setQAPairs(kbvQuestionsFirstSecond.toArray(KbvQuestion[]::new));
+                questionState =
+                        loadKbvQuestionStateWithAnswers(
+                                questionState, kbvQuestionsFirstSecond, questionFirstSecondAnswers);
+
+                questionState.setQAPairs(kbvQuestionsThird.toArray(KbvQuestion[]::new));
+                questionState =
+                        loadKbvQuestionStateWithAnswers(
+                                questionState, kbvQuestionsThird, questionThirdAnswers);
+
+                questionState.setQAPairs(kbvQuestionsFourth.toArray(KbvQuestion[]::new));
+                questionState =
+                        loadKbvQuestionStateWithAnswers(
+                                questionState, kbvQuestionsFourth, questionFourthAnswers);
+
+                kbvItem.setQuestionState(new ObjectMapper().writeValueAsString(questionState));
+
+                evidenceFactory =
+                        new EvidenceFactory(
+                                objectMapper,
+                                mockEventProbe,
+                                objectMapper.readValue(
+                                        "{\"First\":9,\"Second\": 5, \"Third\": 4, \"Fourth\": 8}",
+                                        Map.class));
+
+                var result = evidenceFactory.create(kbvItem, mockEvidenceRequest);
+
+                verify(mockEventProbe)
+                        .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
+                var checkDetailsResults = getEvidenceAsMap(result).get("checkDetails");
+
+                var results =
+                        objectMapper.convertValue(
+                                checkDetailsResults, new TypeReference<List<CheckDetail>>() {});
+                assertNotNull(checkDetailsResults);
+                assertNotNull(getEvidenceAsMap(result).get("failedCheckDetails"));
+
+                assertEquals("3 out of 4 Prioritised", evidenceFactory.getKbvQuestionStrategy());
+                assertEquals(3, results.size());
+                assertEquals(9, results.get(0).getKbvQuality());
+                assertEquals(5, results.get(1).getKbvQuality());
+                assertEquals(8, results.get(2).getKbvQuality());
+            }
+
+            @Test
+            @DisplayName(
+                    "should create two check details and two failed check details, check details would have been assigned to lower kbv Quality values")
+            void shouldHaveTwoFailedAndTwoCheckDetailsOutOfFourKbvQuestionsAsked()
+                    throws JsonProcessingException {
+                KBVItem kbvItem = getKbvItem();
+                kbvItem.setStatus("not Authenticated");
+                kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(4, 2, 2));
+                setKbvItemQuestionState(kbvItem, "First", "Second", "Third", "Fourth");
+
+                doNothing()
+                        .when(mockEventProbe)
+                        .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
+
+                var result = evidenceFactory.create(kbvItem, mockEvidenceRequest);
+
+                verify(mockEventProbe)
+                        .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
+                var failedCheckDetailsResultsNode =
+                        getEvidenceAsMap(result).get("failedCheckDetails");
+                var checkDetailsResultsNode = getEvidenceAsMap(result).get("checkDetails");
+                var checkDetailsResults =
+                        objectMapper.convertValue(
+                                checkDetailsResultsNode, new TypeReference<List<CheckDetail>>() {});
+                var failedCheckDetailsResults =
+                        objectMapper.convertValue(
+                                failedCheckDetailsResultsNode,
+                                new TypeReference<List<CheckDetail>>() {});
+
+                assertNotNull(failedCheckDetailsResultsNode);
+                assertEquals(2, failedCheckDetailsResults.size());
+                assertEquals(2, checkDetailsResults.size());
+                failedCheckDetailsResults.forEach(
+                        failedCheckDetail -> {
+                            assertAll(
+                                    () -> {
+                                        assertEquals("kbv", failedCheckDetail.getCheckMethod());
+                                        assertNull(failedCheckDetail.getKbvQuality());
+                                        assertEquals(
+                                                "multiple_choice",
+                                                failedCheckDetail.getKbvResponseMode());
+                                    });
+                        });
+            }
         }
 
-        @Test
-        @DisplayName("should use the verification score from session item if present")
-        void shouldHaveAVerificationScoreOfOne() throws JsonProcessingException {
-            KBVItem kbvItem = getKbvItem();
-            UUID sessionId = UUID.randomUUID();
-            kbvItem.setSessionId(sessionId);
-            kbvItem.setStatus("authenticated");
-            kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(3, 3, 0));
-            setKbvItemQuestionState(kbvItem, "First", "Second", "Third");
+        @Nested
+        class TwoOutOfThreePrioritisedKbvQuestionStrategy {
+            @BeforeEach
+            void setUp() {
+                evidenceFactory =
+                        new EvidenceFactory(
+                                objectMapper,
+                                mockEventProbe,
+                                KBV_QUESTION_QUALITY_MAPPING_SERIALIZED);
+                evidenceFactory.setKbvQuestionStrategy("2 out of 3 Prioritised");
+            }
 
-            SessionItem sessionItem = new SessionItem();
-            EvidenceRequest evidenceRequest = new EvidenceRequest();
-            evidenceRequest.setVerificationScore(1);
-            sessionItem.setEvidenceRequest(evidenceRequest);
+            @Test
+            @DisplayName(
+                    "KBV passes and two check details are produced for all 2 answered out of 2 asked")
+            void shouldHaveTwoCheckDetailsItemsForTwoCorrectlyAnsweredQuestionsWhenKbvPasses()
+                    throws JsonProcessingException {
+                KBVItem kbvItem = getKbvItem();
+                kbvItem.setStatus("authenticated");
+                kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(2, 2, 0));
+                setKbvItemQuestionState(kbvItem, "First", "Second");
 
-            var result = evidenceFactory.create(kbvItem, evidenceRequest);
+                List<KbvQuestion> kbvQuestionsFirstSecond = getKbvQuestions("First", "Second");
+                List<QuestionAnswer> questionFirstSecondAnswers =
+                        getQuestionAnswers("First", "Second");
 
-            assertEquals(
-                    evidenceRequest.getVerificationScore(),
-                    getEvidenceAsMap(result).get("verificationScore"));
-        }
+                QuestionState questionState = new QuestionState();
+                questionState.setQAPairs(kbvQuestionsFirstSecond.toArray(KbvQuestion[]::new));
+                questionState =
+                        loadKbvQuestionStateWithAnswers(
+                                questionState, kbvQuestionsFirstSecond, questionFirstSecondAnswers);
 
-        @Test
-        @DisplayName(
-                "should have the verification score of 2 if score in session item is not present")
-        void shouldHaveAVerificationScoreOfTwoWhenMissingScore() throws JsonProcessingException {
-            KBVItem kbvItem = getKbvItem();
-            UUID sessionId = UUID.randomUUID();
-            kbvItem.setSessionId(sessionId);
-            kbvItem.setStatus("authenticated");
-            kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(3, 3, 0));
-            setKbvItemQuestionState(kbvItem, "First", "Second", "Third");
+                kbvItem.setQuestionState(new ObjectMapper().writeValueAsString(questionState));
+                evidenceFactory =
+                        new EvidenceFactory(
+                                objectMapper,
+                                mockEventProbe,
+                                objectMapper.readValue("{\"First\":9,\"Second\": 5}", Map.class));
+                evidenceFactory.setKbvQuestionStrategy("2 out of 3 Prioritised");
 
-            SessionItem sessionItem = new SessionItem();
+                var result = evidenceFactory.create(kbvItem, mockEvidenceRequest);
 
-            var result = evidenceFactory.create(kbvItem, sessionItem.getEvidenceRequest());
+                verify(mockEventProbe)
+                        .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
+                var checkDetailsResults = getEvidenceAsMap(result).get("checkDetails");
 
-            assertEquals(2, getEvidenceAsMap(result).get("verificationScore"));
-        }
+                var results =
+                        objectMapper.convertValue(
+                                checkDetailsResults, new TypeReference<List<CheckDetail>>() {});
+                assertEquals(2, results.size());
+                assertNotNull(checkDetailsResults);
+                assertNull(getEvidenceAsMap(result).get("failedCheckDetails"));
+                assertEquals("2 out of 3 Prioritised", evidenceFactory.getKbvQuestionStrategy());
+                assertAll(
+                        () -> {
+                            assertEquals("kbv", results.get(0).getCheckMethod());
+                            assertEquals(9, results.get(0).getKbvQuality());
+                            assertEquals("multiple_choice", results.get(0).getKbvResponseMode());
+                            assertEquals("kbv", results.get(1).getCheckMethod());
+                            assertEquals(5, results.get(1).getKbvQuality());
+                        });
+                assertEquals(2, results.size());
+                assertEquals(9, results.get(0).getKbvQuality());
+                assertEquals(5, results.get(1).getKbvQuality());
+            }
 
-        @Test
-        void shouldContainCheckDetailsWhenKbvPasses() throws JsonProcessingException {
-            KBVItem kbvItem = getKbvItem();
-            kbvItem.setStatus("authenticated");
-            kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(3, 3, 0));
-            setKbvItemQuestionState(kbvItem, "First", "Second", "Third");
+            @Test
+            @DisplayName(
+                    "should create check details with the lowest 2 kbvQuality values, so we are excluding the highest kbvQuality value out of 3 possible questions asked since we don't know which of the initial 2 is incorrect")
+            void shouldReturnActualKbvQualityWhenInitialTwoQuestionsAreAnsweredCorrectly()
+                    throws JsonProcessingException {
+                KBVItem kbvItem = getKbvItem();
+                kbvItem.setStatus("authenticated");
+                kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(3, 2, 1));
+                List<KbvQuestion> kbvQuestionsFirstSecond = getKbvQuestions("First", "Second");
+                List<QuestionAnswer> questionFirstSecondAnswers =
+                        getQuestionAnswers("First", "Second");
+                List<KbvQuestion> kbvQuestionsThird = getKbvQuestions("Third");
+                List<QuestionAnswer> questionThirdAnswers = getQuestionAnswers("Third");
 
-            var result = evidenceFactory.create(kbvItem, mockEvidenceRequest);
+                QuestionState questionState = new QuestionState();
+                questionState.setQAPairs(kbvQuestionsFirstSecond.toArray(KbvQuestion[]::new));
+                questionState =
+                        loadKbvQuestionStateWithAnswers(
+                                questionState, kbvQuestionsFirstSecond, questionFirstSecondAnswers);
 
-            verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
-            assertNotNull(getEvidenceAsMap(result).get("checkDetails"));
-        }
+                questionState.setQAPairs(kbvQuestionsThird.toArray(KbvQuestion[]::new));
+                questionState =
+                        loadKbvQuestionStateWithAnswers(
+                                questionState, kbvQuestionsThird, questionThirdAnswers);
 
-        @Test
-        void shouldHaveAsManyCheckDetailsItemsAsThereAreCorrectQuestionsWhenKbvPasses()
-                throws JsonProcessingException {
-            KBVItem kbvItem = getKbvItem();
-            kbvItem.setStatus("authenticated");
-            kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(3, 3, 0));
-            setKbvItemQuestionState(kbvItem, "First", "Second", "Third");
-            var result = evidenceFactory.create(kbvItem, mockEvidenceRequest);
+                kbvItem.setQuestionState(new ObjectMapper().writeValueAsString(questionState));
 
-            verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
-            var checkDetailsResults = getEvidenceAsMap(result).get("checkDetails");
+                evidenceFactory =
+                        new EvidenceFactory(
+                                objectMapper,
+                                mockEventProbe,
+                                objectMapper.readValue(
+                                        "{\"First\":9,\"Second\": 5, \"Third\": 4}", Map.class));
+                evidenceFactory.setKbvQuestionStrategy("2 out of 3 Prioritised");
 
-            var results =
-                    objectMapper.convertValue(
-                            checkDetailsResults, new TypeReference<List<CheckDetail>>() {});
-            assertEquals(3, results.size());
-            assertNotNull(checkDetailsResults);
-            assertNull(getEvidenceAsMap(result).get("failedCheckDetails"));
-            results.forEach(
-                    checkDetail -> {
-                        assertAll(
-                                () -> {
-                                    assertEquals("kbv", checkDetail.getCheckMethod());
-                                    assertEquals(
-                                            KbvQuality.LOW.getValue(), checkDetail.getKbvQuality());
-                                    assertEquals(
-                                            "multiple_choice", checkDetail.getKbvResponseMode());
-                                });
-                    });
-        }
+                var result = evidenceFactory.create(kbvItem, mockEvidenceRequest);
 
-        @Test
-        void shouldReturnLowerKbvQualityWhenOnlyOneQuestionWasInitiallyAnsweredCorrectly()
-                throws JsonProcessingException {
-            KBVItem kbvItem = getKbvItem();
-            kbvItem.setStatus("authenticated");
-            kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(4, 3, 1));
-            List<KbvQuestion> kbvQuestionsFirstSecond = getKbvQuestions("First", "Second");
-            List<QuestionAnswer> questionFirstSecondAnswers = getQuestionAnswers("First", "Second");
-            List<KbvQuestion> kbvQuestionsThirdFourth = getKbvQuestions("Third", "Fourth");
-            List<QuestionAnswer> questionThirdFourthAnswers = getQuestionAnswers("Third", "Fourth");
-            QuestionState questionState = new QuestionState();
-            questionState.setQAPairs(kbvQuestionsFirstSecond.toArray(KbvQuestion[]::new));
-            questionState =
-                    loadKbvQuestionStateWithAnswers(
-                            questionState, kbvQuestionsFirstSecond, questionFirstSecondAnswers);
+                verify(mockEventProbe)
+                        .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
+                var checkDetailsResults = getEvidenceAsMap(result).get("checkDetails");
 
-            questionState.setQAPairs(kbvQuestionsThirdFourth.toArray(KbvQuestion[]::new));
-            questionState =
-                    loadKbvQuestionStateWithAnswers(
-                            questionState, kbvQuestionsThirdFourth, questionThirdFourthAnswers);
+                var results =
+                        objectMapper.convertValue(
+                                checkDetailsResults, new TypeReference<List<CheckDetail>>() {});
+                assertNotNull(checkDetailsResults);
+                assertNotNull(getEvidenceAsMap(result).get("failedCheckDetails"));
 
-            kbvItem.setQuestionState(new ObjectMapper().writeValueAsString(questionState));
+                assertEquals("2 out of 3 Prioritised", evidenceFactory.getKbvQuestionStrategy());
+                assertEquals(2, results.size());
+                assertEquals(4, results.get(0).getKbvQuality());
+                assertEquals(5, results.get(1).getKbvQuality());
+            }
 
-            evidenceFactory =
-                    new EvidenceFactory(
-                            objectMapper,
-                            mockEventProbe,
-                            objectMapper.readValue(
-                                    "{\"First\":4,\"Second\": 5, \"Third\": 9, \"Fourth\": 9}",
-                                    Map.class));
+            @Test
+            @DisplayName(
+                    "should create two check details and one failed check details, check details would have been assigned to lower kbv Quality values")
+            void shouldHaveTwoFailedAndOneCheckDetailsOutOfThreeKbvQuestionsAsked()
+                    throws JsonProcessingException {
+                KBVItem kbvItem = getKbvItem();
+                kbvItem.setStatus("not Authenticated");
+                kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(3, 1, 2));
+                setKbvItemQuestionState(kbvItem, "First", "Second", "Third");
 
-            var result = evidenceFactory.create(kbvItem, mockEvidenceRequest);
+                doNothing()
+                        .when(mockEventProbe)
+                        .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
 
-            verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
-            var checkDetailsResults = getEvidenceAsMap(result).get("checkDetails");
+                var result = evidenceFactory.create(kbvItem, mockEvidenceRequest);
 
-            var results =
-                    objectMapper.convertValue(
-                            checkDetailsResults, new TypeReference<List<CheckDetail>>() {});
-            assertNotNull(checkDetailsResults);
-            assertNotNull(getEvidenceAsMap(result).get("failedCheckDetails"));
+                verify(mockEventProbe)
+                        .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
+                var failedCheckDetailsResultsNode =
+                        getEvidenceAsMap(result).get("failedCheckDetails");
+                var checkDetailsResultsNode = getEvidenceAsMap(result).get("checkDetails");
+                var checkDetailsResults =
+                        objectMapper.convertValue(
+                                checkDetailsResultsNode, new TypeReference<List<CheckDetail>>() {});
+                var failedCheckDetailsResults =
+                        objectMapper.convertValue(
+                                failedCheckDetailsResultsNode,
+                                new TypeReference<List<CheckDetail>>() {});
 
-            assertEquals(3, results.size());
-            assertEquals(4, results.get(0).getKbvQuality());
-            assertEquals(5, results.get(1).getKbvQuality());
-            assertEquals(9, results.get(2).getKbvQuality());
-        }
-
-        @Test
-        void shouldReturnActualKbvQualityWhenInitial2QuestionsAreAnsweredCorrectly()
-                throws JsonProcessingException {
-            KBVItem kbvItem = getKbvItem();
-            kbvItem.setStatus("authenticated");
-            kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(4, 3, 1));
-            List<KbvQuestion> kbvQuestionsFirstSecond = getKbvQuestions("First", "Second");
-            List<QuestionAnswer> questionFirstSecondAnswers = getQuestionAnswers("First", "Second");
-            List<KbvQuestion> kbvQuestionsThird = getKbvQuestions("Third");
-            List<QuestionAnswer> questionThirdAnswers = getQuestionAnswers("Third");
-            List<KbvQuestion> kbvQuestionsFourth = getKbvQuestions("Fourth");
-            List<QuestionAnswer> questionFourthAnswers = getQuestionAnswers("Fourth");
-
-            QuestionState questionState = new QuestionState();
-            questionState.setQAPairs(kbvQuestionsFirstSecond.toArray(KbvQuestion[]::new));
-            questionState =
-                    loadKbvQuestionStateWithAnswers(
-                            questionState, kbvQuestionsFirstSecond, questionFirstSecondAnswers);
-
-            questionState.setQAPairs(kbvQuestionsThird.toArray(KbvQuestion[]::new));
-            questionState =
-                    loadKbvQuestionStateWithAnswers(
-                            questionState, kbvQuestionsThird, questionThirdAnswers);
-
-            questionState.setQAPairs(kbvQuestionsFourth.toArray(KbvQuestion[]::new));
-            questionState =
-                    loadKbvQuestionStateWithAnswers(
-                            questionState, kbvQuestionsFourth, questionFourthAnswers);
-
-            kbvItem.setQuestionState(new ObjectMapper().writeValueAsString(questionState));
-
-            evidenceFactory =
-                    new EvidenceFactory(
-                            objectMapper,
-                            mockEventProbe,
-                            objectMapper.readValue(
-                                    "{\"First\":4,\"Second\": 5, \"Third\": 9, \"Fourth\": 8}",
-                                    Map.class));
-
-            var result = evidenceFactory.create(kbvItem, mockEvidenceRequest);
-
-            verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "pass"));
-            var checkDetailsResults = getEvidenceAsMap(result).get("checkDetails");
-
-            var results =
-                    objectMapper.convertValue(
-                            checkDetailsResults, new TypeReference<List<CheckDetail>>() {});
-            assertNotNull(checkDetailsResults);
-            assertNotNull(getEvidenceAsMap(result).get("failedCheckDetails"));
-
-            assertEquals(3, results.size());
-            assertEquals(4, results.get(0).getKbvQuality());
-            assertEquals(5, results.get(1).getKbvQuality());
-            assertEquals(8, results.get(2).getKbvQuality());
-        }
-
-        @Test
-        void shouldHave2FailedAnd2CheckDetails2of4KbvQuestionsAreInCorrect()
-                throws JsonProcessingException {
-            KBVItem kbvItem = getKbvItem();
-            kbvItem.setStatus("not Authenticated");
-            kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(4, 2, 2));
-            setKbvItemQuestionState(kbvItem, "First", "Second", "Third", "Fourth");
-
-            doNothing()
-                    .when(mockEventProbe)
-                    .addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
-
-            var result = evidenceFactory.create(kbvItem, mockEvidenceRequest);
-
-            verify(mockEventProbe).addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, "fail"));
-            var failedCheckDetailsResultsNode = getEvidenceAsMap(result).get("failedCheckDetails");
-            var checkDetailsResultsNode = getEvidenceAsMap(result).get("checkDetails");
-            var checkDetailsResults =
-                    objectMapper.convertValue(
-                            checkDetailsResultsNode, new TypeReference<List<CheckDetail>>() {});
-            var failedCheckDetailsResults =
-                    objectMapper.convertValue(
-                            failedCheckDetailsResultsNode,
-                            new TypeReference<List<CheckDetail>>() {});
-
-            assertNotNull(failedCheckDetailsResultsNode);
-            assertEquals(2, failedCheckDetailsResults.size());
-            assertEquals(2, checkDetailsResults.size());
-            failedCheckDetailsResults.forEach(
-                    failedCheckDetail -> {
-                        assertAll(
-                                () -> {
-                                    assertEquals("kbv", failedCheckDetail.getCheckMethod());
-                                    assertNull(failedCheckDetail.getKbvQuality());
-                                    assertEquals(
-                                            "multiple_choice",
-                                            failedCheckDetail.getKbvResponseMode());
-                                });
-                    });
+                assertNotNull(failedCheckDetailsResultsNode);
+                assertEquals(2, failedCheckDetailsResults.size());
+                assertEquals(1, checkDetailsResults.size());
+                failedCheckDetailsResults.forEach(
+                        failedCheckDetail -> {
+                            assertAll(
+                                    () -> {
+                                        assertEquals("kbv", failedCheckDetail.getCheckMethod());
+                                        assertNull(failedCheckDetail.getKbvQuality());
+                                        assertEquals(
+                                                "multiple_choice",
+                                                failedCheckDetail.getKbvResponseMode());
+                                    });
+                        });
+            }
         }
 
         @Test

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/QuestionState.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/QuestionState.java
@@ -19,8 +19,8 @@ public class QuestionState {
     private List<List<QuestionAnswerPair>> allQaPairs = new ArrayList<>();
 
     @JsonIgnore
-    public boolean allQuestionBatchSizesMatch(int expectedBatchSize) {
-        return allQaPairs.stream().allMatch(x -> x.size() == expectedBatchSize);
+    public boolean isQuestionReceivedBatchCountEqualTo(int expectedSize) {
+        return allQaPairs.size() == expectedSize;
     }
 
     @JsonIgnore

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/strategy/KbvStrategyParser.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/strategy/KbvStrategyParser.java
@@ -1,0 +1,37 @@
+package uk.gov.di.ipv.cri.kbv.api.strategy;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+public class KbvStrategyParser {
+    private final String strategy;
+
+    public KbvStrategyParser(String strategy) {
+        this.strategy = strategy;
+    }
+
+    public Strategy parse() {
+        List<Integer> numbers =
+                Arrays.stream(strategy.split("\\D+"))
+                        .filter(Predicate.not(String::isEmpty))
+                        .map(Integer::parseInt)
+                        .collect(Collectors.toList());
+
+        if (numbers.size() != 2) {
+            throw new IllegalArgumentException(String.format("Invalid input string: %s", strategy));
+        }
+
+        int first = numbers.get(0);
+        int second = numbers.get(1);
+
+        if (first >= second) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "First number %d must be less than second number %d: %s",
+                            first, second, strategy));
+        }
+        return new Strategy(first, second);
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/strategy/Strategy.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/strategy/Strategy.java
@@ -1,0 +1,19 @@
+package uk.gov.di.ipv.cri.kbv.api.strategy;
+
+public class Strategy {
+    private final int min;
+    private final int max;
+
+    public Strategy(int min, int max) {
+        this.min = min;
+        this.max = max;
+    }
+
+    public int min() {
+        return min;
+    }
+
+    public int max() {
+        return max;
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/util/EvidenceUtils.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/util/EvidenceUtils.java
@@ -16,6 +16,11 @@ public class EvidenceUtils {
             return VC_PASS_EVIDENCE_SCORE;
         }
         int verificationScore = evidenceRequest.getVerificationScore();
+        if (verificationScore < 0 || verificationScore > VC_PASS_EVIDENCE_SCORE) {
+            String errorMessage =
+                    String.format("Verification Score %d is not supported", verificationScore);
+            throw new IllegalStateException(errorMessage);
+        }
         return verificationScore > 0 ? verificationScore : VC_PASS_EVIDENCE_SCORE;
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/domain/QuestionStateTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/domain/QuestionStateTest.java
@@ -31,7 +31,7 @@ class QuestionStateTest {
     }
 
     @Test
-    void shouldReturnTrueWhenIthasAtLeastOneUnanswered() {
+    void returnsTrueWhenQuestionStateHasAtLeastOneUnanswered() {
         QuestionsResponse questionsResponse =
                 getExperianQuestionResponse(
                         new KbvQuestion[] {getQuestion("Q00015"), getQuestion("Q00040")});
@@ -42,7 +42,7 @@ class QuestionStateTest {
     }
 
     @Test
-    void shouldReturnFalseWhenIthasAtLeastOneUnansweredIsFalse() {
+    void atLeastOneUnansweredIsReturnFalseWhenQuestionStateContainsUnAnsweredQuestions() {
         QuestionsResponse questionsResponse =
                 getExperianQuestionResponse(
                         new KbvQuestion[] {getQuestion("Q00015"), getQuestion("Q00040")});
@@ -64,7 +64,7 @@ class QuestionStateTest {
     }
 
     @Test
-    void shouldReturnAllQaPairs() {
+    void shouldReturnAllQaPairsWhenQuestateIsPopulated() {
         QuestionsResponse questionsResponse1 =
                 getExperianQuestionResponse(
                         new KbvQuestion[] {getQuestion("Q00015"), getQuestion("Q00040")});
@@ -80,7 +80,7 @@ class QuestionStateTest {
     }
 
     @Test
-    void shouldEvaluateToTrueWhenAllQuestionsHaveAnswers() {
+    void questionsHaveAllBeenAnsweredShouldEvaluateToTrueWhenAllQuestionsHaveAnswers() {
         QuestionAnswerPair questionAnswerPairMock1 = mock(QuestionAnswerPair.class);
         when(questionAnswerPairMock1.getAnswer()).thenReturn("answer-1");
         QuestionAnswerPair questionAnswerPairMock2 = mock(QuestionAnswerPair.class);
@@ -148,7 +148,7 @@ class QuestionStateTest {
         questionState.setQAPairs(questionsResponse1.getQuestions());
         questionState.setQAPairs(questionsResponse2.getQuestions());
 
-        assertTrue(questionState.allQuestionBatchSizesMatch(2));
+        assertTrue(questionState.isQuestionReceivedBatchCountEqualTo(2));
         assertEquals(4, questionState.getQuestionIdsFromQAPairs().count());
     }
 
@@ -164,12 +164,32 @@ class QuestionStateTest {
         questionState.setQAPairs(questionsResponse1.getQuestions());
         questionState.setQAPairs(questionsResponse2.getQuestions());
 
-        assertTrue(questionState.allQuestionBatchSizesMatch(2));
+        assertTrue(questionState.isQuestionReceivedBatchCountEqualTo(2));
 
         assertAll(
                 () -> {
                     assertEquals("Q00015,Q00040,Q00045,Q00067", questionState.getAllQaPairsIds());
                     assertEquals("Q00045,Q00067", questionState.getQaPairsIds());
+                });
+    }
+
+    @Test
+    void shouldReturnAllQaPairsWhenNewQuestionsAreSetInBatchesOf2And1() {
+        QuestionsResponse questionsResponse1 =
+                getExperianQuestionResponse(
+                        new KbvQuestion[] {getQuestion("Q00015"), getQuestion("Q00040")});
+        QuestionsResponse questionsResponse2 =
+                getExperianQuestionResponse(new KbvQuestion[] {getQuestion("Q00045")});
+
+        questionState.setQAPairs(questionsResponse1.getQuestions());
+        questionState.setQAPairs(questionsResponse2.getQuestions());
+
+        assertTrue(questionState.isQuestionReceivedBatchCountEqualTo(2));
+
+        assertAll(
+                () -> {
+                    assertEquals("Q00015,Q00040,Q00045", questionState.getAllQaPairsIds());
+                    assertEquals("Q00045", questionState.getQaPairsIds());
                 });
     }
 
@@ -214,12 +234,12 @@ class QuestionStateTest {
         questionState.setQAPairs(questionsResponse3.getQuestions());
         questionState.setQAPairs(questionsResponse4.getQuestions());
 
-        assertFalse(questionState.allQuestionBatchSizesMatch(2));
+        assertFalse(questionState.isQuestionReceivedBatchCountEqualTo(2));
         assertEquals(4, questionState.getQuestionIdsFromQAPairs().count());
     }
 
     @Test
-    void questionStateShouldfilterOutQAPairAtIndexOne() {
+    void questionStateShouldFilterOutQAPairAtIndexOne() {
         var questionOne = getQuestionOne();
         var questionTwo = getQuestionTwo();
         var questionThree = getQuestionOne();
@@ -234,7 +254,7 @@ class QuestionStateTest {
         questionState.setQAPairs(questionsResponse3.getQuestions());
         questionState.setQAPairs(questionsResponse4.getQuestions());
 
-        assertFalse(questionState.allQuestionBatchSizesMatch(2));
+        assertFalse(questionState.isQuestionReceivedBatchCountEqualTo(2));
         assertEquals(2, questionState.skipQaPairAtIndexOne().count());
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/strategy/KbvStrategyParserTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/strategy/KbvStrategyParserTest.java
@@ -1,0 +1,73 @@
+package uk.gov.di.ipv.cri.kbv.api.strategy;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockitoExtension.class)
+class KbvStrategyParserTest {
+    @ParameterizedTest
+    @CsvSource({
+        "3 out of 4 Prioritised, 3,4",
+        "3 out of 4, 3,4",
+        "2 out of 3 Prioritised, 2,3",
+        "2 out of 3, 2,3",
+        "3 of 4, 3,4",
+        "2 of 3, 2,3",
+        "3 4, 3,4",
+        "2 3, 2,3"
+    })
+    void shouldReturnMinAndMaxNumberOfQuestionsNeededToPassStrategy(
+            String strategy, int minimum, int maximum) {
+        KbvStrategyParser strategyParser = new KbvStrategyParser(strategy);
+
+        Strategy result = strategyParser.parse();
+        assertAll(
+                () -> assertEquals(minimum, result.min()),
+                () -> assertEquals(maximum, result.max()));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "4 out of 3 Prioritised,3,4",
+        "3 out of 2 Prioritised,2,3",
+    })
+    void throwsAnErrorWhenStrategyInputHasFirstNumberGreaterThanSecond(
+            String strategy, int minimum, int maximum) {
+        KbvStrategyParser strategyParser = new KbvStrategyParser(strategy);
+        String errorMessage = "First number %d must be less than second number %d: %s";
+
+        IllegalArgumentException exception =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> strategyParser.parse(),
+                        String.format(errorMessage, maximum, minimum, strategy));
+
+        assertEquals(
+                String.format(errorMessage, maximum, minimum, strategy), exception.getMessage());
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "out of 3 Prioritised",
+        "out of 2 Prioritised",
+        "Prioritised",
+    })
+    void throwsAnErrorWhenStrategyInputIsInValid(String strategy) {
+        KbvStrategyParser strategyParser = new KbvStrategyParser(strategy);
+        String errorMessage = "Invalid input string: %s";
+
+        IllegalArgumentException exception =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> strategyParser.parse(),
+                        String.format(errorMessage, strategy));
+
+        assertEquals(String.format(errorMessage, strategy), exception.getMessage());
+    }
+}

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/util/EvidenceUtilsTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/util/EvidenceUtilsTest.java
@@ -1,28 +1,53 @@
 package uk.gov.di.ipv.cri.kbv.api.util;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import uk.gov.di.ipv.cri.common.library.persistence.item.EvidenceRequest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class EvidenceUtilsTest {
-
     @Test
-    void shouldGiveScoreOfTwoWhenNull() {
+    @DisplayName("Should return pass verification score of 2 by default when given null")
+    void returnsPassVerificationScoreOfTwoByDefaultWhenGivenNull() {
         assertEquals(2, EvidenceUtils.getVerificationScoreForPass(null));
     }
 
     @Test
-    void shouldGiveScoreOfTwoWhenZero() {
+    @DisplayName("Should return pass verification score of 2 by default when given zero")
+    void returnsPassVerificationScoreOfTwoByDefaultWhenGivenZero() {
         EvidenceRequest evidenceRequest = new EvidenceRequest();
         evidenceRequest.setVerificationScore(0);
         assertEquals(2, EvidenceUtils.getVerificationScoreForPass(evidenceRequest));
     }
 
-    @Test
-    void shouldGiveScoreWhenGivenScoreGreaterThan0() {
+    @ParameterizedTest
+    @CsvSource({"3", "100", "-2", "-4"})
+    @DisplayName("Should throw IllegalStateException when given any value greater than 2")
+    void throwsIllegalStateExceptionWhenGivenAnyValueGreaterThanTwo(int score) {
         EvidenceRequest evidenceRequest = new EvidenceRequest();
-        evidenceRequest.setVerificationScore(100);
-        assertEquals(100, EvidenceUtils.getVerificationScoreForPass(evidenceRequest));
+        evidenceRequest.setVerificationScore(score);
+
+        IllegalStateException exception =
+                assertThrows(
+                        IllegalStateException.class,
+                        () -> EvidenceUtils.getVerificationScoreForPass(evidenceRequest));
+
+        assertEquals(
+                String.format("Verification Score %d is not supported", score),
+                exception.getMessage());
+    }
+
+    @ParameterizedTest
+    @CsvSource({"1", "2"})
+    @DisplayName("Should return verification score when given a value of 1 or 2")
+    void returnsVerificationScoreWhenGivenAValueOfOneOrTwo(int score) {
+        EvidenceRequest evidenceRequest = new EvidenceRequest();
+        evidenceRequest.setVerificationScore(score);
+
+        assertEquals(score, EvidenceUtils.getVerificationScoreForPass(evidenceRequest));
     }
 }


### PR DESCRIPTION
## Proposed changes

Aim to reuse, existing logic as much as possible by having the ability to specify in Unit test each strategy

Please pay attention to [EvidenceFactoryTest](https://github.com/govuk-one-login/ipv-cri-kbv-api/pull/352/files)

The test here are categorized into 3 areas:

- Test about Evidence **Verification Score**
- Test about the **Authentication Status**
- Test about **EvidenceCheckDetails**


What to be able to swap out the strategy mode of operation of the EvidenceFactory, A new StrategyParser class has been added to enable this. It takes as input the strategy i.e

**Low confidence: "2 out of 3 Prioritised"
Medium confidence: "3 out of 4 Prioritised"**

By default the Strategy is set in the constructor of the EvidenceFactory to "3 out of 4 Prioritised" this is what we currently support.

EvidenceFactory has a setter method, which is used to set the Strategy to "2 out of 3 Prioritised" and therefore enable testing Low Confidence Scenario for the EvidenceFactory

**NB: Next part will looking into renaming methods to make more readable**
