### PR TITLE
OJ-2685: Update integration test to validate VC details

### DIFF
--- a/integration-tests/src/test/java/gov/uk/kbv/api/stepdefinitions/KbvSteps.java
+++ b/integration-tests/src/test/java/gov/uk/kbv/api/stepdefinitions/KbvSteps.java
@@ -110,6 +110,24 @@ public class KbvSteps {
         assertEquals(score, payload.at("/vc/evidence/0/verificationScore").asInt());
     }
 
+    @And("the check details array has {int} objects returned in the response")
+    public void checkDetailsIsReturnedInTheResponse(int object)
+            throws ParseException, IOException {
+        final SignedJWT decodedJWT = SignedJWT.parse(this.testContext.getResponse().body());
+        final var payload = objectMapper.readTree(decodedJWT.getPayload().toString());
+
+        assertEquals(object, payload.at("/vc/evidence/0/checkDetails").size());
+    }
+
+    @And("the failed details array has {int} objects returned in the response")
+    public void failedDetailsIsReturnedInTheResponse(int object)
+            throws ParseException, IOException {
+        final SignedJWT decodedJWT = SignedJWT.parse(this.testContext.getResponse().body());
+        final var payload = objectMapper.readTree(decodedJWT.getPayload().toString());
+
+        assertEquals(object, payload.at("/vc/evidence/0/failedCheckDetails").size());
+    }
+
     @Then("TXMA event is added to the SQS queue containing device information header")
     public void txmaEventIsAddedToSqsQueueContainingDeviceInformationHeader()
             throws IOException, InterruptedException {

--- a/integration-tests/src/test/java/gov/uk/kbv/api/stepdefinitions/KbvSteps.java
+++ b/integration-tests/src/test/java/gov/uk/kbv/api/stepdefinitions/KbvSteps.java
@@ -111,8 +111,7 @@ public class KbvSteps {
     }
 
     @And("the check details array has {int} objects returned in the response")
-    public void checkDetailsIsReturnedInTheResponse(int object)
-            throws ParseException, IOException {
+    public void checkDetailsIsReturnedInTheResponse(int object) throws ParseException, IOException {
         final SignedJWT decodedJWT = SignedJWT.parse(this.testContext.getResponse().body());
         final var payload = objectMapper.readTree(decodedJWT.getPayload().toString());
 

--- a/integration-tests/src/test/resources/features/KbvApiHappyPath.feature
+++ b/integration-tests/src/test/resources/features/KbvApiHappyPath.feature
@@ -49,6 +49,7 @@ Feature: User goes through 3-out-of-4 question strategy. User answers 3 question
     Then user gets status code 200
     And a valid JWT is returned in the response
     And a verification score of 2 is returned in the response
+    And the check details array has 3 objects returned in the response
     And 10 events are deleted from the audit events SQS queue
 
   @pre_merge_happy_medium_confidence
@@ -98,6 +99,7 @@ Feature: User goes through 3-out-of-4 question strategy. User answers 3 question
     Then user gets status code 200
     And a valid JWT is returned in the response
     And a verification score of 2 is returned in the response
+    And the check details array has 3 objects returned in the response
     And 10 events are deleted from the audit events SQS queue
 
   @pre_merge_happy_low_confidence
@@ -141,6 +143,7 @@ Feature: User goes through 3-out-of-4 question strategy. User answers 3 question
     Then user gets status code 200
     And a valid JWT is returned in the response
     And a verification score of 1 is returned in the response
+    And the check details array has 2 objects returned in the response
     And 8 events are deleted from the audit events SQS queue
 
   @pre_merge_happy_low_confidence
@@ -190,4 +193,6 @@ Feature: User goes through 3-out-of-4 question strategy. User answers 3 question
     Then user gets status code 200
     And a valid JWT is returned in the response
     And a verification score of 1 is returned in the response
+    And the check details array has 2 objects returned in the response
+    And the failed details array has 1 objects returned in the response
     And 10 events are deleted from the audit events SQS queue

--- a/integration-tests/src/test/resources/features/KbvApiUnhappyPath.feature
+++ b/integration-tests/src/test/resources/features/KbvApiUnhappyPath.feature
@@ -39,6 +39,7 @@ Feature: User goes through 3-out-of-4 question strategy. User answers 2 question
     When user sends a POST request to credential issue endpoint with a valid access token
     Then user gets status code 200
     And a verification score of 0 is returned in the response
+    And the failed details array has 2 objects returned in the response
     And 8 events are deleted from the audit events SQS queue
 
   @pre_merge_unhappy_low_confidence
@@ -78,4 +79,5 @@ Feature: User goes through 3-out-of-4 question strategy. User answers 2 question
     When user sends a POST request to credential issue endpoint with a valid access token
     Then user gets status code 200
     And a verification score of 0 is returned in the response
+    And the failed details array has 2 objects returned in the response
     And 8 events are deleted from the audit events SQS queue


### PR DESCRIPTION

### What changed

Update existing integration tests for the VC to assert on `checkDetails` and `failedDetails` based on the test scenario so that we aren't solely reliant on the verification score.

### Why did it change

To further coverage in integration tests.

### Issue tracking

- [OJ-2685](https://govukverify.atlassian.net/browse/OJ-2685)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[OJ-2685]: https://govukverify.atlassian.net/browse/OJ-2685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ