### PR TITLE
Set AWS CloudWatch log retention to 30 days

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -328,7 +328,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-${PublicKBVApi}-public-AccessLogs
-      RetentionInDays: 365
+      RetentionInDays: 30
 
   PublicKBVApiAccessLogGroupSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -343,7 +343,7 @@ Resources:
     Condition: IsNotDevEnvironment
     Properties:
       LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-${PrivateKBVApi}-private-AccessLogs
-      RetentionInDays: 365
+      RetentionInDays: 30
 
   DevOnlyKBVApiAccessLogGroup:
     Type: AWS::Logs::LogGroup


### PR DESCRIPTION

## Proposed changes

### What changed

Update retention days to 30 in template.yaml

### Why did it change

This work will help the Platform and SRE Pod address a bug in the LZA - INCIDEN-627: Log retention policy
 
### Issue tracking

- [OJ-2600](https://govukverify.atlassian.net/browse/OJ-2600)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[OJ-2600]: https://govukverify.atlassian.net/browse/OJ-2600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ