### PR TITLE
OJ-2771: Add repeatAttemptAlert to Response Received Audit Event

### DIFF
--- a/integration-tests/src/test/java/gov/uk/kbv/api/util/AnswerResource.java
+++ b/integration-tests/src/test/java/gov/uk/kbv/api/util/AnswerResource.java
@@ -16,7 +16,8 @@ public class AnswerResource {
     private static final Map<Integer, String> resourceMap =
             Map.of(
                     197, "KennethDecerqueira.json",
-                    256, "HildaHead.json");
+                    256, "HildaHead.json",
+                    1188, "CarolineCoulson.json");
 
     public static String getCorrect(String question, int user) throws IOException {
         return AnswerResource.retrieve(question, CORRECT, user);

--- a/integration-tests/src/test/resources/CarolineCoulson.json
+++ b/integration-tests/src/test/resources/CarolineCoulson.json
@@ -1,0 +1,21 @@
+{
+  "Q00040": "CORRECT:OVER £300 UP TO £400;INCORRECT:NONE OF THE ABOVE",
+  "Q00042": "CORRECT:£15;INCORRECT:NONE OF THE ABOVE",
+  "Q00043": "CORRECT:24;INCORRECT:NONE OF THE ABOVE",
+  "Q00052": "CORRECT:55448;INCORRECT:NONE OF THE ABOVE",
+  "title": "MRS",
+  "firstName": "CAROLINE",
+  "surname": "COULSON",
+  "houseNo": "18",
+  "houseName": "DIAMOND COURT",
+  "street": "CARRAM WAY",
+  "postTown": "LINCOLN",
+  "postcode": "LN1 1AB",
+  "dob": "1991-04-10",
+  "addressFound": "Y",
+  "errorOccurred": "N",
+  "noOfQuestionsAfterApplyingBusinessRules": "23",
+  "noOfQuestionsTotal": "23",
+  "accountNumber": "J8193",
+  "ctdbDatabase": "S"
+}

--- a/integration-tests/src/test/resources/features/KbvApiHappyPath.feature
+++ b/integration-tests/src/test/resources/features/KbvApiHappyPath.feature
@@ -16,6 +16,7 @@ Feature: User goes through 3-out-of-4 question strategy. User answers 3 question
     # First question
     When user sends a GET request to question endpoint
     Then user gets status code 200
+    Then TXMA event is added to the SQS queue with repeatAttemptAlert present <alert>
     And <user> answers the question correctly
     Then user gets status code 200
 
@@ -53,8 +54,9 @@ Feature: User goes through 3-out-of-4 question strategy. User answers 3 question
     And 10 events are deleted from the audit events SQS queue
 
     Examples:
-      | user |
-      | 197  |
+      | user | alert |
+      | 197  | false |
+      | 1188 | true |
 
   @pre_merge_happy_medium_confidence
   Scenario Outline: User answers 3 questions correctly in 3-out-of-4 question strategy

--- a/lambdas/answer/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandler.java
+++ b/lambdas/answer/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandler.java
@@ -42,7 +42,7 @@ import static org.apache.logging.log4j.Level.ERROR;
 import static uk.gov.di.ipv.cri.common.library.error.ErrorResponse.SESSION_EXPIRED;
 import static uk.gov.di.ipv.cri.common.library.error.ErrorResponse.SESSION_NOT_FOUND;
 import static uk.gov.di.ipv.cri.kbv.api.domain.KbvResponsesAuditExtension.EXPERIAN_IIQ_RESPONSE;
-import static uk.gov.di.ipv.cri.kbv.api.domain.KbvResponsesAuditExtension.createAuditEventExtensions;
+import static uk.gov.di.ipv.cri.kbv.api.domain.KbvResponsesAuditExtension.createResponseReceivedAuditEventExtensions;
 
 public class QuestionAnswerHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -174,7 +174,9 @@ public class QuestionAnswerHandler
         auditService.sendAuditEvent(
                 AuditEventType.RESPONSE_RECEIVED,
                 new AuditEventContext(requestHeaders, sessionItem),
-                Map.of(EXPERIAN_IIQ_RESPONSE, createAuditEventExtensions(questionsResponse)));
+                Map.of(
+                        EXPERIAN_IIQ_RESPONSE,
+                        createResponseReceivedAuditEventExtensions(questionsResponse)));
         if (questionsResponse.hasQuestions()) {
             LOGGER.info(
                     "ANSWER HANDLER: QuestionIds: {} received from 3rd-party",

--- a/lambdas/answer/src/test/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandlerTest.java
+++ b/lambdas/answer/src/test/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandlerTest.java
@@ -40,6 +40,7 @@ import uk.gov.di.ipv.cri.kbv.api.service.KBVStorageService;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -199,14 +200,17 @@ class QuestionAnswerHandlerTest {
         Map<?, ?> auditEventExtensionEntries =
                 (Map<?, ?>) auditEventExtensionsArgCaptor.getValue().get("experianIiqResponse");
         assertNotNull(auditEventExtensionEntries);
-        assertEquals(responseStatus, auditEventExtensionEntries.get("outcome"));
-        assertEquals(totalQuestionsAsked, auditEventExtensionEntries.get("totalQuestionsAsked"));
-        assertEquals(
-                totalCorrectAnswers,
-                auditEventExtensionEntries.get("totalQuestionsAnsweredCorrect"));
-        assertEquals(
-                totalIncorrectAnswers,
-                auditEventExtensionEntries.get("totalQuestionsAnsweredIncorrect"));
+
+        Map<String, Object> extensionsMap =
+                new HashMap<>(
+                        Map.of(
+                                "totalQuestionsAnsweredCorrect", totalCorrectAnswers,
+                                "totalQuestionsAsked", totalQuestionsAsked,
+                                "totalQuestionsAnsweredIncorrect", totalIncorrectAnswers,
+                                "outcome", responseStatus));
+
+        assertEquals(extensionsMap, auditEventExtensionEntries);
+
         assertEquals(HttpStatusCode.OK, result.getStatusCode());
         assertNull(result.getBody());
     }

--- a/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionHandler.java
+++ b/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionHandler.java
@@ -56,6 +56,7 @@ import static uk.gov.di.ipv.cri.kbv.api.domain.IIQAuditEventType.EXPERIAN_IIQ_ST
 import static uk.gov.di.ipv.cri.kbv.api.domain.IIQAuditEventType.THIN_FILE_ENCOUNTERED;
 import static uk.gov.di.ipv.cri.kbv.api.domain.KbvResponsesAuditExtension.EXPERIAN_IIQ_RESPONSE;
 import static uk.gov.di.ipv.cri.kbv.api.domain.KbvResponsesAuditExtension.createAuditEventExtensions;
+import static uk.gov.di.ipv.cri.kbv.api.domain.KbvResponsesAuditExtension.createResponseReceivedAuditEventExtensions;
 
 public class QuestionHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -331,7 +332,9 @@ public class QuestionHandler
         auditService.sendAuditEvent(
                 AuditEventType.RESPONSE_RECEIVED,
                 new AuditEventContext(requestHeaders, sessionItem),
-                Map.of(EXPERIAN_IIQ_RESPONSE, createAuditEventExtensions(questionsResponse)));
+                Map.of(
+                        EXPERIAN_IIQ_RESPONSE,
+                        createResponseReceivedAuditEventExtensions(questionsResponse)));
     }
 
     private void sendAuditEventIfThinFileEncountered(

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/KbvAlert.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/KbvAlert.java
@@ -1,0 +1,31 @@
+package uk.gov.di.ipv.cri.kbv.api.domain;
+
+import com.experian.uk.schema.experian.identityiq.services.webservice.Alerts;
+
+public class KbvAlert {
+    private String code;
+    private String text;
+
+    public KbvAlert() {}
+
+    public KbvAlert(Alerts alert) {
+        this.code = alert.getCode();
+        this.text = alert.getText();
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/KbvResponsesAuditExtension.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/KbvResponsesAuditExtension.java
@@ -14,32 +14,36 @@ public class KbvResponsesAuditExtension {
     private KbvResponsesAuditExtension() {}
 
     public static Map<String, Object> createAuditEventExtensions(
-            QuestionsResponse questionsResponse) {
-
-        if (Objects.nonNull(questionsResponse)
-                && Objects.nonNull(questionsResponse.getStatus())
-                && Objects.nonNull(questionsResponse.getResults())) {
-
-            return createAuditEventExtensions(
-                    questionsResponse.getStatus(),
-                    questionsResponse.getResults().getAnswerSummary());
-        }
-        return Collections.emptyMap();
+            String status, KbvQuestionAnswerSummary questionSummary) {
+        return getKbvResponsesSummaryEntries(status, questionSummary);
     }
 
     public static Map<String, Object> createAuditEventExtensions(
-            String status, KbvQuestionAnswerSummary questionSummary) {
+            QuestionsResponse questionsResponse) {
+        if (Objects.isNull(questionsResponse) || Objects.isNull(questionsResponse.getResults())) {
+            return Collections.emptyMap();
+        }
+        return createAuditEventExtensions(
+                questionsResponse.getStatus(), questionsResponse.getResults().getAnswerSummary());
+    }
 
-        return Objects.nonNull((status))
-                ? getKbvResponsesSummaryEntries(status, questionSummary)
-                : Collections.emptyMap();
+    public static Map<String, Object> createResponseReceivedAuditEventExtensions(
+            QuestionsResponse questionsResponse) {
+        Map<String, Object> extensionsMap = createAuditEventExtensions(questionsResponse);
+        if (questionsResponse.isRepeatAttemptAlert()) {
+            extensionsMap.put("repeatAttemptAlert", true);
+        }
+        return extensionsMap;
     }
 
     private static Map<String, Object> getKbvResponsesSummaryEntries(
             String status, KbvQuestionAnswerSummary questionSummary) {
 
         Map<String, Object> contextEntries = new HashMap<>();
-        contextEntries.put("outcome", status);
+
+        if (Objects.nonNull(status)) {
+            contextEntries.put("outcome", status);
+        }
 
         if (Objects.nonNull(questionSummary)) {
             contextEntries.put("totalQuestionsAsked", questionSummary.getQuestionsAsked());

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/KbvResult.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/KbvResult.java
@@ -1,8 +1,11 @@
 package uk.gov.di.ipv.cri.kbv.api.domain;
 
+import java.util.List;
+
 public class KbvResult {
     private String outcome;
     private String authenticationResult;
+    private List<KbvAlert> alerts;
     private KbvQuestionAnswerSummary answerSummary;
     private String[] nextTransId;
     private String confirmationCode;
@@ -21,6 +24,14 @@ public class KbvResult {
 
     public void setAuthenticationResult(String authenticationResult) {
         this.authenticationResult = authenticationResult;
+    }
+
+    public List<KbvAlert> getAlerts() {
+        return alerts;
+    }
+
+    public void setAlerts(List<KbvAlert> alerts) {
+        this.alerts = alerts;
     }
 
     public KbvQuestionAnswerSummary getAnswerSummary() {

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/QuestionsResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/domain/QuestionsResponse.java
@@ -7,6 +7,8 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class QuestionsResponse {
+    private static final String REPEAT_ATTEMPT_ALERT_CODE = "U501";
+
     private String uniqueReference;
     private String authReference;
     private String errorCode;
@@ -102,5 +104,12 @@ public class QuestionsResponse {
             return this.getResults().getAnswerSummary();
         }
         return null;
+    }
+
+    public boolean isRepeatAttemptAlert() {
+        return Objects.nonNull(results)
+                && Objects.nonNull(results.getAlerts())
+                && results.getAlerts().stream()
+                        .anyMatch(a -> a.getCode().equalsIgnoreCase(REPEAT_ATTEMPT_ALERT_CODE));
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/gateway/QuestionsResponseMapper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/gateway/QuestionsResponseMapper.java
@@ -6,6 +6,7 @@ import com.experian.uk.schema.experian.identityiq.services.webservice.Questions;
 import com.experian.uk.schema.experian.identityiq.services.webservice.RTQResponse2;
 import com.experian.uk.schema.experian.identityiq.services.webservice.Results;
 import com.experian.uk.schema.experian.identityiq.services.webservice.SAAResponse2;
+import uk.gov.di.ipv.cri.kbv.api.domain.KbvAlert;
 import uk.gov.di.ipv.cri.kbv.api.domain.KbvQuestion;
 import uk.gov.di.ipv.cri.kbv.api.domain.KbvQuestionAnswerSummary;
 import uk.gov.di.ipv.cri.kbv.api.domain.KbvQuestionOptions;
@@ -14,6 +15,7 @@ import uk.gov.di.ipv.cri.kbv.api.domain.QuestionsResponse;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 class QuestionsResponseMapper {
     QuestionsResponse mapRTQResponse(RTQResponse2 response) {
@@ -88,6 +90,13 @@ class QuestionsResponseMapper {
                 summary.setAnsweredIncorrect(results.getQuestions().getIncorrect());
                 summary.setQuestionsAsked(results.getQuestions().getAsked());
                 kbvResult.setAnswerSummary(summary);
+            }
+            if (Objects.nonNull(results.getAlerts())
+                    && Objects.nonNull(results.getAlerts().getAlerts())) {
+                kbvResult.setAlerts(
+                        results.getAlerts().getAlerts().stream()
+                                .map(KbvAlert::new)
+                                .collect(Collectors.toList()));
             }
         }
         return kbvResult;

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/domain/KbvResponsesAuditExtensionTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/domain/KbvResponsesAuditExtensionTest.java
@@ -9,6 +9,9 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static uk.gov.di.ipv.cri.kbv.api.domain.KbvResponsesAuditExtension.createAuditEventExtensions;
+import static uk.gov.di.ipv.cri.kbv.api.domain.KbvResponsesAuditExtension.createResponseReceivedAuditEventExtensions;
+import static uk.gov.di.ipv.cri.kbv.api.util.TestDataCreator.getExperianQuestionResponseWithAlert;
+import static uk.gov.di.ipv.cri.kbv.api.util.TestDataCreator.getExperianQuestionResponseWithQuestions;
 import static uk.gov.di.ipv.cri.kbv.api.util.TestDataCreator.getKbvQuestionAnswerSummary;
 import static uk.gov.di.ipv.cri.kbv.api.util.TestDataCreator.getQuestionResponseWithResults;
 
@@ -17,6 +20,26 @@ class KbvResponsesAuditExtensionTest {
     void shouldReturnEmptyContextEntriesWhenQuestionResponseIsEmpty() {
         QuestionsResponse questionResponse = new QuestionsResponse();
 
+        assertEquals(Collections.emptyMap(), createAuditEventExtensions(questionResponse));
+    }
+
+    @Test
+    void shouldReturnEmptyContextEntriesWhenQuestionResponseIsNull() {
+        assertEquals(Collections.emptyMap(), createAuditEventExtensions((QuestionsResponse) null));
+    }
+
+    @Test
+    void shouldReturnEmptyContextEntriesWhenQuestionResponseResultsIsNull() {
+        QuestionsResponse questionResponse = new QuestionsResponse();
+        questionResponse.setResults(null);
+        assertEquals(Collections.emptyMap(), createAuditEventExtensions(questionResponse));
+    }
+
+    @Test
+    void shouldReturnEmptyWhenQuestionResponseStatusIsNullAndHasNoAlerts() {
+        QuestionsResponse questionResponse = new QuestionsResponse();
+        KbvResult kbvResult = new KbvResult();
+        questionResponse.setResults(kbvResult);
         assertEquals(Collections.emptyMap(), createAuditEventExtensions(questionResponse));
     }
 
@@ -33,8 +56,11 @@ class KbvResponsesAuditExtensionTest {
     @ParameterizedTest(
             name =
                     "{index} => authenticationResult={0}, answeredCorrectly={1}, answeredInCorrectly={2}, totalQuestionsAsked={3}")
-    @CsvSource({"Authenticated, 3, 1, 4", "Not Authenticated, 2, 2, 4"})
-    void shouldReturnContextEntriesWithSummarizedKbvResponseFromQuestionResponse(
+    @CsvSource({
+        "Authenticated, 3, 1, 4",
+        "Not Authenticated, 2, 2, 4",
+    })
+    void shouldReturnContextEntriesWithCorrectExtensionFieldsFromQuestionResponse(
             String authenticationResult,
             int answeredCorrectly,
             int answeredInCorrectly,
@@ -90,5 +116,20 @@ class KbvResponsesAuditExtensionTest {
                 Map.of("outcome", "Not Authenticated"),
                 createAuditEventExtensions(
                         kbvItem.getStatus(), kbvItem.getQuestionAnswerResultSummary()));
+    }
+
+    @Test
+    void shouldCreateEmptyAuditExtensionsFromSAAQuestionResponse() {
+        assertEquals(
+                Collections.emptyMap(),
+                createResponseReceivedAuditEventExtensions(
+                        getExperianQuestionResponseWithQuestions()));
+    }
+
+    @Test
+    void shouldCreateAuditExtensionsWithAlertFromSAAQuestionResponseWithAlert() {
+        assertEquals(
+                Map.of("repeatAttemptAlert", true),
+                createResponseReceivedAuditEventExtensions(getExperianQuestionResponseWithAlert()));
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/domain/QuestionsResponseTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/domain/QuestionsResponseTest.java
@@ -6,6 +6,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.util.Collections;
+
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -97,6 +99,59 @@ class QuestionsResponseTest {
             result.setAuthenticationResult(null);
 
             assertFalse(response.isThinFile());
+        }
+    }
+
+    @Nested
+    class RepeatAttemptAlert {
+        @Test
+        void shouldReturnTrueWhenResponseHasRepeatAttemptAlert() {
+            QuestionsResponse response = new QuestionsResponse();
+            KbvResult result = new KbvResult();
+            KbvAlert alert = new KbvAlert();
+            alert.setCode("U501");
+            alert.setText("Applicant has previously requested authentication");
+            result.setAlerts(Collections.singletonList(alert));
+            response.setResults(result);
+
+            assertTrue(response.isRepeatAttemptAlert());
+        }
+
+        @Test
+        void shouldReturnFalseWhenResponseAlertsEmpty() {
+            QuestionsResponse response = new QuestionsResponse();
+            KbvResult result = new KbvResult();
+            result.setAlerts(Collections.emptyList());
+            response.setResults(result);
+
+            assertFalse(response.isRepeatAttemptAlert());
+        }
+
+        @Test
+        void shouldReturnFalseWhenResponseAlertsDoesNotContainAlertWithAlertCode() {
+            QuestionsResponse response = new QuestionsResponse();
+            KbvResult result = new KbvResult();
+            KbvAlert alert = new KbvAlert();
+            alert.setCode("Not the correct code");
+            alert.setText("Applicant has previously requested authentication");
+            result.setAlerts(Collections.singletonList(alert));
+            response.setResults(result);
+
+            assertFalse(response.isRepeatAttemptAlert());
+        }
+
+        @Test
+        void shouldReturnFalseWhenResponseAlertsIsNull() {
+            QuestionsResponse response = new QuestionsResponse();
+            KbvResult result = new KbvResult();
+            response.setResults(result);
+            assertFalse(response.isRepeatAttemptAlert());
+        }
+
+        @Test
+        void shouldReturnFalseWhenResponseResultsIsNull() {
+            QuestionsResponse response = new QuestionsResponse();
+            assertFalse(response.isRepeatAttemptAlert());
         }
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/util/TestDataCreator.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/util/TestDataCreator.java
@@ -3,6 +3,7 @@ package uk.gov.di.ipv.cri.kbv.api.util;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.Address;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.AddressType;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentity;
+import uk.gov.di.ipv.cri.kbv.api.domain.KbvAlert;
 import uk.gov.di.ipv.cri.kbv.api.domain.KbvQuestion;
 import uk.gov.di.ipv.cri.kbv.api.domain.KbvQuestionAnswerSummary;
 import uk.gov.di.ipv.cri.kbv.api.domain.KbvQuestionOptions;
@@ -15,6 +16,7 @@ import uk.gov.di.ipv.cri.kbv.api.domain.QuestionsResponse;
 
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
+import java.util.Collections;
 import java.util.List;
 
 public class TestDataCreator {
@@ -96,6 +98,31 @@ public class TestDataCreator {
         questionsResponse.setAuthReference("authrefno");
         questionsResponse.setUniqueReference("urn");
         questionsResponse.setQuestions(kbvQuestions);
+
+        return questionsResponse;
+    }
+
+    public static QuestionsResponse getExperianQuestionResponseWithQuestions() {
+        KbvQuestion[] questions = new KbvQuestion[] {getQuestionOne(), getQuestionTwo()};
+        QuestionsResponse questionsResponse = getExperianQuestionResponse(questions);
+
+        KbvResult kbvResult = new KbvResult();
+        kbvResult.setOutcome("Authentication Questions returned");
+        kbvResult.setNextTransId(new String[] {"RTQ"});
+        questionsResponse.setResults(kbvResult);
+        return questionsResponse;
+    }
+
+    public static QuestionsResponse getExperianQuestionResponseWithAlert() {
+        QuestionsResponse questionsResponse = getExperianQuestionResponseWithQuestions();
+        KbvResult kbvResult = questionsResponse.getResults();
+
+        KbvAlert alert = new KbvAlert();
+        alert.setCode("U501");
+        alert.setText("Applicant has previously requested authentication");
+
+        kbvResult.setAlerts(Collections.singletonList(alert));
+        questionsResponse.setResults(kbvResult);
 
         return questionsResponse;
     }


### PR DESCRIPTION
## Proposed changes

### What changed

If a user has passed the attempt threshold, upon trying again an Alert will be included in the SAA response along with the question. We want to include when an alert is present in the RESPONSE_RECEIVED audit event.

- Added KBVAlert to mapped response from Experian to handle alerts being included in the results.
- Refactored audit extension code to also include repeatAttemptAlert in the `experianIiqResponse` block for RESPONSE_RECEIVED audit events.
- Added units tests for scenarios.
- Added integration test for SAA repeatAttemptAlert.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

So that whenever a user is trying to access experian kbv more than the allowed attempts we can monitor and investigate potential fraud attempts in real-time.

The alert message for screenless clients will be sent along with the questions, except where  further questions are output and the alert message has already been sent in the output XML.  There is no concept of `before questions….` and `with decision`. Only the screened IIQ product will display the alert `before questions ....` or `with decision`.

```
<Results>
    <Outcome>Authentication Questions returned</Outcome>
    <Alerts>
        <Alerts>
            <Code>U501</Code>
            <Text>Applicant has previously requested authentication</Text>
        </Alerts>
    </Alerts>
    <NextTransId>
        <string>RTQ</string>
    </NextTransId>
</Results>
```

### Issue tracking
- [OJ-2771](https://govukverify.atlassian.net/browse/OJ-2771)


[OJ-2771]: https://govukverify.atlassian.net/browse/OJ-2771?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ