### PR TITLE
OJ-2778: Resolving linting issue

### DIFF
--- a/.cfnlintrc
+++ b/.cfnlintrc
@@ -1,3 +1,0 @@
-ignore_checks:
-  - E3020
-  - W1028

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: "2010-09-09"
-Transform: [AWS::Serverless-2016-10-31, AWS::LanguageExtensions]
+Transform: [AWS::Serverless-2016-10-31, AWS::LanguageExtensions] 
 Description: "Digital Identity IPV CRI KBV API"
 
 Parameters:
@@ -231,20 +231,19 @@ Resources:
           ThrottlingRateLimit: 200
           ThrottlingBurstLimit: 400
       AccessLogSetting:
-        DestinationArn: !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:${PrivateKBVApiAccessLogGroup}'
-        Format: >-
-          {
-          "requestId":"$context.requestId",
-          "ip":"$context.identity.sourceIp",
-          "requestTime":"$context.requestTime",
-          "httpMethod":"$context.httpMethod",
-          "path":"$context.path",
-          "routeKey":"$context.routeKey",
-          "status":"$context.status",
-          "protocol":"$context.protocol",
-          "responseLatency":"$context.responseLatency",
-          "responseLength":"$context.responseLength"
-          }
+        DestinationArn: !GetAtt PrivateKBVApiAccessLogGroup.Arn
+        Format:
+          Fn::ToJsonString:
+            requestId: $context.requestId
+            ip: $context.identity.sourceIp
+            requestTime: $context.requestTime
+            httpMethod: $context.httpMethod
+            path: $context.path
+            routeKey: $context.routeKey
+            status: $context.status
+            protocol: $context.protocol
+            responseLatency: $context.responseLatency
+            responseLength: $context.responseLength
       TracingEnabled: true
       Name: !Sub "kbv-cri-private-${AWS::StackName}"
       StageName: !Ref Environment
@@ -275,10 +274,7 @@ Resources:
                 - 'execute-api:/*'
               Condition:
                 StringNotEquals:
-                  aws:SourceVpce: !If
-                    - IsDevEnvironment
-                    - vpce-082cab7c78139eb54
-                    - !ImportValue cri-vpc-ApiGatewayVpcEndpointId
+                  aws:SourceVpce: !ImportValue cri-vpc-ApiGatewayVpcEndpointId
 
   DevOnlyKBVApi:
     Type: AWS::Serverless::Api
@@ -871,7 +867,6 @@ Resources:
       OKActions:
         - !ImportValue core-infrastructure-AlarmTopic
       InsufficientDataActions: []
-      Dimensions: []
       DatapointsToAlarm: 3
       EvaluationPeriods: 3
       Threshold: 1


### PR DESCRIPTION
## Proposed Changes

```
Check Fn::If has a path that cannot be reached] (['Fn::If', 1] is not reachable. 
When setting condition 'IsDevEnvironment' to True. Where existing status for condition 'IsNotDevEnvironment' is True)
```

The basically saying the condition `IsDevEnvironment` is never used because of the condition `IsNotDevEnvironment` applied when the resource is defined therefore the IsDevEnvironment can be removed entirely.

Also removed `Dimensions: []` as flagged by linter


Remove `.cfnlintrc` this was temporary way to ignore the linting issues. due to upgrade of SAM CLI to version 1.123.0 
in the github Action

**NB**:
See: https://govukverify.atlassian.net/browse/OJ-2255 which is a related ticket, that's outside the scope of this one.
The `DEV` stack for KBV and ADDRESS are actually more like the LOCALDEV stack `DEV` in Check Nino CRI which is where we should be for Address and KBV at some point that's what OJ-2255 is for

