### PR TITLE
OJ-2720: implement kid

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ ext {
 		glassfish_version        : "3.0.3",
 		powertools_version       : "1.12.3",
 		cri_common_lib           : "3.0.4",
+		webcompere_version : "2.1.6",
 	]
 }
 
@@ -59,6 +60,7 @@ subprojects {
 		lettuce
 		ssm
 		cri_common_lib
+		webcompere
 	}
 
 	// The dynamodb enhanced package loads the apache-client as well as the spi-client, so
@@ -124,6 +126,9 @@ subprojects {
 				"com.nimbusds:nimbus-jose-jwt:${dependencyVersions.nimbusds_jwt_version}"
 
 		cri_common_lib "uk.gov.account:cri-common-lib:${dependencyVersions.cri_common_lib}"
+
+		webcompere "uk.org.webcompere:system-stubs-core:${dependencyVersions.webcompere_version}",
+				"uk.org.webcompere:system-stubs-jupiter:${dependencyVersions.webcompere_version}"
 	}
 
 	apply plugin: 'java'

--- a/lambdas/issuecredential/build.gradle
+++ b/lambdas/issuecredential/build.gradle
@@ -16,7 +16,9 @@ dependencies {
 
 	aspect configurations.powertools
 
-	testImplementation configurations.tests
+	testImplementation configurations.tests,
+			configurations.webcompere
+
 	testRuntimeOnly configurations.test_runtime
 }
 

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/VerifiableCredentialConstants.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/VerifiableCredentialConstants.java
@@ -5,6 +5,7 @@ public class VerifiableCredentialConstants {
     public static final String DI_CONTEXT =
             "https://vocab.account.gov.uk/contexts/identity-v1.jsonld";
     public static final String KBV_CREDENTIAL_TYPE = "IdentityCheckCredential";
+    public static final String METRIC_DIMENSION_KBV_VERIFICATION = "kbv_verification";
 
     public static final String VC_ADDRESS_KEY = "address";
     public static final String VC_BIRTHDATE_KEY = "birthDate";

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/IssueCredentialHandler.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/IssueCredentialHandler.java
@@ -42,6 +42,7 @@ import uk.gov.di.ipv.cri.kbv.api.service.KBVStorageService;
 import uk.gov.di.ipv.cri.kbv.api.service.ServiceFactory;
 import uk.gov.di.ipv.cri.kbv.api.service.VerifiableCredentialService;
 
+import java.security.NoSuchAlgorithmException;
 import java.time.Clock;
 import java.util.Map;
 import java.util.Optional;
@@ -54,6 +55,9 @@ import static uk.gov.di.ipv.cri.common.library.error.ErrorResponse.SESSION_NOT_F
 public class IssueCredentialHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
     private static final Logger LOGGER = LogManager.getLogger();
+
+    public static final String NO_SUCH_ALGORITHM_ERROR =
+            "The algorithm name provided is incorrect or misspelled, should be ES256.";
     public static final String AUTHORIZATION_HEADER_KEY = "Authorization";
     public static final String KBV_CREDENTIAL_ISSUER = "kbv_credentials_issued";
     private static final String CREDENTIAL_NOT_ISSUED = "credential not issued";
@@ -155,6 +159,11 @@ public class IssueCredentialHandler
             eventProbe.log(ERROR, e).counterMetric(KBV_CREDENTIAL_ISSUER, 0d);
             LOGGER.info(VC_MESSAGE_FORMAT, CREDENTIAL_NOT_ISSUED, e.getMessage());
             return apiGatewayAccessDeniedError(SESSION_NOT_FOUND);
+        } catch (NoSuchAlgorithmException e) {
+            eventProbe.log(ERROR, e).counterMetric(KBV_CREDENTIAL_ISSUER, 0d);
+            LOGGER.info(VC_MESSAGE_FORMAT, CREDENTIAL_NOT_ISSUED, NO_SUCH_ALGORITHM_ERROR);
+            return ApiGatewayResponseGenerator.proxyJsonResponse(
+                    HttpStatusCode.INTERNAL_SERVER_ERROR, NO_SUCH_ALGORITHM_ERROR);
         } catch (Exception e) {
             eventProbe.log(ERROR, e).counterMetric(KBV_CREDENTIAL_ISSUER, 0d);
             LOGGER.info(VC_MESSAGE_FORMAT, CREDENTIAL_NOT_ISSUED, e.getMessage());

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/VerifiableCredentialService.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/VerifiableCredentialService.java
@@ -20,6 +20,7 @@ import uk.gov.di.ipv.cri.common.library.util.SignedJWTFactory;
 import uk.gov.di.ipv.cri.common.library.util.VerifiableCredentialClaimsSetBuilder;
 import uk.gov.di.ipv.cri.kbv.api.domain.KBVItem;
 
+import java.security.NoSuchAlgorithmException;
 import java.time.Clock;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
@@ -86,8 +87,10 @@ public class VerifiableCredentialService {
     @Tracing
     public SignedJWT generateSignedVerifiableCredentialJwt(
             SessionItem sessionItem, PersonIdentityDetailed personIdentity, KBVItem kbvItem)
-            throws JOSEException, JsonProcessingException {
+            throws JOSEException, JsonProcessingException, NoSuchAlgorithmException {
         long jwtTtl = this.configurationService.getMaxJwtTtl();
+        String issuer = configurationService.getVerifiableCredentialIssuer();
+        String kmsSigningKeyId = configurationService.getVerifiableCredentialKmsSigningKeyId();
         ChronoUnit jwtTtlUnit =
                 ChronoUnit.valueOf(this.configurationService.getParameterValue("JwtTtlUnit"));
         var claimsSet =
@@ -108,7 +111,7 @@ public class VerifiableCredentialService {
                                 evidenceFactory.create(kbvItem, sessionItem.getEvidenceRequest()))
                         .build();
 
-        return signedJwtFactory.createSignedJwt(claimsSet);
+        return signedJwtFactory.createSignedJwt(claimsSet, issuer, kmsSigningKeyId);
     }
 
     public Map<String, Object> getAuditEventExtensions(

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/fixtures/TestFixtures.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/fixtures/TestFixtures.java
@@ -164,11 +164,15 @@ public interface TestFixtures {
         return question;
     }
 
-    default KBVItem getKbvItem() {
+    default KBVItem getKbvItem(UUID sessionId, String authRefNo) {
         KBVItem kbvItem = new KBVItem();
-        kbvItem.setSessionId(UUID.randomUUID());
-        kbvItem.setAuthRefNo(UUID.randomUUID().toString());
+        kbvItem.setSessionId(sessionId);
+        kbvItem.setAuthRefNo(authRefNo);
         return kbvItem;
+    }
+
+    default KBVItem getKbvItem() {
+        return getKbvItem(UUID.randomUUID(), UUID.randomUUID().toString());
     }
 
     default KbvResult getKbvResult(String transactionValue) {


### PR DESCRIPTION
## Proposed changes

When included in the VCs, the public key id (kid) allows verifiers to determine which key a VC was signed with. Having all the issuers publish the correct information in the JWT header will result in standardisation across the programme.
see https://govukverify.atlassian.net/browse/OJ-2720


