### PR TITLE
INCIDEN-937: Add logging to Base64TokenEncoder

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/exception/InvalidSoapTokenException.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/exception/InvalidSoapTokenException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.ipv.cri.kbv.api.exception;
+
+public class InvalidSoapTokenException extends RuntimeException {
+    public InvalidSoapTokenException(String message) {
+        super(message);
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/security/Base64TokenCacheLoader.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/security/Base64TokenCacheLoader.java
@@ -10,7 +10,7 @@ public class Base64TokenCacheLoader implements CacheLoader<String, Base64TokenEn
     }
 
     @Override
-    public Base64TokenEncoder load(String key) throws Exception {
+    public Base64TokenEncoder load(String key) {
         return new Base64TokenEncoder(key, soapToken);
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/security/Base64TokenEncoder.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/security/Base64TokenEncoder.java
@@ -1,23 +1,27 @@
 package uk.gov.di.ipv.cri.kbv.api.security;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.ipv.cri.kbv.api.exception.InvalidSoapTokenException;
+
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Objects;
 
 public class Base64TokenEncoder {
+    private static final Logger LOGGER = LogManager.getLogger();
     private final String key;
     private String token;
 
     public Base64TokenEncoder(String key, SoapToken soapToken) {
-        this.key = key;
-        this.token = soapToken.getToken();
+        this.key = Objects.requireNonNull(key, "The key must not be null");
+        this.token = Objects.requireNonNull(soapToken.getToken(), "The token must not be null");
     }
 
     public String getToken() {
-        Objects.requireNonNull(token, "The token must not be null");
-
         if (token.contains("Error")) {
-            throw new RuntimeException();
+            LOGGER.info("The SOAP token contains an error: {}", token);
+            throw new InvalidSoapTokenException("The SOAP token contains an error: " + token);
         }
 
         return Base64.getEncoder().encodeToString(token.getBytes(StandardCharsets.UTF_8));

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/security/Base64TokenEncoderTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/security/Base64TokenEncoderTest.java
@@ -3,6 +3,7 @@ package uk.gov.di.ipv.cri.kbv.api.security;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.cri.kbv.api.exception.InvalidSoapTokenException;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
@@ -16,7 +17,7 @@ import static org.mockito.Mockito.when;
 class Base64TokenEncoderTest {
 
     private Base64TokenEncoder base64TokenEncoder;
-    private SoapToken token = mock(SoapToken.class);
+    private final SoapToken token = mock(SoapToken.class);
 
     @Test
     void shouldReturnAGeneratedBase64EncodedTokenWhenGivenASoapTokenService() {
@@ -30,20 +31,21 @@ class Base64TokenEncoderTest {
 
     @Test
     void shouldThrowAnExceptionWhenGivenSoapTokenServiceIsNotValid() {
-        base64TokenEncoder = new Base64TokenEncoder(null, token);
-        when(token.getToken()).thenReturn(null);
+        when(token.getToken()).thenReturn("Error");
+        base64TokenEncoder = new Base64TokenEncoder("token", token);
 
-        NullPointerException soapTokenNullRefException =
-                assertThrows(NullPointerException.class, () -> base64TokenEncoder.getToken());
+        InvalidSoapTokenException soapTokenNullRefException =
+                assertThrows(InvalidSoapTokenException.class, () -> base64TokenEncoder.getToken());
 
-        assertEquals("The token must not be null", soapTokenNullRefException.getMessage());
+        assertEquals(
+                "The SOAP token contains an error: Error", soapTokenNullRefException.getMessage());
     }
 
     @Test
     void shouldThrowAnRuntimeExceptionWhenGivenSoapTokenServiceIsNotValid() {
-        base64TokenEncoder = new Base64TokenEncoder("Error", token);
         when(token.getToken()).thenReturn("Error");
+        base64TokenEncoder = new Base64TokenEncoder("Error", token);
 
-        assertThrows(RuntimeException.class, () -> base64TokenEncoder.getToken());
+        assertThrows(InvalidSoapTokenException.class, () -> base64TokenEncoder.getToken());
     }
 }


### PR DESCRIPTION
## Proposed changes

Experian WASP service errored on https://github.com/govuk-one-login/ipv-cri-kbv-api/blob/main/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/security/Base64TokenEncoder.java#L20

If the token contains an error we can log what the token is


### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [INCIDEN-937](https://govukverify.atlassian.net/browse/INCIDEN-937)



[INCIDEN-937]: https://govukverify.atlassian.net/browse/INCIDEN-937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ