### PR TITLE
OJ-2713: Upgrade cri-lib to version 3.0.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ ext {
 		mockito					 : "4.3.1",
 		glassfish_version        : "3.0.3",
 		powertools_version       : "1.12.3",
-		cri_common_lib           : "2.3.0",
+		cri_common_lib           : "3.0.2",
 	]
 }
 

--- a/lambdas/abandon/build.gradle
+++ b/lambdas/abandon/build.gradle
@@ -9,7 +9,8 @@ dependencies {
 			configurations.cri_common_lib,
 			configurations.aws,
 			configurations.lambda,
-			configurations.sqs
+			configurations.sqs,
+			configurations.dynamodb
 
 	aspect configurations.powertools
 	testImplementation configurations.tests

--- a/lambdas/abandon/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/AbandonKbvHandler.java
+++ b/lambdas/abandon/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/AbandonKbvHandler.java
@@ -14,10 +14,10 @@ import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverage
 import uk.gov.di.ipv.cri.common.library.domain.AuditEventContext;
 import uk.gov.di.ipv.cri.common.library.exception.SqsException;
 import uk.gov.di.ipv.cri.common.library.service.AuditService;
-import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
 import uk.gov.di.ipv.cri.common.library.service.SessionService;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.kbv.api.service.KBVStorageService;
+import uk.gov.di.ipv.cri.kbv.api.service.ServiceFactory;
 
 import java.util.Map;
 import java.util.UUID;
@@ -49,11 +49,11 @@ public class AbandonKbvHandler
 
     @ExcludeFromGeneratedCoverageReport
     public AbandonKbvHandler() {
-        this(
-                new EventProbe(),
-                new KBVStorageService(new ConfigurationService()),
-                new SessionService(),
-                new AuditService());
+        ServiceFactory serviceFactory = new ServiceFactory();
+        this.eventProbe = new EventProbe();
+        this.kbvStorageService = new KBVStorageService(serviceFactory.getConfigurationService());
+        this.sessionService = serviceFactory.getSessionService();
+        this.auditService = serviceFactory.getAuditService();
     }
 
     @Override

--- a/lambdas/answer/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandler.java
+++ b/lambdas/answer/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandler.java
@@ -33,6 +33,7 @@ import uk.gov.di.ipv.cri.kbv.api.domain.QuestionState;
 import uk.gov.di.ipv.cri.kbv.api.gateway.KBVGatewayFactory;
 import uk.gov.di.ipv.cri.kbv.api.service.KBVService;
 import uk.gov.di.ipv.cri.kbv.api.service.KBVStorageService;
+import uk.gov.di.ipv.cri.kbv.api.service.ServiceFactory;
 
 import java.io.IOException;
 import java.util.Map;
@@ -61,12 +62,14 @@ public class QuestionAnswerHandler
 
     @ExcludeFromGeneratedCoverageReport
     public QuestionAnswerHandler() {
+        ServiceFactory serviceFactory = new ServiceFactory();
+
         this.objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
-        this.configurationService = new ConfigurationService();
+        this.configurationService = serviceFactory.getConfigurationService();
         this.kbvStorageService = new KBVStorageService(configurationService);
         this.kbvService = new KBVService(new KBVGatewayFactory().create(configurationService));
-        this.sessionService = new SessionService(configurationService);
-        this.auditService = new AuditService(configurationService);
+        this.sessionService = serviceFactory.getSessionService();
+        this.auditService = serviceFactory.getAuditService();
 
         this.eventProbe = new EventProbe();
     }

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/IssueCredentialHandler.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/IssueCredentialHandler.java
@@ -35,6 +35,7 @@ import uk.gov.di.ipv.cri.common.library.util.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.kbv.api.exception.CredentialRequestException;
 import uk.gov.di.ipv.cri.kbv.api.service.KBVStorageService;
+import uk.gov.di.ipv.cri.kbv.api.service.ServiceFactory;
 import uk.gov.di.ipv.cri.kbv.api.service.VerifiableCredentialService;
 
 import java.time.Clock;
@@ -75,10 +76,12 @@ public class IssueCredentialHandler
 
     @ExcludeFromGeneratedCoverageReport
     public IssueCredentialHandler() throws JsonProcessingException {
+        ServiceFactory serviceFactory = new ServiceFactory();
+
         this.verifiableCredentialService = new VerifiableCredentialService();
-        ConfigurationService configurationService = new ConfigurationService();
+        ConfigurationService configurationService = serviceFactory.getConfigurationService();
         this.kbvStorageService = new KBVStorageService(configurationService);
-        this.sessionService = new SessionService();
+        this.sessionService = serviceFactory.getSessionService();
         this.eventProbe = new EventProbe();
         this.auditService =
                 new AuditService(
@@ -90,7 +93,9 @@ public class IssueCredentialHandler
                         configurationService,
                         new ObjectMapper(),
                         new AuditEventFactory(configurationService, Clock.systemUTC()));
-        this.personIdentityService = new PersonIdentityService();
+        this.personIdentityService =
+                new PersonIdentityService(
+                        configurationService, serviceFactory.getDynamoDbEnhancedClient());
     }
 
     @Override

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/VerifiableCredentialService.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/VerifiableCredentialService.java
@@ -45,7 +45,9 @@ public class VerifiableCredentialService {
 
     @ExcludeFromGeneratedCoverageReport
     public VerifiableCredentialService() throws JsonProcessingException {
-        this.configurationService = new ConfigurationService();
+        ServiceFactory serviceFactory = new ServiceFactory();
+
+        this.configurationService = serviceFactory.getConfigurationService();
         this.signedJwtFactory =
                 new SignedJWTFactory(
                         new KMSSigner(

--- a/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionHandler.java
+++ b/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionHandler.java
@@ -40,6 +40,7 @@ import uk.gov.di.ipv.cri.kbv.api.exception.QuestionNotFoundException;
 import uk.gov.di.ipv.cri.kbv.api.gateway.KBVGatewayFactory;
 import uk.gov.di.ipv.cri.kbv.api.service.KBVService;
 import uk.gov.di.ipv.cri.kbv.api.service.KBVStorageService;
+import uk.gov.di.ipv.cri.kbv.api.service.ServiceFactory;
 import uk.gov.di.ipv.cri.kbv.api.util.EvidenceUtils;
 
 import java.io.IOException;
@@ -80,13 +81,18 @@ public class QuestionHandler
 
     @ExcludeFromGeneratedCoverageReport
     public QuestionHandler() {
+        ServiceFactory serviceFactory = new ServiceFactory();
+
         this.objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
-        this.personIdentityService = new PersonIdentityService();
-        this.configurationService = new ConfigurationService();
+        this.personIdentityService =
+                new PersonIdentityService(
+                        serviceFactory.getConfigurationService(),
+                        serviceFactory.getDynamoDbEnhancedClient());
+        this.configurationService = serviceFactory.getConfigurationService();
         this.kbvService = new KBVService(new KBVGatewayFactory().create(this.configurationService));
         this.kbvStorageService = new KBVStorageService(this.configurationService);
-        this.auditService = new AuditService(this.configurationService);
-        this.sessionService = new SessionService(this.configurationService);
+        this.auditService = serviceFactory.getAuditService();
+        this.sessionService = serviceFactory.getSessionService();
         this.eventProbe = new EventProbe();
     }
 

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -20,7 +20,8 @@ dependencies {
 			configurations.jackson,
 			configurations.hibernate,
 			configurations.nimbus,
-			configurations.soap
+			configurations.soap,
+			configurations.sqs
 
 	aspect configurations.powertools
 

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/ServiceFactory.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/ServiceFactory.java
@@ -1,0 +1,65 @@
+package uk.gov.di.ipv.cri.kbv.api.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.lambda.powertools.parameters.SSMProvider;
+import software.amazon.lambda.powertools.parameters.SecretsProvider;
+import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.cri.common.library.service.AuditEventFactory;
+import uk.gov.di.ipv.cri.common.library.service.AuditService;
+import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
+import uk.gov.di.ipv.cri.common.library.service.SessionService;
+import uk.gov.di.ipv.cri.common.library.util.ClientProviderFactory;
+
+import java.time.Clock;
+
+public class ServiceFactory {
+    private final ClientProviderFactory clientProviderFactory;
+    private ConfigurationService configurationService;
+
+    @ExcludeFromGeneratedCoverageReport
+    public ServiceFactory(ClientProviderFactory clientProviderFactory) {
+        this.clientProviderFactory = clientProviderFactory;
+    }
+
+    @ExcludeFromGeneratedCoverageReport
+    public ServiceFactory() {
+        this(new ClientProviderFactory());
+    }
+
+    public SSMProvider getSsmProvider() {
+        return clientProviderFactory.getSSMProvider();
+    }
+
+    public DynamoDbEnhancedClient getDynamoDbEnhancedClient() {
+        return clientProviderFactory.getDynamoDbEnhancedClient();
+    }
+
+    public SecretsProvider getSecretsProvider() {
+        return clientProviderFactory.getSecretsProvider();
+    }
+
+    public SqsClient getSqsClient() {
+        return clientProviderFactory.getSqsClient();
+    }
+
+    public ConfigurationService getConfigurationService() {
+        if (configurationService == null) {
+            configurationService = new ConfigurationService(getSsmProvider(), getSecretsProvider());
+        }
+        return configurationService;
+    }
+
+    public SessionService getSessionService() {
+        return new SessionService(getConfigurationService(), getDynamoDbEnhancedClient());
+    }
+
+    public AuditService getAuditService() {
+        return new AuditService(
+                getSqsClient(),
+                getConfigurationService(),
+                new ObjectMapper(),
+                new AuditEventFactory(getConfigurationService(), Clock.systemDefaultZone()));
+    }
+}

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/ServiceFactoryTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/ServiceFactoryTest.java
@@ -1,0 +1,91 @@
+package uk.gov.di.ipv.cri.kbv.api.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.lambda.powertools.parameters.SSMProvider;
+import software.amazon.lambda.powertools.parameters.SecretsProvider;
+import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
+import uk.gov.di.ipv.cri.common.library.util.ClientProviderFactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ServiceFactoryTest {
+
+    @Mock private ClientProviderFactory clientProviderFactory;
+
+    @Mock private SSMProvider ssmProvider;
+
+    @Mock private DynamoDbEnhancedClient dynamoDbEnhancedClient;
+
+    @Mock private SecretsProvider secretsProvider;
+
+    @Mock private SqsClient sqsClient;
+
+    @InjectMocks private ServiceFactory serviceFactory;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        when(clientProviderFactory.getSSMProvider()).thenReturn(ssmProvider);
+        when(clientProviderFactory.getDynamoDbEnhancedClient()).thenReturn(dynamoDbEnhancedClient);
+        when(clientProviderFactory.getSecretsProvider()).thenReturn(secretsProvider);
+        when(clientProviderFactory.getSqsClient()).thenReturn(sqsClient);
+    }
+
+    @Test
+    void testGetSsmProvider() {
+        SSMProvider result = serviceFactory.getSsmProvider();
+        assertNotNull(result);
+        verify(clientProviderFactory).getSSMProvider();
+    }
+
+    @Test
+    void testGetDynamoDbEnhancedClient() {
+        DynamoDbEnhancedClient result = serviceFactory.getDynamoDbEnhancedClient();
+        assertNotNull(result);
+        verify(clientProviderFactory).getDynamoDbEnhancedClient();
+    }
+
+    @Test
+    void testGetSecretsProvider() {
+        SecretsProvider result = serviceFactory.getSecretsProvider();
+        assertNotNull(result);
+        verify(clientProviderFactory).getSecretsProvider();
+    }
+
+    @Test
+    void testGetSqsClient() {
+        SqsClient result = serviceFactory.getSqsClient();
+        assertNotNull(result);
+        verify(clientProviderFactory).getSqsClient();
+    }
+
+    @Test
+    void testGetAuditServiceThrowsWhenEnvironmentNotSetupCorrectly() {
+        boolean hasThrown = false;
+        try {
+            serviceFactory.getAuditService();
+        } catch (Exception e) {
+            hasThrown = true;
+        }
+        assertTrue(hasThrown);
+    }
+
+    @Test
+    void testGetConfigurationService() {
+        ConfigurationService configurationService1 = serviceFactory.getConfigurationService();
+        assertNotNull(configurationService1);
+        ConfigurationService configurationService2 = serviceFactory.getConfigurationService();
+        assertNotNull(configurationService2);
+        assertEquals(configurationService1, configurationService2);
+    }
+}


### PR DESCRIPTION
## Proposed changes

### What changed
cri-lib to version 3.0.2

As part of the upgrade, I have created a `ServiceFactory` class which encapsulates all the AWS Clients and service objects that we have. Primary purpose is to avoid duplication and to keep the code clean.

### Why did it change
To keep us up to date with the latest common-lib changes. 

### Issue tracking
- [OJ-2713](https://govukverify.atlassian.net/browse/OJ-2713)


[OJ-2713]: https://govukverify.atlassian.net/browse/OJ-2713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ