### PR TITLE
OJ-2689: Enable three new questions

### DIFF
--- a/integration-tests/src/test/java/gov/uk/kbv/api/client/KbvApiClient.java
+++ b/integration-tests/src/test/java/gov/uk/kbv/api/client/KbvApiClient.java
@@ -83,11 +83,15 @@ public class KbvApiClient {
         return sendHttpRequest(request);
     }
 
-    public void submitCorrectAnswers(String question, String sessionId)
+    public void submitCorrectAnswers(String question, String sessionId, int user)
             throws IOException, InterruptedException {
 
         String POST_REQUEST_BODY =
-                "{\"questionId\":\"" + question + "\",\"answer\":\"" + getCorrect(question) + "\"}";
+                "{\"questionId\":\""
+                        + question
+                        + "\",\"answer\":\""
+                        + getCorrect(question, user)
+                        + "\"}";
         HttpRequest request =
                 HttpRequest.newBuilder()
                         .uri(
@@ -106,14 +110,14 @@ public class KbvApiClient {
         sendHttpRequest(request);
     }
 
-    public void submitIncorrectAnswers(String question, String sessionId)
+    public void submitIncorrectAnswers(String question, String sessionId, int user)
             throws IOException, InterruptedException {
 
         String POST_REQUEST_BODY =
                 "{\"questionId\":\""
                         + question
                         + "\",\"answer\":\""
-                        + getInCorrect(question)
+                        + getInCorrect(question, user)
                         + "\"}";
         HttpRequest request =
                 HttpRequest.newBuilder()

--- a/integration-tests/src/test/java/gov/uk/kbv/api/stepdefinitions/KbvSteps.java
+++ b/integration-tests/src/test/java/gov/uk/kbv/api/stepdefinitions/KbvSteps.java
@@ -83,14 +83,15 @@ public class KbvSteps {
                 this.kbvApiClient.sendAbandonRequest(this.testContext.getSessionId()));
     }
 
-    @And("user answers the question correctly")
-    public void userAnswersTheQuestionCorrectly() throws IOException, InterruptedException {
-        this.kbvApiClient.submitCorrectAnswers(questionId, this.testContext.getSessionId());
+    @And("{int} answers the question correctly")
+    public void userAnswersTheQuestionCorrectly(int user) throws IOException, InterruptedException {
+        this.kbvApiClient.submitCorrectAnswers(questionId, this.testContext.getSessionId(), user);
     }
 
-    @Then("user answers the question incorrectly")
-    public void userAnswersTheQuestionIncorrectly() throws IOException, InterruptedException {
-        this.kbvApiClient.submitIncorrectAnswers(questionId, this.testContext.getSessionId());
+    @Then("{int} answers the question incorrectly")
+    public void userAnswersTheQuestionIncorrectly(int user)
+            throws IOException, InterruptedException {
+        this.kbvApiClient.submitIncorrectAnswers(questionId, this.testContext.getSessionId(), user);
     }
 
     @And("a valid JWT is returned in the response")

--- a/integration-tests/src/test/java/gov/uk/kbv/api/util/AnswerResource.java
+++ b/integration-tests/src/test/java/gov/uk/kbv/api/util/AnswerResource.java
@@ -13,18 +13,23 @@ import java.util.stream.Collectors;
 public class AnswerResource {
     private static final String CORRECT = "CORRECT";
     private static final String INCORRECT = "INCORRECT";
-    private static final String KENNETH_DECERQUEIRA = "KennethDecerqueira.json";
+    private static final Map<Integer, String> resourceMap =
+            Map.of(
+                    197, "KennethDecerqueira.json",
+                    256, "HildaHead.json");
 
-    public static String getCorrect(String question) throws IOException {
-        return AnswerResource.retrieve(question, CORRECT);
+    public static String getCorrect(String question, int user) throws IOException {
+        return AnswerResource.retrieve(question, CORRECT, user);
     }
 
-    public static String getInCorrect(String question) throws IOException {
-        return AnswerResource.retrieve(question, INCORRECT);
+    public static String getInCorrect(String question, int user) throws IOException {
+        return AnswerResource.retrieve(question, INCORRECT, user);
     }
 
-    private static String retrieve(String question, String answerState) throws IOException {
-        return Arrays.stream(convert(KENNETH_DECERQUEIRA).get(question).toString().split(";"))
+    private static String retrieve(String question, String answerState, int user)
+            throws IOException {
+        String jsonFileName = getResourceFileName(user);
+        return Arrays.stream(convert(jsonFileName).get(question).toString().split(";"))
                 .filter(item -> item.startsWith(answerState))
                 .collect(Collectors.joining())
                 .split(":")[1];
@@ -38,5 +43,13 @@ public class AnswerResource {
         Map<String, Object> map = mapper.readValue(reader, Map.class);
 
         return map;
+    }
+
+    private static String getResourceFileName(int user) throws IOException {
+        String jsonFileName = resourceMap.get(user);
+        if (jsonFileName == null) {
+            throw new IOException("Resource ID not found: " + user);
+        }
+        return jsonFileName;
     }
 }

--- a/integration-tests/src/test/resources/HildaHead.json
+++ b/integration-tests/src/test/resources/HildaHead.json
@@ -1,0 +1,21 @@
+{
+  "Q00092": "CORRECT:£60;INCORRECT:£70",
+  "Q00088": "CORRECT:£33;INCORRECT:£45",
+  "Q00100": "CORRECT:£21;INCORRECT:£15",
+  "title": "MRS",
+  "name": "HILDA",
+  "surname": "HEAD",
+  "houseNo": "153",
+  "houseName": "DIAMOND COURT",
+  "street": "FLAT 58",
+  "district": "BANBURY ROAD",
+  "postTown": "OXFORD",
+  "postcode": "OX2 7AA",
+  "dob": "1961-05-30",
+  "addressFound": "Y",
+  "errorOccurred": "N",
+  "noOfQuestionsAfterApplyingBusinessRules": "10",
+  "noOfQuestionsTotal": "10",
+  "accountNumber": "J8193",
+  "ctdbDatabase": "S"
+}

--- a/integration-tests/src/test/resources/features/KbvApiAbandonPath.feature
+++ b/integration-tests/src/test/resources/features/KbvApiAbandonPath.feature
@@ -88,3 +88,4 @@ Feature: User goes through 3-out-of-4 question strategy and 2-out-of-3 question 
     Examples:
       | user |
       | 197  |
+      | 256  |

--- a/integration-tests/src/test/resources/features/KbvApiAbandonPath.feature
+++ b/integration-tests/src/test/resources/features/KbvApiAbandonPath.feature
@@ -19,8 +19,8 @@ Feature: User goes through 3-out-of-4 question strategy and 2-out-of-3 question 
     And 5 events are deleted from the audit events SQS queue
 
   @pre_merge_abandon_medium_confidence
-  Scenario: 3-out-of-4 question strategy user abandons second question
-    Given user has the test-identity 197 in the form of a signed JWT string
+  Scenario Outline: 3-out-of-4 question strategy user abandons second question
+    Given user has the test-identity <user> in the form of a signed JWT string
 
     # Session
     When user sends a POST request to session end point
@@ -29,7 +29,7 @@ Feature: User goes through 3-out-of-4 question strategy and 2-out-of-3 question 
     # First question
     When user sends a GET request to question endpoint
     Then user gets status code 200
-    And user answers the question correctly
+    And <user> answers the question correctly
     Then user gets status code 200
 
     # Second question
@@ -41,6 +41,10 @@ Feature: User goes through 3-out-of-4 question strategy and 2-out-of-3 question 
     Then user gets status code 200
     And 5 events are deleted from the audit events SQS queue
 
+    Examples:
+      | user |
+      | 197  |
+  
   @pre_merge_abandon_low_confidence
   Scenario: 2-out-of-3 question strategy user abandons first question
     Given user has the test-identity 197 and verificationScore of 1 in the form of a signed JWT string
@@ -59,8 +63,8 @@ Feature: User goes through 3-out-of-4 question strategy and 2-out-of-3 question 
     And 5 events are deleted from the audit events SQS queue
 
   @pre_merge_abandon_low_confidence
-  Scenario: 2-out-of-3 question strategy user abandons second question
-    Given user has the test-identity 197 and verificationScore of 1 in the form of a signed JWT string
+  Scenario Outline: 2-out-of-3 question strategy user abandons second question
+    Given user has the test-identity <user> and verificationScore of 1 in the form of a signed JWT string
 
     # Session
     When user sends a POST request to session end point
@@ -69,7 +73,7 @@ Feature: User goes through 3-out-of-4 question strategy and 2-out-of-3 question 
     # First question
     When user sends a GET request to question endpoint
     Then user gets status code 200
-    And user answers the question correctly
+    And <user> answers the question correctly
     Then user gets status code 200
 
     # Second question
@@ -80,3 +84,7 @@ Feature: User goes through 3-out-of-4 question strategy and 2-out-of-3 question 
     When user chooses to abandon the question
     Then user gets status code 200
     And 5 events are deleted from the audit events SQS queue
+
+    Examples:
+      | user |
+      | 197  |

--- a/integration-tests/src/test/resources/features/KbvApiHappyPath.feature
+++ b/integration-tests/src/test/resources/features/KbvApiHappyPath.feature
@@ -3,8 +3,8 @@ Feature: User goes through 3-out-of-4 question strategy. User answers 3 question
   Tests are run against the KBV Stub.
 
   @pre_merge_happy_with_device_information_header
-  Scenario: User answers 3 questions correctly in 3-out-of-4 question strategy with device information header
-    Given user has the test-identity 197 in the form of a signed JWT string
+  Scenario Outline: User answers 3 questions correctly in 3-out-of-4 question strategy with device information header
+    Given user has the test-identity <user> in the form of a signed JWT string
 
     # Session
     When user sends a POST request to session end point with txma header
@@ -16,19 +16,19 @@ Feature: User goes through 3-out-of-4 question strategy. User answers 3 question
     # First question
     When user sends a GET request to question endpoint
     Then user gets status code 200
-    And user answers the question correctly
+    And <user> answers the question correctly
     Then user gets status code 200
 
     # Second question
     When user sends a GET request to question endpoint
     Then user gets status code 200
-    And user answers the question correctly
+    And <user> answers the question correctly
     Then user gets status code 200
 
     # Third question
     When user sends a GET request to question endpoint
     Then user gets status code 200
-    And user answers the question correctly
+    And <user> answers the question correctly
     Then user gets status code 200
 
     When user sends a GET request to question endpoint when there are no questions left
@@ -52,9 +52,13 @@ Feature: User goes through 3-out-of-4 question strategy. User answers 3 question
     And the check details array has 3 objects returned in the response
     And 10 events are deleted from the audit events SQS queue
 
+    Examples:
+      | user |
+      | 197  |
+
   @pre_merge_happy_medium_confidence
-  Scenario: User answers 3 questions correctly in 3-out-of-4 question strategy
-    Given user has the test-identity 197 in the form of a signed JWT string
+  Scenario Outline: User answers 3 questions correctly in 3-out-of-4 question strategy
+    Given user has the test-identity <user> in the form of a signed JWT string
 
     # Session
     When user sends a POST request to session end point
@@ -66,19 +70,19 @@ Feature: User goes through 3-out-of-4 question strategy. User answers 3 question
     # First question
     When user sends a GET request to question endpoint
     Then user gets status code 200
-    And user answers the question correctly
+    And <user> answers the question correctly
     Then user gets status code 200
 
     # Second question
     When user sends a GET request to question endpoint
     Then user gets status code 200
-    And user answers the question correctly
+    And <user> answers the question correctly
     Then user gets status code 200
 
     # Third question
     When user sends a GET request to question endpoint
     Then user gets status code 200
-    And user answers the question correctly
+    And <user> answers the question correctly
     Then user gets status code 200
 
     When user sends a GET request to question endpoint when there are no questions left
@@ -102,9 +106,13 @@ Feature: User goes through 3-out-of-4 question strategy. User answers 3 question
     And the check details array has 3 objects returned in the response
     And 10 events are deleted from the audit events SQS queue
 
+    Examples:
+      | user |
+      | 197  |
+
   @pre_merge_happy_low_confidence
-  Scenario: User answers 2 questions correctly in 2-out-of-3 question strategy
-    Given user has the test-identity 197 and verificationScore of 1 in the form of a signed JWT string
+  Scenario Outline: User answers 2 questions correctly in 2-out-of-3 question strategy
+    Given user has the test-identity <user> and verificationScore of 1 in the form of a signed JWT string
 
     # Session
     When user sends a POST request to session end point
@@ -116,13 +124,13 @@ Feature: User goes through 3-out-of-4 question strategy. User answers 3 question
     # First question
     When user sends a GET request to question endpoint
     Then user gets status code 200
-    And user answers the question correctly
+    And <user> answers the question correctly
     Then user gets status code 200
 
     # Second question
     When user sends a GET request to question endpoint
     Then user gets status code 200
-    And user answers the question correctly
+    And <user> answers the question correctly
     Then user gets status code 200
 
     When user sends a GET request to question endpoint when there are no questions left
@@ -146,9 +154,13 @@ Feature: User goes through 3-out-of-4 question strategy. User answers 3 question
     And the check details array has 2 objects returned in the response
     And 8 events are deleted from the audit events SQS queue
 
+    Examples:
+      | user |
+      | 197  |
+
   @pre_merge_happy_low_confidence
-  Scenario: User answers 2 out of 3 questions correctly with in 2-out-of-3 question strategy
-    Given user has the test-identity 197 and verificationScore of 1 in the form of a signed JWT string
+  Scenario Outline: User answers 2 out of 3 questions correctly with in 2-out-of-3 question strategy
+    Given user has the test-identity <user> and verificationScore of 1 in the form of a signed JWT string
 
     # Session
     When user sends a POST request to session end point
@@ -160,19 +172,19 @@ Feature: User goes through 3-out-of-4 question strategy. User answers 3 question
     # First question
     When user sends a GET request to question endpoint
     Then user gets status code 200
-    And user answers the question correctly
+    And <user> answers the question correctly
     Then user gets status code 200
 
     # Second question
     When user sends a GET request to question endpoint
     Then user gets status code 200
-    And user answers the question incorrectly
+    And <user> answers the question incorrectly
     Then user gets status code 200
 
     # Third question
     When user sends a GET request to question endpoint
     Then user gets status code 200
-    And user answers the question correctly
+    And <user> answers the question correctly
     Then user gets status code 200
 
     When user sends a GET request to question endpoint when there are no questions left
@@ -196,3 +208,7 @@ Feature: User goes through 3-out-of-4 question strategy. User answers 3 question
     And the check details array has 2 objects returned in the response
     And the failed details array has 1 objects returned in the response
     And 10 events are deleted from the audit events SQS queue
+
+    Examples:
+      | user |
+      | 197  |

--- a/integration-tests/src/test/resources/features/KbvApiHappyPath.feature
+++ b/integration-tests/src/test/resources/features/KbvApiHappyPath.feature
@@ -212,3 +212,4 @@ Feature: User goes through 3-out-of-4 question strategy. User answers 3 question
     Examples:
       | user |
       | 197  |
+      | 256  |

--- a/integration-tests/src/test/resources/features/KbvApiUnhappyPath.feature
+++ b/integration-tests/src/test/resources/features/KbvApiUnhappyPath.feature
@@ -90,3 +90,4 @@ Feature: User goes through 3-out-of-4 question strategy. User answers 2 question
     Examples:
       | user |
       | 197  |
+      | 256  |

--- a/integration-tests/src/test/resources/features/KbvApiUnhappyPath.feature
+++ b/integration-tests/src/test/resources/features/KbvApiUnhappyPath.feature
@@ -3,8 +3,8 @@ Feature: User goes through 3-out-of-4 question strategy. User answers 2 question
   Tests are run against the KBV Stub.
 
   @pre_merge_unhappy_medium_confidence
-  Scenario: 3-out-of-4 question strategy user answers 2 questions incorrectly
-    Given user has the test-identity 197 in the form of a signed JWT string
+  Scenario Outline: 3-out-of-4 question strategy user answers 2 questions incorrectly
+    Given user has the test-identity <user> in the form of a signed JWT string
 
     # Session
     When user sends a POST request to session end point
@@ -13,13 +13,14 @@ Feature: User goes through 3-out-of-4 question strategy. User answers 2 question
     # First question
     When user sends a GET request to question endpoint
     Then user gets status code 200
-    And user answers the question incorrectly
+    And <user> answers the question incorrectly
     Then user gets status code 200
+
 
     # Second question
     When user sends a GET request to question endpoint
     Then user gets status code 200
-    And user answers the question incorrectly
+    And <user> answers the question incorrectly
     Then user gets status code 200
 
     When user sends a GET request to question endpoint when there are no questions left
@@ -41,10 +42,14 @@ Feature: User goes through 3-out-of-4 question strategy. User answers 2 question
     And a verification score of 0 is returned in the response
     And the failed details array has 2 objects returned in the response
     And 8 events are deleted from the audit events SQS queue
+
+    Examples:
+      | user |
+      | 197  |
 
   @pre_merge_unhappy_low_confidence
-  Scenario: 2-out-of-3 question strategy user answers 2 questions incorrectly
-    Given user has the test-identity 197 and verificationScore of 1 in the form of a signed JWT string
+  Scenario Outline: 2-out-of-3 question strategy user answers 2 questions incorrectly
+    Given user has the test-identity <user> and verificationScore of 1 in the form of a signed JWT string
 
     # Session
     When user sends a POST request to session end point
@@ -53,13 +58,13 @@ Feature: User goes through 3-out-of-4 question strategy. User answers 2 question
     # First question
     When user sends a GET request to question endpoint
     Then user gets status code 200
-    And user answers the question incorrectly
+    And <user> answers the question incorrectly
     Then user gets status code 200
 
     # Second question
     When user sends a GET request to question endpoint
     Then user gets status code 200
-    And user answers the question incorrectly
+    And <user> answers the question incorrectly
     Then user gets status code 200
 
     When user sends a GET request to question endpoint when there are no questions left
@@ -81,3 +86,7 @@ Feature: User goes through 3-out-of-4 question strategy. User answers 2 question
     And a verification score of 0 is returned in the response
     And the failed details array has 2 objects returned in the response
     And 8 events are deleted from the audit events SQS queue
+
+    Examples:
+      | user |
+      | 197  |


### PR DESCRIPTION
## Proposed changes

see: https://govukverify.atlassian.net/browse/OJ-2689

### What changed

AnswerResource extended to handle multiple users, use the row number of in the spreadsheet to select which the user on which the features are run

### Why did it change

support 3 new questions
