### PR TITLE
Revert "IPS-1213: Lambda canaries"

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -17,7 +17,7 @@ Parameters:
       - "staging"
       - "integration"
       - "production"
-    ConstraintDescription: Must be dev, build, staging, integration or production
+    ConstraintDescription: must be dev, build, staging, integration or production
   LambdaDeploymentPreference:
     Description: "Specifies the configuration to enable gradual Lambda deployments. It can be used to set deployment type, and also allows skipping canary deployment by setting to 'AllAtOnce'."
     Type: String
@@ -837,34 +837,6 @@ Resources:
       FunctionName: !Ref IssueCredentialFunction.Alias
       Principal: apigateway.amazonaws.com
 
-  KBVQuestionFunctionPermissionAlias:
-    Type: AWS::Lambda::Permission
-    Properties:
-      Action: lambda:InvokeFunction
-      FunctionName: !Ref KBVQuestionFunction.Alias
-      Principal: apigateway.amazonaws.com
-
-  KBVAnswerFunctionPermissionAlias:
-    Type: AWS::Lambda::Permission
-    Properties:
-      Action: lambda:InvokeFunction
-      FunctionName: !Ref KBVAnswerFunction.Alias
-      Principal: apigateway.amazonaws.com
-
-  KBVAbandonFunctionPermissionAlias:
-    Type: AWS::Lambda::Permission
-    Properties:
-      Action: lambda:InvokeFunction
-      FunctionName: !Ref KBVAbandonFunction.Alias
-      Principal: apigateway.amazonaws.com
-
-  IssueCredentialFunctionPermissionAlias:
-    Type: AWS::Lambda::Permission
-    Properties:
-      Action: lambda:InvokeFunction
-      FunctionName: !Ref IssueCredentialFunction.Alias
-      Principal: apigateway.amazonaws.com
-
   LoggingKmsKey:
     Type: AWS::KMS::Key
     Properties:
@@ -981,7 +953,7 @@ Resources:
       Statistic: Sum
       Unit: Count
       Period: 60
-      EvaluationPeriods: 3
+      EvaluationPeriods: 1
       Threshold: 1
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
@@ -1039,7 +1011,7 @@ Resources:
       Statistic: Sum
       Unit: Count
       Period: 60
-      EvaluationPeriods: 3
+      EvaluationPeriods: 1
       Threshold: 1
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
@@ -1097,7 +1069,7 @@ Resources:
       Statistic: Sum
       Unit: Count
       Period: 60
-      EvaluationPeriods: 3
+      EvaluationPeriods: 1
       Threshold: 1
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
@@ -1155,7 +1127,7 @@ Resources:
       Statistic: Sum
       Unit: Count
       Period: 60
-      EvaluationPeriods: 3
+      EvaluationPeriods: 1
       Threshold: 1
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching


### PR DESCRIPTION
Reverts govuk-one-login/ipv-cri-kbv-api#422

- This was the fix to add extra permissions for APIGW to invoke the lambda alias
- However, the traffic tests still failed
- This PR (as well as https://github.com/govuk-one-login/ipv-cri-kbv-api/pull/423) will be reverted for now to unblock the pipeline