### PR TITLE
OJ-2621: Updated tests to include extensions work for low confidence

### DIFF
--- a/integration-tests/src/test/java/gov/uk/kbv/api/stepdefinitions/KbvSteps.java
+++ b/integration-tests/src/test/java/gov/uk/kbv/api/stepdefinitions/KbvSteps.java
@@ -136,7 +136,7 @@ public class KbvSteps {
     @Then("TXMA event is added to the SQS queue containing evidence requested")
     public void txmaEventIsAddedToSqsQueueContainingEvidenceRequested()
             throws IOException, InterruptedException {
-        assertEquals("1" , getEvidenceRequested());
+        assertEquals("1", getEvidenceRequested());
     }
 
     @Then("TXMA event is added to the SQS queue not containing device information header")
@@ -169,6 +169,7 @@ public class KbvSteps {
                 .at("/restricted/device_information/encoded")
                 .asText();
     }
+
     private String getEvidenceRequested() throws InterruptedException, IOException {
         final List<Message> startEventMessages =
                 this.sqs.receiveMatchingMessages(
@@ -185,7 +186,6 @@ public class KbvSteps {
                 .at("/extensions/evidence_requested/verificationScore")
                 .asText();
     }
-
 
     private void makeVerifiableCredentialJwtAssertions(SignedJWT decodedJWT) throws IOException {
         final var header = objectMapper.readTree(decodedJWT.getHeader().toString());

--- a/integration-tests/src/test/resources/features/KbvApiHappyPath.feature
+++ b/integration-tests/src/test/resources/features/KbvApiHappyPath.feature
@@ -111,7 +111,7 @@ Feature: User goes through 3-out-of-4 question strategy. User answers 3 question
     Then user gets a session-id
 
     # TXMA event
-    Then TXMA event is added to the SQS queue not containing device information header
+    Then TXMA event is added to the SQS queue containing evidence requested
 
     # First question
     When user sends a GET request to question endpoint
@@ -155,7 +155,7 @@ Feature: User goes through 3-out-of-4 question strategy. User answers 3 question
     Then user gets a session-id
 
     # TXMA event
-    Then TXMA event is added to the SQS queue not containing device information header
+    Then TXMA event is added to the SQS queue containing evidence requested
 
     # First question
     When user sends a GET request to question endpoint


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Updated the low confidence tests to assert the new  `"extensions": { "evidence": [ { "context": "identity_check", } ] "evidence_requested": { "verficationScore": "1", ... } }` work that has been added is visible in the start message.

### Why did it change

To ensure the correct data is being sent for the start message.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-2621](https://govukverify.atlassian.net/browse/OJ-2621)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[OJ-2621]: https://govukverify.atlassian.net/browse/OJ-2621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ