### PR TITLE
Revert "IPS-1087: Update lambda canaries"

### DIFF
--- a/infrastructure/lambda/private-api.yaml
+++ b/infrastructure/lambda/private-api.yaml
@@ -121,7 +121,7 @@ paths:
         type: "aws_proxy"
         httpMethod: "POST"
         uri:
-          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${KBVQuestionFunction.Arn}:live/invocations"
+          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${KBVQuestionFunction.Arn}/invocations"
         passthroughBehavior: "when_no_match"
 
   /answer:
@@ -155,7 +155,7 @@ paths:
         type: "aws_proxy"
         httpMethod: "POST"
         uri:
-          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${KBVAnswerFunction.Arn}:live/invocations"
+          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${KBVAnswerFunction.Arn}/invocations"
         passthroughBehavior: "when_no_match"
 
   /abandon:
@@ -182,7 +182,7 @@ paths:
         type: "aws_proxy"
         httpMethod: "POST"
         uri:
-          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${KBVAbandonFunction.Arn}:live/invocations"
+          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${KBVAbandonFunction.Arn}/invocations"
         passthroughBehavior: "when_no_match"
 components:
   parameters:

--- a/infrastructure/lambda/public-api.yaml
+++ b/infrastructure/lambda/public-api.yaml
@@ -118,7 +118,7 @@ paths:
       x-amazon-apigateway-integration:
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${IssueCredentialFunction.Arn}:live/invocations
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${IssueCredentialFunction.Arn}/invocations
         responses:
           default:
             statusCode: "200"

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -813,28 +813,28 @@ Resources:
     Type: AWS::Lambda::Permission
     Properties:
       Action: lambda:InvokeFunction
-      FunctionName: !Ref KBVQuestionFunction.Alias
+      FunctionName: !GetAtt KBVQuestionFunction.Arn
       Principal: apigateway.amazonaws.com
 
   KBVAnswerFunctionPermission:
     Type: AWS::Lambda::Permission
     Properties:
       Action: lambda:InvokeFunction
-      FunctionName: !Ref KBVAnswerFunction.Alias
+      FunctionName: !GetAtt KBVAnswerFunction.Arn
       Principal: apigateway.amazonaws.com
 
   KBVAbandonFunctionPermission:
     Type: AWS::Lambda::Permission
     Properties:
       Action: lambda:InvokeFunction
-      FunctionName: !Ref KBVAbandonFunction.Alias
+      FunctionName: !GetAtt KBVAbandonFunction.Arn
       Principal: apigateway.amazonaws.com
 
   IssueCredentialFunctionPermission:
     Type: AWS::Lambda::Permission
     Properties:
       Action: lambda:InvokeFunction
-      FunctionName: !Ref IssueCredentialFunction.Alias
+      FunctionName: !GetAtt IssueCredentialFunction.Arn
       Principal: apigateway.amazonaws.com
 
   LoggingKmsKey:
@@ -972,7 +972,7 @@ Resources:
       MetricName: Errors
       Dimensions:
         - Name: Resource
-          Value: !Sub ${KBVQuestionFunction}:live
+          Value: !Sub "${AWS::StackName}-KBVQuestionFunction:live"
         - Name: FunctionName
           Value: !Ref KBVQuestionFunction
         - Name: ExecutedVersion
@@ -1030,7 +1030,7 @@ Resources:
       MetricName: Errors
       Dimensions:
         - Name: Resource
-          Value: !Sub ${KBVAnswerFunction}:live
+          Value: !Sub "${AWS::StackName}-KBVAnswerFunction:live"
         - Name: FunctionName
           Value: !Ref KBVAnswerFunction
         - Name: ExecutedVersion
@@ -1088,7 +1088,7 @@ Resources:
       MetricName: Errors
       Dimensions:
         - Name: Resource
-          Value: !Sub ${KBVAbandonFunction}:live
+          Value: !Sub "${AWS::StackName}-KBVAbandonFunction:live"
         - Name: FunctionName
           Value: !Ref KBVAbandonFunction
         - Name: ExecutedVersion
@@ -1146,7 +1146,7 @@ Resources:
       MetricName: Errors
       Dimensions:
         - Name: Resource
-          Value: !Sub ${IssueCredentialFunction}:live
+          Value: !Sub "${AWS::StackName}-IssueCredentialFunction:live"
         - Name: FunctionName
           Value: !Ref IssueCredentialFunction
         - Name: ExecutedVersion


### PR DESCRIPTION
Reverts the following changes:

> ### What changed
> 
> - Point apispec to live alias of the lambdas
> - Edit the lambda permissions to allow apigw to invoke the live alias
> - Update resource names for alarms
> 
> ### Why did it change
> 
> - Ensure apigw has permissions to invoke live alias of lambdas
> 
> ### Issue tracking
> <!-- List any related Jira tickets or GitHub issues -->
> <!-- List any related ADRs or RFCs -->
> <!-- Delete/copy as appropriate -->
> 
> - [IPS-1087](https://govukverify.atlassian.net/browse/IPS-1087)

[IPS-1087]: https://govukverify.atlassian.net/browse/IPS-1087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ