### PR TITLE
OJ-2643: Improving naming in EvidenceFactory

### DIFF
--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/builder/CheckDetailsBuilder.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/builder/CheckDetailsBuilder.java
@@ -1,0 +1,150 @@
+package uk.gov.di.ipv.cri.kbv.api.builder;
+
+import uk.gov.di.ipv.cri.kbv.api.builder.steps.BuildTo;
+import uk.gov.di.ipv.cri.kbv.api.builder.steps.CreateCheckDetailsWithKbvQuality;
+import uk.gov.di.ipv.cri.kbv.api.builder.steps.Init;
+import uk.gov.di.ipv.cri.kbv.api.builder.steps.QuestionIdsInAllBatches;
+import uk.gov.di.ipv.cri.kbv.api.builder.steps.Skip1stQuestionIdIn2ndBatch;
+import uk.gov.di.ipv.cri.kbv.api.builder.steps.SortByKbvQuality;
+import uk.gov.di.ipv.cri.kbv.api.builder.steps.UnSkippedQuestionIdsInAllBatches;
+import uk.gov.di.ipv.cri.kbv.api.domain.CheckDetail;
+import uk.gov.di.ipv.cri.kbv.api.domain.KbvQuality;
+import uk.gov.di.ipv.cri.kbv.api.domain.KbvQuestion;
+import uk.gov.di.ipv.cri.kbv.api.domain.QuestionAnswerPair;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class CheckDetailsBuilder {
+    private static final int UNSUITABLE_QUESTION_QUALITY = 0;
+    private final int numberOfCorrectAnswers;
+    private final Map<String, Integer> kbvQualityMapping;
+    private List<List<QuestionAnswerPair>> qaBatches;
+    private Stream<List<QuestionAnswerPair>> skipFirstQuestionOf2ndBatch;
+    private Stream<CheckDetail> checkDetailStream;
+    private Stream<String> qaIds;
+
+    public CheckDetailsBuilder(
+            List<List<QuestionAnswerPair>> questionPairs,
+            int numberOfCorrectAnswers,
+            Map<String, Integer> kbvQualityMapping) {
+        this.numberOfCorrectAnswers = numberOfCorrectAnswers;
+        this.kbvQualityMapping = kbvQualityMapping;
+        this.qaBatches = questionPairs;
+    }
+
+    public Skip1stQuestionIdIn2ndBatch skip1stQuestionIdIn2ndBatch() {
+        return new BuilderSteps(this).skip1stQuestionIdIn2ndBatch();
+    }
+
+    public QuestionIdsInAllBatches getQuestionIdsInBatches() {
+        return new BuilderSteps(this).getQuestionIdsInAllBatches();
+    }
+
+    private class BuilderSteps
+            implements Init,
+                    Skip1stQuestionIdIn2ndBatch,
+                    QuestionIdsInAllBatches,
+                    UnSkippedQuestionIdsInAllBatches,
+                    CreateCheckDetailsWithKbvQuality,
+                    SortByKbvQuality,
+                    BuildTo {
+
+        private final CheckDetailsBuilder builder;
+
+        BuilderSteps(CheckDetailsBuilder builder) {
+            this.builder = builder;
+        }
+
+        @Override
+        public Skip1stQuestionIdIn2ndBatch skip1stQuestionIdIn2ndBatch() {
+            skipFirstQuestionOf2ndBatch =
+                    qaBatches.stream().filter(Predicate.not(q -> qaBatches.indexOf(q) == 1));
+
+            return this;
+        }
+
+        @Override
+        public QuestionIdsInAllBatches getQuestionIdsInAllBatches() {
+            qaIds =
+                    qaBatches.stream()
+                            .flatMap(List::stream)
+                            .map(QuestionAnswerPair::getQuestion)
+                            .map(KbvQuestion::getQuestionId);
+
+            return this;
+        }
+
+        @Override
+        public UnSkippedQuestionIdsInAllBatches getUnSkippedQuestionIdsInBatches() {
+            qaIds =
+                    skipFirstQuestionOf2ndBatch
+                            .flatMap(List::stream)
+                            .map(QuestionAnswerPair::getQuestion)
+                            .map(KbvQuestion::getQuestionId);
+
+            return this;
+        }
+
+        @Override
+        public CreateCheckDetailsWithKbvQuality createCheckDetailsWithKbvQuality() {
+            checkDetailStream = qaIds.map(builder::createCheckDetailWithQuality);
+
+            return this;
+        }
+
+        @Override
+        public SortByKbvQuality sortByKbvQualityFromLowestToHighest() {
+            checkDetailStream =
+                    checkDetailStream.sorted(Comparator.comparingInt(CheckDetail::getKbvQuality));
+
+            return this;
+        }
+
+        @Override
+        public BuildTo filterByNumberOfCorrectQuestions() {
+            checkDetailStream = checkDetailStream.limit(numberOfCorrectAnswers);
+
+            return this;
+        }
+
+        @Override
+        public CheckDetail[] buildToArray() {
+            return checkDetailStream.collect(Collectors.toList()).toArray(CheckDetail[]::new);
+        }
+
+        @Override
+        public List<String> buildToList() {
+            return qaIds.collect(Collectors.toList());
+        }
+    }
+
+    private int mapToKbvQuality(String questionId) {
+        return kbvQualityMapping.entrySet().stream()
+                .filter(item -> questionId.equals(item.getKey()))
+                .map(Map.Entry::getValue)
+                .map(this::getKbvQuality)
+                .findFirst()
+                .orElseThrow(
+                        () ->
+                                new IllegalStateException(
+                                        String.format(
+                                                "QuestionId: %s may not be present in Mapping",
+                                                questionId)));
+    }
+
+    private int getKbvQuality(int quality) {
+        return quality == UNSUITABLE_QUESTION_QUALITY ? KbvQuality.LOW.getValue() : quality;
+    }
+
+    private CheckDetail createCheckDetailWithQuality(String questionId) {
+        CheckDetail checkDetail = new CheckDetail();
+        checkDetail.setKbvQuality(this.mapToKbvQuality(questionId));
+
+        return checkDetail;
+    }
+}

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/builder/steps/BuildTo.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/builder/steps/BuildTo.java
@@ -1,0 +1,7 @@
+package uk.gov.di.ipv.cri.kbv.api.builder.steps;
+
+import uk.gov.di.ipv.cri.kbv.api.domain.CheckDetail;
+
+public interface BuildTo {
+    CheckDetail[] buildToArray();
+}

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/builder/steps/CreateCheckDetailsWithKbvQuality.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/builder/steps/CreateCheckDetailsWithKbvQuality.java
@@ -1,0 +1,11 @@
+package uk.gov.di.ipv.cri.kbv.api.builder.steps;
+
+import uk.gov.di.ipv.cri.kbv.api.domain.CheckDetail;
+
+public interface CreateCheckDetailsWithKbvQuality extends BuildTo {
+    SortByKbvQuality sortByKbvQualityFromLowestToHighest();
+
+    BuildTo filterByNumberOfCorrectQuestions();
+
+    CheckDetail[] buildToArray();
+}

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/builder/steps/Init.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/builder/steps/Init.java
@@ -1,0 +1,7 @@
+package uk.gov.di.ipv.cri.kbv.api.builder.steps;
+
+public interface Init {
+    Skip1stQuestionIdIn2ndBatch skip1stQuestionIdIn2ndBatch();
+
+    QuestionIdsInAllBatches getQuestionIdsInAllBatches();
+}

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/builder/steps/QuestionIdsInAllBatches.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/builder/steps/QuestionIdsInAllBatches.java
@@ -1,0 +1,9 @@
+package uk.gov.di.ipv.cri.kbv.api.builder.steps;
+
+import java.util.List;
+
+public interface QuestionIdsInAllBatches {
+    CreateCheckDetailsWithKbvQuality createCheckDetailsWithKbvQuality();
+
+    List<String> buildToList();
+}

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/builder/steps/Skip1stQuestionIdIn2ndBatch.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/builder/steps/Skip1stQuestionIdIn2ndBatch.java
@@ -1,0 +1,5 @@
+package uk.gov.di.ipv.cri.kbv.api.builder.steps;
+
+public interface Skip1stQuestionIdIn2ndBatch {
+    UnSkippedQuestionIdsInAllBatches getUnSkippedQuestionIdsInBatches();
+}

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/builder/steps/SortByKbvQuality.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/builder/steps/SortByKbvQuality.java
@@ -1,0 +1,5 @@
+package uk.gov.di.ipv.cri.kbv.api.builder.steps;
+
+public interface SortByKbvQuality {
+    BuildTo filterByNumberOfCorrectQuestions();
+}

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/builder/steps/UnSkippedQuestionIdsInAllBatches.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/builder/steps/UnSkippedQuestionIdsInAllBatches.java
@@ -1,0 +1,9 @@
+package uk.gov.di.ipv.cri.kbv.api.builder.steps;
+
+import java.util.List;
+
+public interface UnSkippedQuestionIdsInAllBatches {
+    CreateCheckDetailsWithKbvQuality createCheckDetailsWithKbvQuality();
+
+    List<String> buildToList();
+}

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactory.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactory.java
@@ -6,26 +6,23 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.ipv.cri.common.library.persistence.item.EvidenceRequest;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
+import uk.gov.di.ipv.cri.kbv.api.builder.CheckDetailsBuilder;
+import uk.gov.di.ipv.cri.kbv.api.builder.steps.BuildTo;
 import uk.gov.di.ipv.cri.kbv.api.domain.CheckDetail;
 import uk.gov.di.ipv.cri.kbv.api.domain.ContraIndicator;
 import uk.gov.di.ipv.cri.kbv.api.domain.Evidence;
 import uk.gov.di.ipv.cri.kbv.api.domain.KBVItem;
-import uk.gov.di.ipv.cri.kbv.api.domain.KbvQuality;
-import uk.gov.di.ipv.cri.kbv.api.domain.KbvQuestion;
+import uk.gov.di.ipv.cri.kbv.api.domain.KbvQuestionAnswerSummary;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionAnswerPair;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionState;
 import uk.gov.di.ipv.cri.kbv.api.strategy.KbvStrategyParser;
 import uk.gov.di.ipv.cri.kbv.api.strategy.Strategy;
 
-import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
-import static java.util.Comparator.comparingInt;
 import static uk.gov.di.ipv.cri.kbv.api.domain.VerifiableCredentialConstants.VC_FAIL_EVIDENCE_SCORE;
 import static uk.gov.di.ipv.cri.kbv.api.domain.VerifiableCredentialConstants.VC_THIRD_PARTY_KBV_CHECK_NOT_AUTHENTICATED;
 import static uk.gov.di.ipv.cri.kbv.api.domain.VerifiableCredentialConstants.VC_THIRD_PARTY_KBV_CHECK_PASS;
@@ -34,7 +31,6 @@ import static uk.gov.di.ipv.cri.kbv.api.domain.VerifiableCredentialConstants.VC_
 public class EvidenceFactory {
     private static final Logger LOGGER = LogManager.getLogger();
     private static final String METRIC_DIMENSION_KBV_VERIFICATION = "kbv_verification";
-    private static final int UNSUITABLE_QUESTION_QUALITY = 0;
     private final EventProbe eventProbe;
     private final ObjectMapper objectMapper;
     private String kbvQuestionStrategy;
@@ -64,11 +60,16 @@ public class EvidenceFactory {
 
     public Object[] create(KBVItem kbvItem, EvidenceRequest evidenceRequest)
             throws JsonProcessingException {
+        String kbvStatus = kbvItem.getStatus();
         Evidence evidence = new Evidence();
         evidence.setTxn(kbvItem.getAuthRefNo());
-        if (hasQuestionsAsked(kbvItem)) {
-            evidence.setCheckDetails(createCheckDetailsWithKbvQuality(kbvItem));
-            evidence.setFailedCheckDetails(createFailedCheckDetails(kbvItem));
+        KbvQuestionAnswerSummary summary = kbvItem.getQuestionAnswerResultSummary();
+        QuestionState questionState =
+                objectMapper.readValue(kbvItem.getQuestionState(), QuestionState.class);
+
+        if (hasQuestionsAsked(summary)) {
+            evidence.setCheckDetails(withKbvQuality(questionState, summary));
+            evidence.setFailedCheckDetails(withoutKbvQuality(summary));
         }
         if (VC_THIRD_PARTY_KBV_CHECK_PASS.equalsIgnoreCase(kbvItem.getStatus())) {
             evidence.setVerificationScore(evidenceRequest);
@@ -76,123 +77,106 @@ public class EvidenceFactory {
         } else {
             evidence.setVerificationScore(VC_FAIL_EVIDENCE_SCORE);
             logVcScore("fail");
-            if (hasTooManyIncorrectAnswers(kbvItem)) {
+            if (hasTooManyIncorrectAnswers(kbvStatus, summary)) {
                 evidence.setCi(new ContraIndicator[] {ContraIndicator.V03});
             }
         }
 
         return new Map[] {objectMapper.convertValue(evidence, Map.class)};
     }
+    /**
+     * Return CheckDetail[] with CheckDetail elements that have kbvQuality values assigned according
+     * to the following scenarios:
+     *
+     * <p>Scenario: It completed in 3 batches of requests, the (1st batch of 2 questions) were
+     * answered correctly, the answer to the question in the (second batch of 1 question) was
+     * incorrect and the answer to the question in the (3rd batch of 1 question) was correct. Since
+     * 1 question was returned in the 2nd batch, we can infer it was wrong and exclude it from the
+     * CheckDetail and correctly assign kbvQuality using the correct questions respectively.
+     *
+     * <p>Scenario: It completed 2 batches of requests, one of the questions in the (1st batch of 2
+     * questions) was incorrect; we don't know which is wrong, the final batch (of 2 questions) were
+     * answered correctly. To assign Kbv Quality we sort and eliminate the highest. creating
+     * CheckDetails with the 3 lowest kbvQuality values
+     *
+     * <p>Scenario: All questions are answered correctly, none was incorrect. For 3 out of 4
+     * strategy, this means (3 out of 3) success completion in 2 batches (1st batch with 2
+     * questions) and (2nd batch with 1 question) For 2 out of 3 strategy, this means (2 out of 2)
+     * success completion in a single batch (i.e 2 question was answered correct, no need for
+     * another) CheckDetails are assigned with their respective kbvQuality
+     *
+     * @param questionState
+     * @param summary of the outcome of answered question number asked, numbers incorrect or numbers
+     *     correct
+     * @return A array CheckDetails, with KbvQuality assigned to each
+     */
+    private CheckDetail[] withKbvQuality(
+            QuestionState questionState, KbvQuestionAnswerSummary summary) {
+        BuildTo checkDetails;
+        int batch = questionState.getBatchCount();
+        int correctAnswers = summary.getAnsweredCorrect();
+        List<List<QuestionAnswerPair>> allQaBatches = questionState.getAllQaPairs();
+        var builder = new CheckDetailsBuilder(allQaBatches, correctAnswers, kbvQualityMapping);
 
-    private CheckDetail[] createCheckDetailsWithKbvQuality(KBVItem kbvItem)
-            throws JsonProcessingException {
-        var questionState = objectMapper.readValue(kbvItem.getQuestionState(), QuestionState.class);
-
-        if (hasPassedWithOneIncorrectAnswer(kbvItem)) {
-            /**
-             * Scenario: We create the `checkDetails` with the lowest 3 kbvQuality values, so we are
-             * excluding the highest kbvQuality value.
-             *
-             * <p>1 question was wrong in the first batch, therefore 2 questions were given in
-             * second batch, and they were answered correctly. We can sort by quality and remove any
-             * additional question(s)
-             */
-            if (questionState.isQuestionReceivedBatchCountEqualTo(2)) {
-                return createCheckDetailsBySortingOnKbvQuality(kbvItem, questionState);
-            }
-            /**
-             * Scenario: 2 questions in first batch were correct, third question in the second batch
-             * was incorrect, and fourth question in the third batch was correct. We can safely
-             * exclude the third question from the `checkDetails`
-             */
-            return createCheckDetailsBySkipping3rdIncorrectQa(questionState);
+        if (batchNumberOfIncorrectAnswer(summary, batch) == 3) {
+            checkDetails =
+                    builder.skip1stQuestionIdIn2ndBatch()
+                            .getUnSkippedQuestionIdsInBatches()
+                            .createCheckDetailsWithKbvQuality();
+        } else if (batchNumberOfIncorrectAnswer(summary, batch) == 2) {
+            checkDetails =
+                    builder.getQuestionIdsInBatches()
+                            .createCheckDetailsWithKbvQuality()
+                            .sortByKbvQualityFromLowestToHighest()
+                            .filterByNumberOfCorrectQuestions();
+        } else if (twoCorrectIn1Batch(batch, summary) || threeCorrectIn2Batches(batch, summary)) {
+            checkDetails = builder.getQuestionIdsInBatches().createCheckDetailsWithKbvQuality();
+        } else {
+            checkDetails =
+                    builder.getQuestionIdsInBatches()
+                            .createCheckDetailsWithKbvQuality()
+                            .filterByNumberOfCorrectQuestions();
         }
-        /** Scenario: 3 out of 3 correct answers from 2 batches */
-        return createCheckDetails(kbvItem, questionState);
+        return checkDetails.buildToArray();
     }
 
-    private CheckDetail[] createCheckDetails(KBVItem kbvItem, QuestionState questionState) {
-        return mapKbvQualityToCheckDetail(questionState)
-                .get()
-                .limit(kbvItem.getQuestionAnswerResultSummary().getAnsweredCorrect())
-                .toArray(CheckDetail[]::new);
-    }
-
-    private CheckDetail[] createCheckDetailsBySkipping3rdIncorrectQa(QuestionState questionState) {
-        return questionState
-                .skipQaPairAtIndexOne()
-                .flatMap(Collection::stream)
-                .map(QuestionAnswerPair::getQuestion)
-                .map(KbvQuestion::getQuestionId)
-                .map(this::createCheckDetailWithQuality)
-                .toArray(CheckDetail[]::new);
-    }
-
-    private CheckDetail[] createCheckDetailsBySortingOnKbvQuality(
-            KBVItem kbvItem, QuestionState questionState) {
-        return mapKbvQualityToCheckDetail(questionState)
-                .get()
-                .sorted(comparingInt(CheckDetail::getKbvQuality))
-                // getAnsweredCorrect tells us how many questions were answered correctly
-                // But not which question was incorrect
-                // So we pessimistically remove the highest quality questions
-                .limit(kbvItem.getQuestionAnswerResultSummary().getAnsweredCorrect())
-                .collect(Collectors.toList())
-                .toArray(CheckDetail[]::new);
-    }
-
-    private CheckDetail[] createFailedCheckDetails(KBVItem kbvItem) {
-        return IntStream.range(0, kbvItem.getQuestionAnswerResultSummary().getAnsweredIncorrect())
+    private CheckDetail[] withoutKbvQuality(KbvQuestionAnswerSummary summary) {
+        return IntStream.range(0, summary.getAnsweredIncorrect())
                 .mapToObj(i -> new CheckDetail())
-                .limit(kbvItem.getQuestionAnswerResultSummary().getAnsweredIncorrect())
+                .limit(summary.getAnsweredIncorrect())
                 .toArray(CheckDetail[]::new);
     }
 
-    private CheckDetail createCheckDetailWithQuality(String questionId) {
-        CheckDetail checkDetail = new CheckDetail();
-        checkDetail.setKbvQuality(getKbvQuality(questionId));
-        return checkDetail;
+    private boolean hasQuestionsAsked(KbvQuestionAnswerSummary summary) {
+        return Objects.nonNull(summary) && summary.getQuestionsAsked() > 0;
     }
 
-    private int getKbvQuality(String questionId) {
-        return this.getKbvQualityMapping().entrySet().stream()
-                .filter(item -> questionId.equals(item.getKey()))
-                .map(Map.Entry::getValue)
-                .map(this::mapKbvQuality)
-                .findFirst()
-                .orElseThrow(
-                        () ->
-                                new IllegalStateException(
-                                        String.format(
-                                                "QuestionId: %s may not be present in Mapping",
-                                                questionId)));
+    private boolean twoCorrectIn1Batch(int batchCount, KbvQuestionAnswerSummary summary) {
+        return batchCount == 1 && hasPassed(summary, 2, 2);
     }
 
-    private int mapKbvQuality(int quality) {
-        return quality == UNSUITABLE_QUESTION_QUALITY ? KbvQuality.LOW.getValue() : quality;
+    private boolean threeCorrectIn2Batches(int batchCount, KbvQuestionAnswerSummary summary) {
+        return batchCount == 2 && hasPassed(summary, 3, 3);
     }
 
-    private Supplier<Stream<CheckDetail>> mapKbvQualityToCheckDetail(QuestionState questionState) {
-        return () ->
-                questionState.getQuestionIdsFromQAPairs().map(this::createCheckDetailWithQuality);
+    private int batchNumberOfIncorrectAnswer(KbvQuestionAnswerSummary summary, int batchCount) {
+        return hasPassedWithOneIncorrectAnswer(summary) ? batchCount : -1;
     }
 
-    private boolean hasQuestionsAsked(KBVItem kbvItem) {
-        return Objects.nonNull(kbvItem.getQuestionAnswerResultSummary())
-                && kbvItem.getQuestionAnswerResultSummary().getQuestionsAsked() > 0;
-    }
-
-    private boolean hasPassedWithOneIncorrectAnswer(KBVItem kbvItem) {
+    private boolean hasPassedWithOneIncorrectAnswer(KbvQuestionAnswerSummary summary) {
         KbvStrategyParser parser = new KbvStrategyParser(this.getKbvQuestionStrategy());
         Strategy strategy = parser.parse();
-        return Objects.nonNull(kbvItem.getQuestionAnswerResultSummary())
-                && kbvItem.getQuestionAnswerResultSummary().getQuestionsAsked() == strategy.max()
-                && kbvItem.getQuestionAnswerResultSummary().getAnsweredCorrect() == strategy.min();
+
+        return hasPassed(summary, strategy.min(), strategy.max());
     }
 
-    private boolean hasTooManyIncorrectAnswers(KBVItem kbvItem) {
-        var status = kbvItem.getStatus();
-        var summary = kbvItem.getQuestionAnswerResultSummary();
+    private boolean hasPassed(KbvQuestionAnswerSummary summary, int min, int max) {
+        return Objects.nonNull(summary)
+                && summary.getQuestionsAsked() == max
+                && summary.getAnsweredCorrect() == min;
+    }
+
+    private boolean hasTooManyIncorrectAnswers(String status, KbvQuestionAnswerSummary summary) {
         return Objects.nonNull(summary)
                 && ((VC_THIRD_PARTY_KBV_CHECK_NOT_AUTHENTICATED.equalsIgnoreCase(status)
                                 && summary.getAnsweredIncorrect() > 1)
@@ -202,6 +186,7 @@ public class EvidenceFactory {
 
     private void logVcScore(String result) {
         eventProbe.addDimensions(Map.of(METRIC_DIMENSION_KBV_VERIFICATION, result));
+
         LOGGER.info("kbv {}", result);
     }
 }

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/builder/CheckDetailsBuilderTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/builder/CheckDetailsBuilderTest.java
@@ -1,0 +1,205 @@
+package uk.gov.di.ipv.cri.kbv.api.builder;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.cri.kbv.api.domain.CheckDetail;
+import uk.gov.di.ipv.cri.kbv.api.domain.KBVItem;
+import uk.gov.di.ipv.cri.kbv.api.domain.KbvQuestion;
+import uk.gov.di.ipv.cri.kbv.api.domain.KbvQuestionAnswerSummary;
+import uk.gov.di.ipv.cri.kbv.api.domain.QuestionAnswer;
+import uk.gov.di.ipv.cri.kbv.api.domain.QuestionState;
+import uk.gov.di.ipv.cri.kbv.api.service.fixtures.TestFixtures;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@ExtendWith(MockitoExtension.class)
+class CheckDetailsBuilderTest implements TestFixtures {
+    private QuestionState questionState;
+    private KBVItem kbvItem;
+    private Map<String, Integer> kbvQualityQuestionMapping =
+            Map.of(
+                    "FirstQuestion", 9,
+                    "SecondQuestion", 3,
+                    "ThirdQuestion", 7,
+                    "FourthQuestion", 4);
+    private CheckDetailsBuilder builder;
+
+    @Test
+    @DisplayName(
+            "On CheckDetailsBuilder creation only the following methods in the test are available i.e. ")
+    void whenInitIsCalledTheStepHasTwoPossibleMethods() {
+        CheckDetailsBuilder checkDetailsBuilder =
+                new CheckDetailsBuilder(
+                        new QuestionState().getAllQaPairs(),
+                        new KbvQuestionAnswerSummary().getAnsweredCorrect(),
+                        Map.of("", 0));
+
+        assertNotNull(checkDetailsBuilder);
+        assertNotNull(checkDetailsBuilder.getQuestionIdsInBatches());
+        assertNotNull(checkDetailsBuilder.skip1stQuestionIdIn2ndBatch());
+    }
+
+    @BeforeEach
+    void setUp() throws JsonProcessingException {
+
+        kbvItem = getKbvItem();
+        kbvItem.setQuestionAnswerResultSummary(getKbvQuestionAnswerSummary(4, 3, 1));
+        setKbvItemQuestionState(
+                kbvItem, "FirstQuestion", "SecondQuestion", "ThirdQuestion", "FourthQuestion");
+
+        List<KbvQuestion> kbvQuestionsFirstSecond =
+                getKbvQuestions("FirstQuestion", "SecondQuestion");
+        List<QuestionAnswer> questionFirstSecondAnswers =
+                getQuestionAnswers("FirstQuestion", "SecondQuestion");
+
+        List<KbvQuestion> kbvQuestionsThird = getKbvQuestions("ThirdQuestion");
+        List<QuestionAnswer> questionThirdAnswers = getQuestionAnswers("ThirdQuestion");
+
+        List<KbvQuestion> kbvQuestionsFourth = getKbvQuestions("FourthQuestion");
+        List<QuestionAnswer> questionFourthAnswers = getQuestionAnswers("FourthQuestion");
+
+        questionState = new QuestionState();
+        questionState.setQAPairs(kbvQuestionsFirstSecond.toArray(KbvQuestion[]::new));
+
+        questionState =
+                loadKbvQuestionStateWithAnswers(
+                        questionState, kbvQuestionsFirstSecond, questionFirstSecondAnswers);
+
+        questionState.setQAPairs(kbvQuestionsThird.toArray(KbvQuestion[]::new));
+        questionState =
+                loadKbvQuestionStateWithAnswers(
+                        questionState, kbvQuestionsThird, questionThirdAnswers);
+
+        questionState.setQAPairs(kbvQuestionsFourth.toArray(KbvQuestion[]::new));
+        questionState =
+                loadKbvQuestionStateWithAnswers(
+                        questionState, kbvQuestionsFourth, questionFourthAnswers);
+
+        kbvItem.setQuestionState(new ObjectMapper().writeValueAsString(questionState));
+
+        builder =
+                new CheckDetailsBuilder(
+                        questionState.getAllQaPairs(),
+                        kbvItem.getQuestionAnswerResultSummary().getAnsweredCorrect(),
+                        kbvQualityQuestionMapping);
+    }
+
+    @Test
+    @DisplayName(
+            " getQuestionIdsInAllBatches returns all QuestionId(s) for all batches questions received")
+    void returnsAllQuestionIdsInAllBatches() {
+        List<String> questionIds = builder.getQuestionIdsInBatches().buildToList();
+
+        assertAll(
+                () -> assertEquals(4, questionIds.size()),
+                () -> assertEquals("FirstQuestion", questionIds.get(0)),
+                () -> assertEquals("SecondQuestion", questionIds.get(1)),
+                () -> assertEquals("ThirdQuestion", questionIds.get(2)),
+                () -> assertEquals("FourthQuestion", questionIds.get(3)));
+    }
+
+    @Test
+    @DisplayName(
+            "Get un-skipped question Ids returns all the other questions; assuming the first two questions requested are correct, then first question of the next batch of question is skipped")
+    void returnsTheRemainingQuestionIdsInAllBatchesWhenQuestionIdIn2ndBatchIsSkipped() {
+        List<String> questionIds =
+                builder.skip1stQuestionIdIn2ndBatch()
+                        .getUnSkippedQuestionIdsInBatches()
+                        .buildToList();
+
+        assertAll(
+                () -> assertEquals(3, questionIds.size()),
+                () -> assertEquals("FirstQuestion", questionIds.get(0)),
+                () -> assertEquals("SecondQuestion", questionIds.get(1)),
+                () -> assertEquals("FourthQuestion", questionIds.get(2)));
+    }
+
+    @Test
+    @DisplayName(
+            "It maps questionId(s) exactly with there corresponding kbvQuality values, when all questions received are assumed to have passed")
+    void returnKbvQualityAssociatedWithQuestionIdInAllBatchesInTheExpectedOrder() {
+        CheckDetail[] checkDetails =
+                builder.getQuestionIdsInBatches()
+                        .createCheckDetailsWithKbvQuality()
+                        .filterByNumberOfCorrectQuestions()
+                        .buildToArray();
+
+        assertAll(
+                () -> assertEquals(3, checkDetails.length),
+                () ->
+                        assertEquals(
+                                kbvQualityQuestionMapping.get("FirstQuestion"),
+                                checkDetails[0].getKbvQuality()),
+                () ->
+                        assertEquals(
+                                kbvQualityQuestionMapping.get("SecondQuestion"),
+                                checkDetails[1].getKbvQuality()),
+                () ->
+                        assertEquals(
+                                kbvQualityQuestionMapping.get("ThirdQuestion"),
+                                checkDetails[2].getKbvQuality()));
+    }
+
+    @Test
+    @DisplayName(
+            "It maps questionId(s) exactly with there corresponding kbvQuality values, when the wrong question has been excluded received are assumed to have passed")
+    void returnsKbvQualityAssociatedWithQuestionIdInAllBatchesInTheExpectedOrder() {
+        CheckDetail[] checkDetails =
+                builder.skip1stQuestionIdIn2ndBatch()
+                        .getUnSkippedQuestionIdsInBatches()
+                        .createCheckDetailsWithKbvQuality()
+                        .buildToArray();
+
+        assertAll(
+                () -> assertEquals(3, checkDetails.length),
+                () ->
+                        assertEquals(
+                                kbvQualityQuestionMapping.get("FirstQuestion"),
+                                checkDetails[0].getKbvQuality()),
+                () ->
+                        assertEquals(
+                                kbvQualityQuestionMapping.get("SecondQuestion"),
+                                checkDetails[1].getKbvQuality()),
+                () ->
+                        assertEquals(
+                                kbvQualityQuestionMapping.get("FourthQuestion"),
+                                checkDetails[2].getKbvQuality()));
+    }
+
+    @Test
+    @DisplayName(
+            "Assuming any one of the two initial question is wrong, it would map kbv quality values from the lowest to the highest")
+    void returnsKbvQualitySortedFromLowestToHighest() {
+        CheckDetail[] checkDetails =
+                builder.getQuestionIdsInBatches()
+                        .createCheckDetailsWithKbvQuality()
+                        .sortByKbvQualityFromLowestToHighest()
+                        .filterByNumberOfCorrectQuestions()
+                        .buildToArray();
+
+        assertAll(
+                () -> assertEquals(3, checkDetails.length),
+                () ->
+                        assertEquals(
+                                kbvQualityQuestionMapping.get("SecondQuestion"),
+                                checkDetails[0].getKbvQuality()),
+                () ->
+                        assertEquals(
+                                kbvQualityQuestionMapping.get("FourthQuestion"),
+                                checkDetails[1].getKbvQuality()),
+                () ->
+                        assertEquals(
+                                kbvQualityQuestionMapping.get("ThirdQuestion"),
+                                checkDetails[2].getKbvQuality()));
+    }
+}

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/VerifiableCredentialServiceTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/VerifiableCredentialServiceTest.java
@@ -31,6 +31,7 @@ import uk.gov.di.ipv.cri.common.library.util.SignedJWTFactory;
 import uk.gov.di.ipv.cri.common.library.util.VerifiableCredentialClaimsSetBuilder;
 import uk.gov.di.ipv.cri.kbv.api.domain.ContraIndicator;
 import uk.gov.di.ipv.cri.kbv.api.domain.KBVItem;
+import uk.gov.di.ipv.cri.kbv.api.domain.QuestionState;
 import uk.gov.di.ipv.cri.kbv.api.service.fixtures.TestFixtures;
 
 import java.security.NoSuchAlgorithmException;
@@ -181,6 +182,9 @@ class VerifiableCredentialServiceTest {
             KBVItem kbvItem = new KBVItem();
             kbvItem.setStatus(status);
             kbvItem.setAuthRefNo(authRefNo);
+            QuestionState questionState = new QuestionState();
+            kbvItem.setStatus("some unknown value");
+            kbvItem.setQuestionState(objectMapper.writeValueAsString(questionState));
 
             when(mockVcClaimSetBuilder.build()).thenReturn(TEST_CLAIMS_SET);
 

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/QuestionState.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/QuestionState.java
@@ -24,6 +24,11 @@ public class QuestionState {
     }
 
     @JsonIgnore
+    public int getBatchCount() {
+        return allQaPairs.size();
+    }
+
+    @JsonIgnore
     public Stream<String> getQuestionIdsFromQAPairs() {
         return allQaPairs.stream()
                 .flatMap(List::stream)


### PR DESCRIPTION
## Proposed changes:

see: https://govukverify.atlassian.net/browse/OJ-2643

1. Renamed methods in EvidenceFactory, so it is readable and more understandable
2. Moved comments to the top of the method, it can be removed entirely in future or maybe moved to readme.

Introduced a  CheckDetailsBuilder to wrap the intricate logic in a named fluent interface of methods the are easier to understand

The Builder implements a `StepBuilder` pattern

inspired from
https://java-design-patterns.com/patterns/step-builder/#detailed-explanation-of-step-builder-pattern-with-real-world-examples-1

This is to ensure that methods that make sense are callable, from each step, essentially guiding the implementer of the logic when it is used, and preventing future missuse

After `createCheckDetailsWithKbvQuality()` the next likely steps are either:

 - sortByKbvQualityFromLowestToHighest
 - filterByNumberOfCorrectQuestions
 
 But trying to call the below methods after `createCheckDetailsWithKbvQuality` wouldn't make much sense

 - skip1stQuestionIdIn2ndBatch()
 - getUnSkippedQuestionIdsInAllBatches()

 Because the CheckDetail[] array has already being built and those methods
 can only be called prior to createCheckDetailsWithKbvQuality()
