### PR TITLE
OJ-2720: Update integration test to include kid in JWT assertion

### DIFF
--- a/.cfnlintrc
+++ b/.cfnlintrc
@@ -1,0 +1,3 @@
+ignore_checks:
+  - E3020
+  - W1028

--- a/integration-tests/src/test/java/gov/uk/kbv/api/stepdefinitions/KbvSteps.java
+++ b/integration-tests/src/test/java/gov/uk/kbv/api/stepdefinitions/KbvSteps.java
@@ -196,7 +196,9 @@ public class KbvSteps {
         assertEquals("JWT", header.at("/typ").asText());
         assertEquals("ES256", header.at("/alg").asText());
 
-        assertEquals("did:web:review-k.dev.account.gov.uk#f06e603c0b11557151851ba196a46657f47daaca9f151761980f9f5c39210482", header.at("/kid").asText());
+        assertEquals(
+                "did:web:review-k.dev.account.gov.uk#f06e603c0b11557151851ba196a46657f47daaca9f151761980f9f5c39210482",
+                header.at("/kid").asText());
 
         assertNotNull(payload);
         assertNotNull(payload.at("/nbf"));

--- a/integration-tests/src/test/java/gov/uk/kbv/api/stepdefinitions/KbvSteps.java
+++ b/integration-tests/src/test/java/gov/uk/kbv/api/stepdefinitions/KbvSteps.java
@@ -196,6 +196,8 @@ public class KbvSteps {
         assertEquals("JWT", header.at("/typ").asText());
         assertEquals("ES256", header.at("/alg").asText());
 
+        assertEquals("did:web:review-k.dev.account.gov.uk#f06e603c0b11557151851ba196a46657f47daaca9f151761980f9f5c39210482", header.at("/kid").asText());
+
         assertNotNull(payload);
         assertNotNull(payload.at("/nbf"));
         assertNotNull(payload.at("/vc/evidence/0/txn"));


### PR DESCRIPTION

### What changed

Added /kid assertion for JWT headers
<img width="1175" alt="Screenshot 2024-08-21 at 08 49 14" src="https://github.com/user-attachments/assets/1685dd59-e3e0-4ba7-b0ba-e2d0fda271ac">


### Why did it change

/kid have been added to the JWT headers

### Issue tracking

- [OJ-2720](https://govukverify.atlassian.net/browse/OJ-2720)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[OJ-2720]: https://govukverify.atlassian.net/browse/OJ-2720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ