### PR TITLE
Add "NOSONAR"

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/gateway/KeyStoreLoader.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/gateway/KeyStoreLoader.java
@@ -21,7 +21,8 @@ public class KeyStoreLoader {
 
     private String getKeyStorePath() throws IOException {
         try {
-            File file = Files.createTempFile(UUID.randomUUID().toString(), ".tmp").toFile();
+            File file =
+                    Files.createTempFile(UUID.randomUUID().toString(), ".tmp").toFile(); // NOSONAR
             Path tempFile = file.toPath();
             Files.write(
                     tempFile,


### PR DESCRIPTION
## Proposed changes

### What changed and why
Fixes [java:S5443](https://sonarcloud.io/organizations/govuk-one-login/rules?open=java%3AS5443&rule_key=java%3AS5443) 

Sonar does a hard check for directories like /tmp and it does not consider the AWS Lambda environment as part of its check. Since tmp is the only usable space we have, this PR add a comment to ignore the Sonar warning. 

There are occurrences of this being done in other repos: https://github.com/search?q=org%3Agovuk-one-login+%2F%2F+NOSONAR&type=code

### Issue tracking
- [OJ-2829](https://govukverify.atlassian.net/browse/OJ-2829)

[OJ-2829]: https://govukverify.atlassian.net/browse/OJ-2829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ