### PR TITLE
OJ-2607: miscellenous

### DIFF
--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactory.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactory.java
@@ -33,10 +33,6 @@ public class EvidenceFactory {
     private final ObjectMapper objectMapper;
     private final Map<String, Integer> kbvQualityMapping;
 
-    public Map<String, Integer> getKbvQualityMapping() {
-        return kbvQualityMapping;
-    }
-
     public EvidenceFactory(
             ObjectMapper objectMapper,
             EventProbe eventProbe,
@@ -131,7 +127,6 @@ public class EvidenceFactory {
     private CheckDetail[] withoutKbvQuality(KbvQuestionAnswerSummary summary) {
         return IntStream.range(0, summary.getAnsweredIncorrect())
                 .mapToObj(i -> new CheckDetail())
-                .limit(summary.getAnsweredIncorrect())
                 .toArray(CheckDetail[]::new);
     }
 


### PR DESCRIPTION
## Proposed changes

Remove unused code segments i.e `getKbvQualityMapping` and unnecessary filter on `withoutKbvQuality`
Added 2 out of 3 prioritised test data to existing `shouldReturnASignedVerifiableCredentialJwt` which only had
3 out of 4 prioritised test data.

Stopped using deprecated constructor  `PersonIdentityDetailed(List.of(name), List.of(birthDate), List.of(address));`

- [OJ-2607](https://govukverify.atlassian.net/browse/OJ-2607)


[OJ-2607]: https://govukverify.atlassian.net/browse/OJ-2607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ