### PR TITLE
OJ-272: Bump cri-lib to fix kid format

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ ext {
 		mockito					 : "4.3.1",
 		glassfish_version        : "3.0.3",
 		powertools_version       : "1.12.3",
-		cri_common_lib           : "3.0.4",
+		cri_common_lib           : "3.0.5",
 		pact_provider_version    : "4.5.11",
 		webcompere_version       : "2.1.6",
 	]


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Bumped cri lib

<!-- Describe the changes in detail - the "what"-->

### Why did it change

The kid in the JWT header was formatted wrong. Changes to cri lib now remove https:// from the issuer and formats the kid with a hash like `did:web:Issuer#HashedKeyID` instead of with a colon like `did:web:Issuer:HashedKeyID`

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-2720](https://govukverify.atlassian.net/browse/OJ-2720)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[OJ-2720]: https://govukverify.atlassian.net/browse/OJ-2720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ