### PR TITLE
OJ:2619 Add verification score to logs and metrics

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ ext {
 		mockito					 : "4.3.1",
 		glassfish_version        : "3.0.3",
 		powertools_version       : "1.12.3",
-		cri_common_lib           : "2.2.3",
+		cri_common_lib           : "2.3.0",
 	]
 }
 

--- a/lambdas/abandon/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/AbandonKbvHandler.java
+++ b/lambdas/abandon/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/AbandonKbvHandler.java
@@ -71,7 +71,7 @@ public class AbandonKbvHandler
             kbvItem.setStatus(ABANDON_STATUS);
             kbvStorageService.update(kbvItem);
 
-            var sessionItem = sessionService.getSession(sessionId.toString());
+            var sessionItem = sessionService.validateSessionId(sessionId.toString());
             sessionService.createAuthorizationCode(sessionItem);
 
             response.withStatusCode(HttpStatusCode.OK);

--- a/lambdas/abandon/src/test/java/uk/gov/di/ipv/cri/kbv/api/handler/AbandonKbvHandlerTest.java
+++ b/lambdas/abandon/src/test/java/uk/gov/di/ipv/cri/kbv/api/handler/AbandonKbvHandlerTest.java
@@ -63,7 +63,7 @@ class AbandonKbvHandlerTest {
                         UUID.fromString(sessionHeader.get(HEADER_SESSION_ID))))
                 .thenReturn(kbvItem);
         SessionItem mockSessionItem = mock(SessionItem.class);
-        when(mockSessionService.getSession(sessionHeader.get(HEADER_SESSION_ID)))
+        when(mockSessionService.validateSessionId(sessionHeader.get(HEADER_SESSION_ID)))
                 .thenReturn(mockSessionItem);
         doNothing().when(mockSessionService).createAuthorizationCode(mockSessionItem);
 
@@ -106,7 +106,7 @@ class AbandonKbvHandlerTest {
                         UUID.fromString(sessionHeader.get(HEADER_SESSION_ID))))
                 .thenReturn(kbvItem);
         SessionItem mockSessionItem = mock(SessionItem.class);
-        when(mockSessionService.getSession(sessionHeader.get(HEADER_SESSION_ID)))
+        when(mockSessionService.validateSessionId(sessionHeader.get(HEADER_SESSION_ID)))
                 .thenReturn(mockSessionItem);
         when(mockEventProbe.log(any(ERROR.getClass()), any(SqsException.class)))
                 .thenReturn(mockEventProbe);
@@ -189,7 +189,7 @@ class AbandonKbvHandlerTest {
                         .errorMessage("AWS Server error occurred.")
                         .build();
 
-        when(mockSessionService.getSession(sessionHeader.get(HEADER_SESSION_ID)))
+        when(mockSessionService.validateSessionId(sessionHeader.get(HEADER_SESSION_ID)))
                 .thenThrow(
                         AwsServiceException.builder()
                                 .statusCode(500)
@@ -204,7 +204,7 @@ class AbandonKbvHandlerTest {
         assertEquals(HttpStatusCode.INTERNAL_SERVER_ERROR, response.getStatusCode());
 
         verify(mockSessionItem, never()).setAuthorizationCode(String.valueOf(authorizationCode));
-        verify(mockSessionService).getSession(sessionHeader.get(HEADER_SESSION_ID));
+        verify(mockSessionService).validateSessionId(sessionHeader.get(HEADER_SESSION_ID));
         verify(mockSessionService, never()).createAuthorizationCode(mockSessionItem);
         verify(mockEventProbe).log(any(ERROR.getClass()), any(AwsServiceException.class));
         verify(mockEventProbe).counterMetric(ABANDON_KBV, 0d);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

<!-- Describe the changes in detail - the "what"-->
Bumped cri_common_lib (2.2.3 -> 2.3.0) to include requested_verification_score in log keys
Added requested_verification_score to the question_strategy metric. 
Modified AbandonLambda to validate session, which includes the logic for setting requested_verification_score log keys .
Refactored shouldReturn200OkWhen1stCalledAndReturn1stUnAnsweredQuestionFromExperianEndpoint test to remove code smell

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
As a developer,
I want to update the performance metrics to distinguish between Medium and Low confidence KBV challenges and log these metrics with the associated journey ID,
so that the system can accurately track and report on the performance of different confidence level challenges.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-2619](https://govukverify.atlassian.net/browse/OJ-2619)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[OJ-2619]: https://govukverify.atlassian.net/browse/OJ-2619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ