### PR TITLE
OJ-785: Fix sonar cloud code smells in abandon handler test

### DIFF
--- a/lambdas/abandon/src/test/java/uk/gov/di/ipv/cri/kbv/api/handler/AbandonKbvHandlerTest.java
+++ b/lambdas/abandon/src/test/java/uk/gov/di/ipv/cri/kbv/api/handler/AbandonKbvHandlerTest.java
@@ -28,7 +28,6 @@ import static org.apache.logging.log4j.Level.ERROR;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
@@ -113,9 +112,12 @@ class AbandonKbvHandlerTest {
         when(mockEventProbe.counterMetric(ABANDON_KBV)).thenReturn(mockEventProbe);
 
         doNothing().when(mockSessionService).createAuthorizationCode(mockSessionItem);
-        doThrow(SqsException.class).when(mockAuditService).sendAuditEvent(anyString(), any());
+        doThrow(SqsException.class)
+                .when(mockAuditService)
+                .sendAuditEvent(eq("ABANDONED"), any(AuditEventContext.class));
 
         var result = abandonKbvHandler.handleRequest(input, mock(Context.class));
+        assertEquals(HttpStatusCode.BAD_REQUEST, result.getStatusCode());
 
         verify(mockKbvStorageService)
                 .getKBVItem(UUID.fromString(sessionHeader.get(HEADER_SESSION_ID)));
@@ -125,6 +127,8 @@ class AbandonKbvHandlerTest {
 
         verify(mockEventProbe).log(any(ERROR.getClass()), any(SqsException.class));
         verify(mockEventProbe).counterMetric(ABANDON_KBV, 0d);
+
+        verify(mockAuditService).sendAuditEvent(eq("ABANDONED"), any(AuditEventContext.class));
     }
 
     @Test


### PR DESCRIPTION
### What changed
Code issue - Remove this unused "result" local variable
Updated the sendAuditEvent in the abandon unit test to include the event name rather than anyString and asserted on the result variable status code.

### Why did it change
The following issues were highlighted in Sonarcloud which helps us identify areas of code that have issues that may make it hard to maintain:
Issue 1: Code issue - Remove this unused "result" local variable.

### Issue tracking
[OJ-785](https://govukverify.atlassian.net/browse/OJ-785)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[OJ-785]: https://govukverify.atlassian.net/browse/OJ-785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ