### PR TITLE
IPS-1155: Refine alarms

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -56,9 +56,9 @@ Conditions:
     - !Equals [ !Ref Environment, staging ]
     - !Equals [ !Ref Environment, integration ]
   IsDevEnvironment: !Equals [!Ref Environment, dev]
-  IsProdEnvironment: !Equals [!Ref Environment, production]
   IsNotDevEnvironment: !Not [!Condition IsDevEnvironment]
   UseSecretPrefix: !Not [!Equals [!Ref SecretPrefix, "none"]]
+  UseCanaryDeploymentAlarms: !Not [ !Equals [ !Ref LambdaDeploymentPreference, AllAtOnce ]]
 
 Globals:
   Function:
@@ -375,9 +375,10 @@ Resources:
           SQS_AUDIT_EVENT_QUEUE_URL:
             Fn::ImportValue: !Sub ${TxmaStackName}-AuditEventQueueUrl
       DeploymentPreference:
-        Alarms:
-          - !Ref KBVQuestionFunctionCanaryErrors
-          - !Ref KBVQuestionFunctionCanary5xxErrors
+        Alarms: !If
+          - UseCanaryDeploymentAlarms
+          - [!Ref KBVQuestionFunctionCanaryErrors, !Ref KBVQuestionFunction5xxCanaryErrors]
+          - [!Ref AWS::NoValue]
       Policies:
         - AWSLambdaBasicExecutionRole
         - AWSXrayWriteOnlyAccess
@@ -457,9 +458,10 @@ Resources:
           SQS_AUDIT_EVENT_QUEUE_URL:
             Fn::ImportValue: !Sub ${TxmaStackName}-AuditEventQueueUrl
       DeploymentPreference:
-        Alarms:
-          - !Ref KBVAnswerFunctionCanaryErrors
-          - !Ref KBVAnswerFunctionCanary5xxErrors
+        Alarms: !If
+          - UseCanaryDeploymentAlarms
+          - [!Ref KBVAnswerFunctionCanaryErrors, !Ref KBVAnswerFunction5xxCanaryErrors]
+          - [!Ref AWS::NoValue]
       Policies:
         - AWSLambdaBasicExecutionRole
         - AWSXrayWriteOnlyAccess
@@ -535,9 +537,10 @@ Resources:
           SQS_AUDIT_EVENT_QUEUE_URL:
             Fn::ImportValue: !Sub ${TxmaStackName}-AuditEventQueueUrl
       DeploymentPreference:
-        Alarms:
-          - !Ref KBVAbandonFunctionCanaryErrors
-          - !Ref KBVAbandonFunctionCanary5xxErrors
+        Alarms: !If
+          - UseCanaryDeploymentAlarms
+          - [!Ref KBVAbandonFunctionCanaryErrors, !Ref KBVAbandonFunction5xxCanaryErrors]
+          - [!Ref AWS::NoValue]
       Policies:
         - AWSLambdaBasicExecutionRole
         - AWSXrayWriteOnlyAccess
@@ -594,9 +597,10 @@ Resources:
           SQS_AUDIT_EVENT_QUEUE_URL:
             Fn::ImportValue: !Sub ${TxmaStackName}-AuditEventQueueUrl
       DeploymentPreference:
-        Alarms:
-          - !Ref IssueCredentialFunctionCanaryErrors
-          - !Ref IssueCredentialFunctionCanary5xxErrors
+        Alarms: !If
+          - UseCanaryDeploymentAlarms
+          - [!Ref IssueCredentialFunctionCanaryErrors, !Ref IssueCredentialFunction5xxCanaryErrors]
+          - [!Ref AWS::NoValue]
       Policies:
         - AWSLambdaBasicExecutionRole
         - AWSXrayWriteOnlyAccess
@@ -924,14 +928,15 @@ Resources:
             Period: 300
             Stat: Sum
 
-  KBVQuestionFunctionCanary5xxErrors:
+  KBVQuestionFunction5xxCanaryErrors:
     Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
     Properties:
       ActionsEnabled: false
       AlarmActions:
-        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue] # Only sends notifications in prod, where LambdaCanaryDeployment is set. See https://github.com/govuk-one-login/identity-common-infra/blob/main/terraform/orange/kbv/production/pipelines/main.tf
+        - !ImportValue platform-alarm-warning-alert-topic
       OKActions:
-        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
+        - !ImportValue platform-alarm-warning-alert-topic
       AlarmDescription: !Sub "KBVQuestionFunction Lambda returning 5xx response."
       Namespace: AWS/ApiGateway
       MetricName: 5XXError
@@ -954,12 +959,13 @@ Resources:
 
   KBVQuestionFunctionCanaryErrors:
     Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
     Properties:
       ActionsEnabled: false
       AlarmActions:
-        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
+        - !ImportValue platform-alarm-warning-alert-topic
       OKActions:
-        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
+        - !ImportValue platform-alarm-warning-alert-topic
       AlarmDescription: !Sub "KBVQuestionFunction Lambda error."
       MetricName: Errors
       Dimensions:
@@ -978,14 +984,15 @@ Resources:
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
 
-  KBVAnswerFunctionCanary5xxErrors:
+  KBVAnswerFunction5xxCanaryErrors:
     Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
     Properties:
       ActionsEnabled: false
       AlarmActions:
-        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
+        - !ImportValue platform-alarm-warning-alert-topic
       OKActions:
-        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
+        - !ImportValue platform-alarm-warning-alert-topic
       AlarmDescription: !Sub "KBVAnswerFunction Lambda returning 5xx response."
       Namespace: AWS/ApiGateway
       MetricName: 5XXError
@@ -1008,12 +1015,13 @@ Resources:
 
   KBVAnswerFunctionCanaryErrors:
     Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
     Properties:
       ActionsEnabled: false
       AlarmActions:
-        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
+        - !ImportValue platform-alarm-warning-alert-topic
       OKActions:
-        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
+        - !ImportValue platform-alarm-warning-alert-topic
       AlarmDescription: !Sub "KBVAnswerFunction Lambda error."
       MetricName: Errors
       Dimensions:
@@ -1032,14 +1040,15 @@ Resources:
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
       
-  KBVAbandonFunctionCanary5xxErrors:
+  KBVAbandonFunction5xxCanaryErrors:
     Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
     Properties:
       ActionsEnabled: false
       AlarmActions:
-        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
+        - !ImportValue platform-alarm-warning-alert-topic
       OKActions:
-        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
+        - !ImportValue platform-alarm-warning-alert-topic
       AlarmDescription: !Sub "KBVAbandonFunction Lambda returning 5xx response."
       Namespace: AWS/ApiGateway
       MetricName: 5XXError
@@ -1062,12 +1071,13 @@ Resources:
 
   KBVAbandonFunctionCanaryErrors:
     Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
     Properties:
       ActionsEnabled: false
       AlarmActions:
-        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
+        - !ImportValue platform-alarm-warning-alert-topic
       OKActions:
-        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
+        - !ImportValue platform-alarm-warning-alert-topic
       AlarmDescription: !Sub "KBVAbandon Lambda error."
       MetricName: Errors
       Dimensions:
@@ -1086,14 +1096,15 @@ Resources:
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
 
-  IssueCredentialFunctionCanary5xxErrors:
+  IssueCredentialFunction5xxCanaryErrors:
     Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
     Properties:
       ActionsEnabled: false
       AlarmActions:
-        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
+        - !ImportValue platform-alarm-warning-alert-topic
       OKActions:
-        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
+        - !ImportValue platform-alarm-warning-alert-topic
       AlarmDescription: !Sub "IssueCredentialFunction Lambda returning 5xx response."
       Namespace: AWS/ApiGateway
       MetricName: 5XXError
@@ -1116,12 +1127,13 @@ Resources:
 
   IssueCredentialFunctionCanaryErrors:
     Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
     Properties:
       ActionsEnabled: false
       AlarmActions:
-        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
+        - !ImportValue platform-alarm-warning-alert-topic
       OKActions:
-        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
+        - !ImportValue platform-alarm-warning-alert-topic
       AlarmDescription: !Sub "IssueCredential Lambda error."
       MetricName: Errors
       Dimensions:

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -938,6 +938,7 @@ Resources:
       OKActions:
         - !ImportValue platform-alarm-warning-alert-topic
       AlarmDescription: !Sub "KBVQuestionFunction Lambda returning 5xx response."
+      AlarmName: !Sub ${AWS::StackName}-${Environment}-KBVQuestionFunction5xxCanaryError
       Namespace: AWS/ApiGateway
       MetricName: 5XXError
       Dimensions:
@@ -967,6 +968,7 @@ Resources:
       OKActions:
         - !ImportValue platform-alarm-warning-alert-topic
       AlarmDescription: !Sub "KBVQuestionFunction Lambda error."
+      AlarmName: !Sub ${AWS::StackName}-${Environment}-KBVQuestionFunctionCanaryError
       MetricName: Errors
       Dimensions:
         - Name: Resource
@@ -994,6 +996,7 @@ Resources:
       OKActions:
         - !ImportValue platform-alarm-warning-alert-topic
       AlarmDescription: !Sub "KBVAnswerFunction Lambda returning 5xx response."
+      AlarmName: !Sub ${AWS::StackName}-${Environment}-KBVAnswerFunction5xxCanaryError
       Namespace: AWS/ApiGateway
       MetricName: 5XXError
       Dimensions:
@@ -1023,6 +1026,7 @@ Resources:
       OKActions:
         - !ImportValue platform-alarm-warning-alert-topic
       AlarmDescription: !Sub "KBVAnswerFunction Lambda error."
+      AlarmName: !Sub ${AWS::StackName}-${Environment}-KBVAnswerFunctionCanaryError
       MetricName: Errors
       Dimensions:
         - Name: Resource
@@ -1050,6 +1054,7 @@ Resources:
       OKActions:
         - !ImportValue platform-alarm-warning-alert-topic
       AlarmDescription: !Sub "KBVAbandonFunction Lambda returning 5xx response."
+      AlarmName: !Sub ${AWS::StackName}-${Environment}-KBVAbandonFunction5xxCanaryError
       Namespace: AWS/ApiGateway
       MetricName: 5XXError
       Dimensions:
@@ -1079,6 +1084,7 @@ Resources:
       OKActions:
         - !ImportValue platform-alarm-warning-alert-topic
       AlarmDescription: !Sub "KBVAbandon Lambda error."
+      AlarmName: !Sub ${AWS::StackName}-${Environment}-KBVAbandonFunctionCanaryError
       MetricName: Errors
       Dimensions:
         - Name: Resource
@@ -1106,6 +1112,7 @@ Resources:
       OKActions:
         - !ImportValue platform-alarm-warning-alert-topic
       AlarmDescription: !Sub "IssueCredentialFunction Lambda returning 5xx response."
+      AlarmName: !Sub ${AWS::StackName}-${Environment}-IssueCredentialFunction5xxCanaryError
       Namespace: AWS/ApiGateway
       MetricName: 5XXError
       Dimensions:
@@ -1135,6 +1142,7 @@ Resources:
       OKActions:
         - !ImportValue platform-alarm-warning-alert-topic
       AlarmDescription: !Sub "IssueCredential Lambda error."
+      AlarmName: !Sub ${AWS::StackName}-${Environment}-IssueCredentialFunctionCanaryError
       MetricName: Errors
       Dimensions:
         - Name: Resource


### PR DESCRIPTION
### What changed

- Added `UseCanaryDeploymentAlarms` condition

### Why did it change

Only if the if the strategy is not `AllAtOnce` should:
- Canary alarms be used to roll back deployments
- Canary alarms be deployed 

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-1155](https://govukverify.atlassian.net/browse/IPS-1155)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[IPS-1155]: https://govukverify.atlassian.net/browse/IPS-1155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ