### PR TITLE
Revert "Revert "Revert "IPS-1087: Update lambda canaries"""

### DIFF
--- a/infrastructure/lambda/private-api.yaml
+++ b/infrastructure/lambda/private-api.yaml
@@ -121,7 +121,7 @@ paths:
         type: "aws_proxy"
         httpMethod: "POST"
         uri:
-          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${KBVQuestionFunction.Arn}:live/invocations"
+          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${KBVQuestionFunction.Arn}/invocations"
         passthroughBehavior: "when_no_match"
 
   /answer:
@@ -155,7 +155,7 @@ paths:
         type: "aws_proxy"
         httpMethod: "POST"
         uri:
-          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${KBVAnswerFunction.Arn}:live/invocations"
+          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${KBVAnswerFunction.Arn}/invocations"
         passthroughBehavior: "when_no_match"
 
   /abandon:
@@ -182,7 +182,7 @@ paths:
         type: "aws_proxy"
         httpMethod: "POST"
         uri:
-          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${KBVAbandonFunction.Arn}:live/invocations"
+          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${KBVAbandonFunction.Arn}/invocations"
         passthroughBehavior: "when_no_match"
 components:
   parameters:

--- a/infrastructure/lambda/public-api.yaml
+++ b/infrastructure/lambda/public-api.yaml
@@ -118,7 +118,7 @@ paths:
       x-amazon-apigateway-integration:
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${IssueCredentialFunction.Arn}:live/invocations
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${IssueCredentialFunction.Arn}/invocations
         responses:
           default:
             statusCode: "200"

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -813,28 +813,28 @@ Resources:
     Type: AWS::Lambda::Permission
     Properties:
       Action: lambda:InvokeFunction
-      FunctionName: !Ref KBVQuestionFunction.Alias
+      FunctionName: !GetAtt KBVQuestionFunction.Arn
       Principal: apigateway.amazonaws.com
 
   KBVAnswerFunctionPermission:
     Type: AWS::Lambda::Permission
     Properties:
       Action: lambda:InvokeFunction
-      FunctionName: !Ref KBVAnswerFunction.Alias
+      FunctionName: !GetAtt KBVAnswerFunction.Arn
       Principal: apigateway.amazonaws.com
 
   KBVAbandonFunctionPermission:
     Type: AWS::Lambda::Permission
     Properties:
       Action: lambda:InvokeFunction
-      FunctionName: !Ref KBVAbandonFunction.Alias
+      FunctionName: !GetAtt KBVAbandonFunction.Arn
       Principal: apigateway.amazonaws.com
 
   IssueCredentialFunctionPermission:
     Type: AWS::Lambda::Permission
     Properties:
       Action: lambda:InvokeFunction
-      FunctionName: !Ref IssueCredentialFunction.Alias
+      FunctionName: !GetAtt IssueCredentialFunction.Arn
       Principal: apigateway.amazonaws.com
 
   KBVQuestionFunctionPermissionAlias:
@@ -1000,7 +1000,7 @@ Resources:
       MetricName: Errors
       Dimensions:
         - Name: Resource
-          Value: !Sub ${KBVQuestionFunction}:live
+          Value: !Sub "${AWS::StackName}-KBVQuestionFunction:live"
         - Name: FunctionName
           Value: !Ref KBVQuestionFunction
         - Name: ExecutedVersion
@@ -1058,7 +1058,7 @@ Resources:
       MetricName: Errors
       Dimensions:
         - Name: Resource
-          Value: !Sub ${KBVAnswerFunction}:live
+          Value: !Sub "${AWS::StackName}-KBVAnswerFunction:live"
         - Name: FunctionName
           Value: !Ref KBVAnswerFunction
         - Name: ExecutedVersion
@@ -1116,7 +1116,7 @@ Resources:
       MetricName: Errors
       Dimensions:
         - Name: Resource
-          Value: !Sub ${KBVAbandonFunction}:live
+          Value: !Sub "${AWS::StackName}-KBVAbandonFunction:live"
         - Name: FunctionName
           Value: !Ref KBVAbandonFunction
         - Name: ExecutedVersion
@@ -1174,7 +1174,7 @@ Resources:
       MetricName: Errors
       Dimensions:
         - Name: Resource
-          Value: !Sub ${IssueCredentialFunction}:live
+          Value: !Sub "${AWS::StackName}-IssueCredentialFunction:live"
         - Name: FunctionName
           Value: !Ref IssueCredentialFunction
         - Name: ExecutedVersion


### PR DESCRIPTION
Reverts govuk-one-login/ipv-cri-kbv-api#423

- Revert lambda alias changes
- https://github.com/govuk-one-login/ipv-cri-kbv-api/pull/422 failed traffic tests so both these PRs are being reverted to unblock the pipeline
- See https://gds.slack.com/archives/C04RH15THAL/p1730721625257609 for context