### PR TITLE
Fix TTL state machine

### DIFF
--- a/step-functions/fix-session-ttl.asl.json
+++ b/step-functions/fix-session-ttl.asl.json
@@ -17,10 +17,10 @@
       "Type": "Task",
       "Parameters": {
         "TableName": "${SessionTable}",
-        "FilterExpression": "expiryDate = :expiryDate",
+        "FilterExpression": "expiryDate > :expiryDate",
         "ExpressionAttributeValues": {
           ":expiryDate": {
-            "N": "7200"
+            "N": "1753879270"
           }
         },
         "Limit": 100
@@ -41,10 +41,10 @@
       "Type": "Task",
       "Parameters": {
         "TableName": "${SessionTable}",
-        "FilterExpression": "expiryDate = :expiryDate",
+        "FilterExpression": "expiryDate > :expiryDate",
         "ExpressionAttributeValues": {
           ":expiryDate": {
-            "N": "7200"
+            "N": "1753879270"
           }
         },
         "ExclusiveStartKey": {

--- a/ts-lambdas/time-function/src/time-function.ts
+++ b/ts-lambdas/time-function/src/time-function.ts
@@ -2,7 +2,7 @@ import { LambdaInterface } from "@aws-lambda-powertools/commons";
 
 export class TimeFunction implements LambdaInterface {
   public async handler(_event: unknown, _context: unknown): Promise<any> {
-    return Date.now();
+    return Math.floor(Date.now() / 1000);
   }
 }
 


### PR DESCRIPTION
## Proposed changes

### What changed
The Time Function is now returning epoch time in Unix timestamps in seconds rather than milliseconds.
The state machine will now update any records that have an expiry date greater than `1721520000000` i.e. 30/07/2025 - I have chosen this date specific as it won't affect the correct session records but fix the broken ones which are in the year 50k
### Why did it change
We set the expiryDate TTL to epoch milliseconds instead of epoch seconds which caused the TTL value to be many many years into the future. 
