### PR TITLE
OJ-2731: Adding new metric for latency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ ext {
 		mockito					 : "4.3.1",
 		glassfish_version        : "3.0.3",
 		powertools_version       : "1.12.3",
-		cri_common_lib           : "3.0.5",
+		cri_common_lib           : "3.0.6",
 		pact_provider_version    : "4.5.11",
 		webcompere_version       : "2.1.6",
 	]

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/MetricsService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/MetricsService.java
@@ -45,4 +45,8 @@ public class MetricsService {
             }
         }
     }
+
+    public EventProbe getEventProbe() {
+        return eventProbe;
+    }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/gateway/KBVGatewayTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/gateway/KBVGatewayTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.kbv.api.domain.KbvResult;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionAnswerRequest;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionRequest;
@@ -45,7 +46,7 @@ class KBVGatewayTest {
         when(mockIdentityIQWebServiceSoap.saa(mockSaaRequest)).thenReturn(mockSaaResponse);
         when(mockQuestionsResponseMapper.mapSAAResponse(mockSaaResponse))
                 .thenReturn(mockQuestionsResponse);
-
+        when(mockMetricsService.getEventProbe()).thenReturn(mock(EventProbe.class));
         kbvGateway.getQuestions(questionRequest);
 
         verify(mockSAARequestMapper).mapQuestionRequest(questionRequest);
@@ -68,7 +69,7 @@ class KBVGatewayTest {
         when(mockIdentityIQWebServiceSoap.rtq(mockRtqRequest)).thenReturn(mockRtqResponse);
         when(mockQuestionsResponseMapper.mapRTQResponse(mockRtqResponse))
                 .thenReturn(mockQuestionsResponse);
-
+        when(mockMetricsService.getEventProbe()).thenReturn(mock(EventProbe.class));
         kbvGateway.submitAnswers(questionAnswerRequest);
 
         verify(mockResponseToQuestionMapper).mapQuestionAnswersRtqRequest(questionAnswerRequest);

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/MetricsServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/MetricsServiceTest.java
@@ -10,6 +10,7 @@ import uk.gov.di.ipv.cri.kbv.api.domain.KbvResult;
 
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.verify;
 import static uk.gov.di.ipv.cri.kbv.api.service.MetricsService.ERROR_CODE;
 import static uk.gov.di.ipv.cri.kbv.api.service.MetricsService.EXECUTION_DURATION;
@@ -52,5 +53,10 @@ class MetricsServiceTest {
         this.metricsService.sendErrorMetric(errorCode, "baz");
         verify(eventProbe).counterMetric("baz");
         verify(eventProbe).addDimensions(Map.of(ERROR_CODE, errorCode));
+    }
+
+    @Test
+    void eventProbeShouldNotBeNull() {
+        assertNotNull(metricsService.getEventProbe());
     }
 }


### PR DESCRIPTION
## Proposed changes

### What changed

Added two new metrics for "getQuestion" and "submitQuestion" API to check latency.
<img width="1172" alt="image" src="https://github.com/user-attachments/assets/f6265256-cd9e-4f62-ae83-9ff79aba1522">
<img width="1172" alt="Screenshot 2024-09-06 at 17 05 25" src="https://github.com/user-attachments/assets/d696891f-f138-43c1-93e5-de2fdc7ddc3c">

### Why did it change
The original method `sendResultMetric` did not have the correct unit of measurement (ms) for the metric, so we were not able create the appropriate Dynatrace dashboards or see the duration time properly on the Cloudwatch metric graph.

To increase observability.

### Issue tracking

- [OJ-2731](https://govukverify.atlassian.net/browse/OJ-2731)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[OJ-2731]: https://govukverify.atlassian.net/browse/OJ-2731?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ