### PR TITLE
BAU: Remove cucumber publish quiet

### DIFF
--- a/integration-tests/src/test/resources/cucumber.properties
+++ b/integration-tests/src/test/resources/cucumber.properties
@@ -1,5 +1,4 @@
 cucumber.publish.enabled=false
-cucumber.publish.quiet=true
 cucumber.features=src/test/resources
 cucumber.glue=gov.uk.kbv.api.stepdefinitions,uk.gov.di.ipv.cri.common.library.stepdefinitions
 cucumber.plugin=pretty,json:target/cucumber.json,html:target/index.html


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Remove cucumber publish quiet

### Why did it change

It's been deprecated as per the [docs](https://github.com/cucumber/cucumber-js/blob/main/docs/deprecations.md)
