### PR TITLE
OJ-2255: Add localdev environment to the template

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -1,6 +1,9 @@
 name: Check PR
 
-on: pull_request
+on:
+  workflow_dispatch:
+  pull_request:
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/clean-up-deployments.yml
+++ b/.github/workflows/clean-up-deployments.yml
@@ -26,7 +26,7 @@ jobs:
           aws-region: eu-west-2
 
       - name: Get stale preview stacks
-        uses: govuk-one-login/github-actions/sam/get-stale-stacks@cd7d35dde348251237efbbaee5345e95adef0321
+        uses: govuk-one-login/github-actions/sam/get-stale-stacks@d201191485b645ec856a34e5ca48636cf97b2574
         with:
           threshold-days: 14
           stack-name-filter: preview-kbv-api
@@ -38,7 +38,7 @@ jobs:
 
       - name: Delete stacks
         if: ${{ env.STACKS != null }}
-        uses: govuk-one-login/github-actions/sam/delete-stacks@cd7d35dde348251237efbbaee5345e95adef0321
+        uses: govuk-one-login/github-actions/sam/delete-stacks@d201191485b645ec856a34e5ca48636cf97b2574
         with:
           stack-names: ${{ env.STACKS }}
           verbose: true

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run pre-commit
-        uses: govuk-one-login/github-actions/code-quality/run-pre-commit@cd7d35dde348251237efbbaee5345e95adef0321
+        uses: govuk-one-login/github-actions/code-quality/run-pre-commit@d201191485b645ec856a34e5ca48636cf97b2574
         with:
           all-files: true
 

--- a/.github/workflows/delete-deployment.yml
+++ b/.github/workflows/delete-deployment.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Get stack name
-        uses: govuk-one-login/github-actions/beautify-branch-name@cd7d35dde348251237efbbaee5345e95adef0321
+        uses: govuk-one-login/github-actions/beautify-branch-name@d201191485b645ec856a34e5ca48636cf97b2574
         id: get-stack-name
         with:
           usage: Stack name
@@ -29,7 +29,7 @@ jobs:
           verbose: false
 
       - name: Delete stack
-        uses: govuk-one-login/github-actions/sam/delete-stacks@cd7d35dde348251237efbbaee5345e95adef0321
+        uses: govuk-one-login/github-actions/sam/delete-stacks@d201191485b645ec856a34e5ca48636cf97b2574
         with:
           stack-names: ${{ steps.get-stack-name.outputs.pretty-branch-name }}
           aws-role-arn: ${{ vars.DEPLOYMENT_ROLE_ARN }}

--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -84,5 +84,5 @@ jobs:
             cri:application=Orange
             cri:deployment-source=github-actions
           parameters: |
-            Environment=dev
+            Environment=localdev
             SecretPrefix=pre-merge-test

--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -1,4 +1,4 @@
-name: Preview
+name: Deploy preview
 
 on:
   workflow_dispatch:
@@ -23,6 +23,9 @@ jobs:
     name: Build SAM app
     runs-on: ubuntu-latest
     permissions: {}
+    outputs:
+      cache-key: ${{ steps.build.outputs.cache-key }}
+      cache-restore-keys: ${{ steps.build.outputs.cache-restore-keys }}
     steps:
       - name: Pull repository
         uses: actions/checkout@v4
@@ -40,12 +43,13 @@ jobs:
           cache: gradle
 
       - name: Build SAM application
-        uses: govuk-one-login/github-actions/sam/build-application@cd7d35dde348251237efbbaee5345e95adef0321
+        uses: govuk-one-login/github-actions/sam/build-application@d201191485b645ec856a34e5ca48636cf97b2574
         id: build
         with:
           template: infrastructure/lambda/template.yaml
-          cache-key: kbv-api
           pull-repository: false
+          cache-name: kbv-api
+          source-dir: lambdas
 
   deploy:
     name: Deploy stack
@@ -63,13 +67,14 @@ jobs:
       stack-outputs: ${{ steps.deploy.outputs.stack-outputs }}
     steps:
       - name: Deploy stack
-        uses: govuk-one-login/github-actions/sam/deploy-stack@cd7d35dde348251237efbbaee5345e95adef0321
+        uses: govuk-one-login/github-actions/sam/deploy-stack@d201191485b645ec856a34e5ca48636cf97b2574
         id: deploy
         with:
           sam-deployment-bucket: ${{ vars.DEPLOYMENT_ARTIFACTS_BUCKET }}
           aws-role-arn: ${{ vars.DEPLOYMENT_ROLE_ARN }}
           stack-name-prefix: preview-kbv-api
-          cache-key: kbv-api
+          cache-key: ${{ needs.build.outputs.cache-key }}
+          cache-restore-keys: ${{ needs.build.outputs.cache-restore-keys }}
           s3-prefix: preview
           pull-repository: true
           delete-failed-stack: true

--- a/.github/workflows/package-for-build.yml
+++ b/.github/workflows/package-for-build.yml
@@ -1,17 +1,17 @@
-name: Deploy to dev
+name: Package for Build
+
 on:
   push:
-    branches:
-      - main
-  workflow_dispatch: # deploy manually
+    branches: [main]
 
 jobs:
   deploy:
-    name: Deploy to dev
+    name: Package for build
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
       AWS_REGION: eu-west-2
+      ENVIRONMENT: build
     permissions:
       id-token: write
       contents: read
@@ -41,7 +41,7 @@ jobs:
       - name: Assume temporary AWS role
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          role-to-assume: ${{ secrets.DEV_GH_ACTIONS_ROLE_ARN }}
+          role-to-assume: ${{ secrets.BUILD_GH_ACTIONS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: SAM Validate
@@ -55,6 +55,6 @@ jobs:
       - name: Deploy SAM app
         uses: govuk-one-login/devplatform-upload-action@v3.9.1
         with:
-          artifact-bucket-name: ${{ secrets.DEV_ARTIFACT_SOURCE_BUCKET_NAME }}
-          signing-profile-name: ${{ secrets.DEV_SIGNING_PROFILE_NAME }}
+          artifact-bucket-name: ${{ secrets.BUILD_ARTIFACT_SOURCE_BUCKET_NAME }}
+          signing-profile-name: ${{ secrets.BUILD_SIGNING_PROFILE_NAME }}
           working-directory: ./out

--- a/.github/workflows/package-for-dev.yml
+++ b/.github/workflows/package-for-dev.yml
@@ -1,17 +1,16 @@
-name: Package for Build
+name: Package for Dev
 on:
+  workflow_dispatch:
   push:
-    branches:
-      - main
+    branches: [main]
 
 jobs:
   deploy:
-    name: Package for build
+    name: Deploy to dev
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
       AWS_REGION: eu-west-2
-      ENVIRONMENT: build
     permissions:
       id-token: write
       contents: read
@@ -41,7 +40,7 @@ jobs:
       - name: Assume temporary AWS role
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          role-to-assume: ${{ secrets.BUILD_GH_ACTIONS_ROLE_ARN }}
+          role-to-assume: ${{ secrets.DEV_GH_ACTIONS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: SAM Validate
@@ -55,6 +54,6 @@ jobs:
       - name: Deploy SAM app
         uses: govuk-one-login/devplatform-upload-action@v3.9.1
         with:
-          artifact-bucket-name: ${{ secrets.BUILD_ARTIFACT_SOURCE_BUCKET_NAME }}
-          signing-profile-name: ${{ secrets.BUILD_SIGNING_PROFILE_NAME }}
+          artifact-bucket-name: ${{ secrets.DEV_ARTIFACT_SOURCE_BUCKET_NAME }}
+          signing-profile-name: ${{ secrets.DEV_SIGNING_PROFILE_NAME }}
           working-directory: ./out

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -15,8 +15,8 @@ on:
 permissions: {}
 
 concurrency:
-  group: integration-tests
-  cancel-in-progress: false
+  group: integration-tests-${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
 
 jobs:
   run-tests:

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Run tests
         env:
-          ENVIRONMENT: dev
+          ENVIRONMENT: localdev
           AWS_REGION: ${{ inputs.aws-region }}
           STACK_NAME: ${{ inputs.stack-name }}
           API_GATEWAY_ID_PUBLIC: ${{ fromJson(inputs.stack-outputs).PublicKBVApiGatewayId }}

--- a/.github/workflows/scan-repo.yml
+++ b/.github/workflows/scan-repo.yml
@@ -78,6 +78,6 @@ jobs:
       security-events: write
     steps:
       - name: Run CodeQL scan
-        uses: govuk-one-login/github-actions/code-quality/codeql@d4ec36f4ed5ebfb93d4866b3322a70b27bb8f92f #31st Jan 2024
+        uses: govuk-one-login/github-actions/code-quality/codeql@d201191485b645ec856a34e5ca48636cf97b2574
         with:
           languages: javascript-typescript

--- a/README.md
+++ b/README.md
@@ -88,14 +88,10 @@ Deployment to Build:
 |----------------------------|----------------------------------|
 | `/alerting/email-address`  | email address to receive alerts  |
 
-## Run Integration Tests
+## Run integration tests
 
-To run:
+The command below runs using `https://cri.core.build.stubs.account.gov.uk` in AWS with stub client ID `ipv-core-stub-aws-prod`.
 
-Below runs by with stub client using `https://cri.core.build.stubs.account.gov.uk` in AWS with stub a client_id `ipv-core-stub-aws-stub`
+Optionally set a value for `TEST_RESOURCES_STACK_NAME` if you have deployed a local test resources stack and want to override the default stack named `test-resources`.
 
-Use the default `test-resources` stack in TEST_RESOURCES_STACK_NAME unless you have deployed a local test-resources stack
-
-`ENVIRONMENT=xxxx STACK_NAME=xxxx IPV_CORE_STUB_CRI_ID=kbv-cri-dev  API_GATEWAY_ID_PRIVATE=xxxx API_GATEWAY_ID_PUBLIC=xxxx IPV_CORE_STUB_BASIC_AUTH_USER=xxxx IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxxx IPV_CORE_STUB_URL="https://cri.core.build.stubs.account.gov.uk" DEFAULT_CLIENT_ID=ipv-core-stub-aws-build APIGW_API_KEY=xxxx TEST_RESOURCES_STACK_NAME=xxxx gradle integration-tests:cucumber`
-
-NB: The environment variable with value `kbv-cri-dev` allows the command above to use keys in `ipv-config` pointing to keys in `di-ipv-cri-kbv-dev` for the deployed stack.
+`ENVIRONMENT=localdev STACK_NAME=<your-stack> API_GATEWAY_ID_PRIVATE=<from-your-stack> API_GATEWAY_ID_PUBLIC=<from-your-stack> IPV_CORE_STUB_CRI_ID=kbv-cri-dev IPV_CORE_STUB_BASIC_AUTH_USER=xxxx IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxxx IPV_CORE_STUB_URL=https://cri.core.build.stubs.account.gov.uk DEFAULT_CLIENT_ID=ipv-core-stub-aws-prod APIGW_API_KEY=xxxx TEST_RESOURCES_STACK_NAME= gradle integration-tests:cucumber`

--- a/deploy.sh
+++ b/deploy.sh
@@ -26,11 +26,11 @@ sam deploy --stack-name "$stack_name" \
   --capabilities CAPABILITY_IAM \
   --tags \
   cri:component=ipv-cri-kbv-api \
-  cri:stack-type=dev \
+  cri:stack-type=localdev \
   cri:application=Orange \
   cri:deployment-source=manual \
   --parameter-overrides \
-  Environment=dev \
+  Environment=localdev \
   SecretPrefix=pre-merge-test \
   ${common_stack_name:+CommonStackName=$common_stack_name} \
   ${secret_prefix:+SecretPrefix=$secret_prefix}

--- a/infrastructure/lambda/private-api.yaml
+++ b/infrastructure/lambda/private-api.yaml
@@ -4,7 +4,6 @@ info:
   version: "1.0"
 
 paths:
-
   /authorization:
     get:
       parameters:
@@ -184,6 +183,7 @@ paths:
         uri:
           Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${KBVAbandonFunction.Arn}/invocations"
         passthroughBehavior: "when_no_match"
+
 components:
   parameters:
     SessionHeader:

--- a/infrastructure/lambda/public-api.yaml
+++ b/infrastructure/lambda/public-api.yaml
@@ -72,6 +72,7 @@ paths:
         passthroughBehavior: "when_no_match"
         contentHandling: "CONVERT_TO_TEXT"
         type: "aws_proxy"
+
   /credential/issue:
     summary: Resource for the KBV API
     description: >-

--- a/infrastructure/lambda/samconfig.toml
+++ b/infrastructure/lambda/samconfig.toml
@@ -1,0 +1,26 @@
+version = 0.1
+
+[default.build.parameters]
+cached = true
+parallel = true
+
+[default.deploy.parameters]
+stack_name = "<your-name>-kbv-api"
+
+capabilities = ["CAPABILITY_IAM"]
+fail_on_empty_changeset = false
+confirm_changeset = false
+s3_prefix = "localdev"
+region = "eu-west-2"
+resolve_s3 = true
+
+parameter_overrides = [
+    "Environment=localdev"
+]
+
+tags = [
+    "cri:component=ipv-cri-kbv-api",
+    "cri:deployment-source=manual",
+    "cri:application=Orange",
+    "cri:stack-type=localdev"
+]

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
-Transform: [AWS::Serverless-2016-10-31, AWS::LanguageExtensions] 
-Description: "Digital Identity IPV CRI KBV API"
+Description: Digital Identity IPV CRI KBV API
+Transform: [AWS::Serverless-2016-10-31, AWS::LanguageExtensions] #TODO: LanguageExtensions must come before Serverless
 
 Parameters:
   Environment:
@@ -60,57 +60,75 @@ Conditions:
 Globals:
   Function:
     VpcConfig:
-      SecurityGroupIds:
-        - !ImportValue cri-vpc-LambdaSecurityGroup
-      SubnetIds: !Split [ ",", !ImportValue cri-vpc-PrivateSubnets ]
-    PermissionsBoundary: !If
-      - UsePermissionsBoundary
-      - !Ref PermissionsBoundary
-      - !Ref AWS::NoValue
-    CodeSigningConfigArn: !If
-      - UseCodeSigningConfigArn
-      - !Ref CodeSigningConfigArn
-      - !Ref AWS::NoValue
+      SecurityGroupIds: [!ImportValue cri-vpc-LambdaSecurityGroup]
+      SubnetIds: !Split [",", !ImportValue cri-vpc-PrivateSubnets]
+    PermissionsBoundary:
+      !If [UsePermissionsBoundary, !Ref PermissionsBoundary, !Ref AWS::NoValue]
+    CodeSigningConfigArn:
+      !If [UseCodeSigningConfigArn, !Ref CodeSigningConfigArn, !Ref AWS::NoValue]
+    Tracing: Active
     Timeout: 30 # seconds
     Runtime: java11
+    Architectures: [arm64]
     AutoPublishAlias: live
     DeploymentPreference:
       Type: !Ref LambdaDeploymentPreference
       Role: !GetAtt CodeDeployServiceRole.Arn
-    Tracing: Active
-    MemorySize: !FindInMap [MemorySizeMapping, Environment, !Ref 'Environment']
-    Architectures:
-      - arm64
+    MemorySize: !FindInMap [MemorySizeMapping, Environment, !Ref Environment]
     Environment:
       Variables:
-        JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1
-        AWS_STACK_NAME: !Sub ${AWS::StackName}
+        AWS_STACK_NAME: !Ref AWS::StackName
         SECRET_PREFIX: !If [UseSecretPrefix, !Ref SecretPrefix , !Ref AWS::StackName]
-        POWERTOOLS_LOG_LEVEL: INFO
-        POWERTOOLS_METRICS_NAMESPACE: !Ref CriIdentifier
         SQS_AUDIT_EVENT_PREFIX: !Ref AuditEventNamePrefix
         COMMON_PARAMETER_NAME_PREFIX: !Ref CommonStackName
+        POWERTOOLS_METRICS_NAMESPACE: !Ref CriIdentifier
+        POWERTOOLS_LOG_LEVEL: INFO
         AWS_LAMBDA_EXEC_WRAPPER: /opt/dynatrace
+        JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1
         DT_CONNECTION_AUTH_TOKEN: !Sub
-          - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CONNECTION_AUTH_TOKEN}}'
-          - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+          - "{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CONNECTION_AUTH_TOKEN}}"
+          - SecretArn: !FindInMap [EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn]
         DT_CONNECTION_BASE_URL: !Sub
-          - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CONNECTION_BASE_URL}}'
-          - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+          - "{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CONNECTION_BASE_URL}}"
+          - SecretArn: !FindInMap [EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn]
         DT_CLUSTER_ID: !Sub
-          - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CLUSTER_ID}}'
-          - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+          - "{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CLUSTER_ID}}"
+          - SecretArn: !FindInMap [EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn]
         DT_LOG_COLLECTION_AUTH_TOKEN: !Sub
-          - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_LOG_COLLECTION_AUTH_TOKEN}}'
-          - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+          - "{{resolve:secretsmanager:${SecretArn}:SecretString:DT_LOG_COLLECTION_AUTH_TOKEN}}"
+          - SecretArn: !FindInMap [EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn]
         DT_TENANT: !Sub
-          - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_TENANT}}'
-          - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+          - "{{resolve:secretsmanager:${SecretArn}:SecretString:DT_TENANT}}"
+          - SecretArn: !FindInMap [EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn]
         DT_OPEN_TELEMETRY_ENABLE_INTEGRATION: "true"
     Layers:
       - !Sub
-        - '{{resolve:secretsmanager:${SecretArn}:SecretString:JAVA_LAYER}}'
-        - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+        - "{{resolve:secretsmanager:${SecretArn}:SecretString:JAVA_LAYER}}"
+        - SecretArn: !FindInMap [EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn]
+  Api:
+    TracingEnabled: true
+    OpenApiVersion: 3.0.1
+    MethodSettings:
+      - LoggingLevel: INFO
+        ResourcePath: /*
+        HttpMethod: "*"
+        DataTraceEnabled: true
+        MetricsEnabled: true
+        ThrottlingRateLimit: 200
+        ThrottlingBurstLimit: 400
+    AccessLogSetting:
+      Format:
+        Fn::ToJsonString:
+          requestId: $context.requestId
+          ip: $context.identity.sourceIp
+          requestTime: $context.requestTime
+          httpMethod: $context.httpMethod
+          path: $context.path
+          routeKey: $context.routeKey
+          status: $context.status
+          protocol: $context.protocol
+          responseLatency: $context.responseLatency
+          responseLength: $context.responseLength
 
 Mappings:
   EnvironmentConfiguration:
@@ -187,87 +205,40 @@ Resources:
   PublicKBVApi:
     Type: AWS::Serverless::Api
     Properties:
+      Name: !Sub kbv-cri-${AWS::StackName}
       Description: Public KBV CRI API
-      MethodSettings:
-        - LoggingLevel: INFO
-          ResourcePath: '/*'
-          HttpMethod: '*'
-          # Disable data trace in production to avoid logging customer sensitive information
-          DataTraceEnabled: true
-          MetricsEnabled: true
-          ThrottlingRateLimit: 200
-          ThrottlingBurstLimit: 400
-      AccessLogSetting:
-        DestinationArn: !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:${PublicKBVApiAccessLogGroup}'
-        Format: >-
-          {
-          "requestId":"$context.requestId",
-          "ip":"$context.identity.sourceIp",
-          "requestTime":"$context.requestTime",
-          "httpMethod":"$context.httpMethod",
-          "path":"$context.path",
-          "routeKey":"$context.routeKey",
-          "status":"$context.status",
-          "protocol":"$context.protocol",
-          "responseLatency":"$context.responseLatency",
-          "responseLength":"$context.responseLength"
-          }
-      TracingEnabled: true
-      Name: !Sub "kbv-cri-${AWS::StackName}"
       StageName: !Ref Environment
+      AccessLogSetting:
+        DestinationArn: !GetAtt PublicKBVApiAccessLogGroup.Arn
       DefinitionBody:
-        openapi: "3.0.1" # workaround to get `sam validate` to work
+        openapi: 3.0.1
         paths: # workaround to get `sam validate` to work
           /never-created:
-            options: { } # workaround to get `sam validate` to work
+            options: { }
         Fn::Transform:
           Name: AWS::Include
           Parameters:
-            Location: './public-api.yaml'
-      OpenApiVersion: 3.0.1
+            Location: ./public-api.yaml
       EndpointConfiguration:
         Type: REGIONAL
 
   PrivateKBVApi:
     Type: AWS::Serverless::Api
     Properties:
+      Name: !Sub kbv-cri-private-${AWS::StackName}
       Description: Private KBV CRI API
-      MethodSettings:
-        - LoggingLevel: INFO
-          ResourcePath: '/*'
-          HttpMethod: '*'
-          # Disable data trace in production to avoid logging customer sensitive information
-          DataTraceEnabled: true
-          MetricsEnabled: true
-          ThrottlingRateLimit: 200
-          ThrottlingBurstLimit: 400
+      StageName: !Ref Environment
       AccessLogSetting:
         DestinationArn: !GetAtt PrivateKBVApiAccessLogGroup.Arn
-        Format:
-          Fn::ToJsonString:
-            requestId: $context.requestId
-            ip: $context.identity.sourceIp
-            requestTime: $context.requestTime
-            httpMethod: $context.httpMethod
-            path: $context.path
-            routeKey: $context.routeKey
-            status: $context.status
-            protocol: $context.protocol
-            responseLatency: $context.responseLatency
-            responseLength: $context.responseLength
-      TracingEnabled: true
-      Name: !Sub "kbv-cri-private-${AWS::StackName}"
-      StageName: !Ref Environment
       DefinitionBody:
-        openapi: "3.0.1" # workaround to get `sam validate` to work
+        openapi: 3.0.1
         paths: # workaround to get `sam validate` to work
           /never-created:
-            options: { } # workaround to get `sam validate` to work
+            options: { }
         Fn::Transform:
           Name: AWS::Include
           Parameters:
-            Location: './private-api.yaml'
-      OpenApiVersion: 3.0.1
+            Location: ./private-api.yaml
       EndpointConfiguration:
         Type: !If [IsLocalDevEnvironment, REGIONAL, PRIVATE]
       Auth:
@@ -626,12 +597,10 @@ Resources:
   PublicApiUsagePlan:
     Type: AWS::ApiGateway::UsagePlan
     Condition: IsNotDevEnvironment
-    DependsOn:
-      - PublicKBVApiStage
     Properties:
       ApiStages:
         - ApiId: !Ref PublicKBVApi
-          Stage: !Ref Environment
+          Stage: !Ref PublicKBVApi.Stage
       Quota:
         Limit: 500000
         Period: DAY
@@ -642,12 +611,10 @@ Resources:
   PrivateApiUsagePlan:
     Type: AWS::ApiGateway::UsagePlan
     Condition: IsNotDevEnvironment
-    DependsOn:
-      - PrivateKBVApiStage
     Properties:
       ApiStages:
         - ApiId: !Ref PrivateKBVApi
-          Stage: !Ref Environment
+          Stage: !Ref PrivateKBVApi.Stage
       Quota:
         Limit: 500000
         Period: DAY

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -3,25 +3,21 @@ Transform: [AWS::Serverless-2016-10-31, AWS::LanguageExtensions]
 Description: "Digital Identity IPV CRI KBV API"
 
 Parameters:
+  Environment:
+    Type: String
+    Default: dev
+    AllowedValues: [dev, localdev, build, staging, integration, production]
+    ConstraintDescription: Must be dev, localdev, build, staging, integration or production
+  LambdaDeploymentPreference:
+    Type: String
+    Default: AllAtOnce
+    Description: >-
+      Specifies the configuration to enable gradual Lambda deployments.
+      It can be used to set deployment type, and also allows skipping canary deployment by setting to 'AllAtOnce'.
   CodeSigningConfigArn:
     Type: String
     Default: "none"
-    Description: >
-      The ARN of the Code Signing Config to use, provided by the deployment pipeline
-  Environment:
-    Description: "The environment type"
-    Type: "String"
-    AllowedValues:
-      - "dev"
-      - "build"
-      - "staging"
-      - "integration"
-      - "production"
-    ConstraintDescription: must be dev, build, staging, integration or production
-  LambdaDeploymentPreference:
-    Description: "Specifies the configuration to enable gradual Lambda deployments. It can be used to set deployment type, and also allows skipping canary deployment by setting to 'AllAtOnce'."
-    Type: String
-    Default: AllAtOnce
+    Description: The ARN of the Code Signing Config to use, provided by the deployment pipeline
   PermissionsBoundary:
     Description: "The ARN of the permissions boundary to apply when creating IAM roles"
     Type: String
@@ -52,17 +48,14 @@ Parameters:
     Description: The support manual URL to be provided in alarm messages.
 
 Conditions:
-  UseCodeSigningConfigArn: !Not [!Equals [!Ref CodeSigningConfigArn, "none"]]
-  UsePermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundary, "none"]]
-  IsStubEnvironment: !Or
-    - !Equals [ !Ref Environment, dev]
-    - !Equals [ !Ref Environment, build ]
-    - !Equals [ !Ref Environment, staging ]
-    - !Equals [ !Ref Environment, integration ]
-  IsDevEnvironment: !Equals [!Ref Environment, dev]
-  IsNotDevEnvironment: !Not [!Condition IsDevEnvironment]
   UseSecretPrefix: !Not [!Equals [!Ref SecretPrefix, "none"]]
-  UseCanaryDeploymentAlarms: !Not [ !Equals [ !Ref LambdaDeploymentPreference, AllAtOnce ]]
+  UsePermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundary, "none"]]
+  UseCodeSigningConfigArn: !Not [!Equals [!Ref CodeSigningConfigArn, "none"]]
+  UseCanaryDeploymentAlarms: !Not [!Equals [!Ref LambdaDeploymentPreference, AllAtOnce]]
+  IsDevEnvironment: !Or [!Equals [!Ref Environment, dev], !Condition IsLocalDevEnvironment]
+  IsStubEnvironment: !Not [!Equals [!Ref Environment, production]]
+  IsLocalDevEnvironment: !Equals [!Ref Environment, localdev]
+  IsNotDevEnvironment: !Not [!Condition IsDevEnvironment]
 
 Globals:
   Function:
@@ -120,9 +113,10 @@ Globals:
         - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
 
 Mappings:
-
   EnvironmentConfiguration:
     dev:
+      dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
+    localdev:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
     build:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
@@ -140,6 +134,7 @@ Mappings:
       staging: 2048
       integration: 2048
       production: 3072
+      localdev: 2048
 
   IIQAPIDatabaseModeMapping:
     Environment:
@@ -148,6 +143,7 @@ Mappings:
       staging: Static
       integration: Static
       production: Normal
+      localdev: Static
 
   IIQOperatorIdMapping:
     Environment:
@@ -156,6 +152,7 @@ Mappings:
       staging: GDSCABINETUIIQ01U
       integration: GDSCABINETUIIQ01U
       production: GDSCABINETUIIQ01U
+      localdev: GDSCABINETUIIQ01U
 
   # Only numeric values should be assigned here
   MaxJwtTtlMapping:
@@ -165,6 +162,7 @@ Mappings:
       staging: 6
       integration: 6
       production: 6
+      localdev: 2
 
   # Permitted values: SECONDS,MINUTES,HOURS,DAYS,MONTHS,YEARS
   JwtTtlUnitMapping:
@@ -174,14 +172,16 @@ Mappings:
       staging: MONTHS
       integration: MONTHS
       production: MONTHS
+      localdev: HOURS
 
   VcContainsUniqueIdMapping:
     Environment:
-      dev: "true"
-      build: "true"
-      staging: "true"
-      integration: "false"
-      production: "false"
+      dev: true
+      build: true
+      staging: true
+      integration: false
+      production: false
+      localdev: true
 
 Resources:
   PublicKBVApi:
@@ -230,7 +230,6 @@ Resources:
 
   PrivateKBVApi:
     Type: AWS::Serverless::Api
-    Condition: IsNotDevEnvironment
     Properties:
       Description: Private KBV CRI API
       MethodSettings:
@@ -270,67 +269,25 @@ Resources:
             Location: './private-api.yaml'
       OpenApiVersion: 3.0.1
       EndpointConfiguration:
-        Type: PRIVATE
+        Type: !If [IsLocalDevEnvironment, REGIONAL, PRIVATE]
       Auth:
         ResourcePolicy:
           CustomStatements:
-            - Action: 'execute-api:Invoke'
-              Effect: Allow
-              Principal: '*'
-              Resource:
-                - 'execute-api:/*'
-            - Action: 'execute-api:Invoke'
-              Effect: Deny
-              Principal: '*'
-              Resource:
-                - 'execute-api:/*'
-              Condition:
-                StringNotEquals:
-                  aws:SourceVpce: !ImportValue cri-vpc-ApiGatewayVpcEndpointId
-
-  DevOnlyKBVApi:
-    Type: AWS::Serverless::Api
-    Condition: IsDevEnvironment
-    Properties:
-      Description: Private Dev KBV CRI API
-      MethodSettings:
-        - LoggingLevel: INFO
-          ResourcePath: '/*'
-          HttpMethod: '*'
-          DataTraceEnabled: true
-          MetricsEnabled: true
-          ThrottlingRateLimit: 200
-          ThrottlingBurstLimit: 400
-      AccessLogSetting:
-        DestinationArn: !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:${DevOnlyKBVApiAccessLogGroup}'
-        Format: >-
-          {
-          "requestId":"$context.requestId",
-          "ip":"$context.identity.sourceIp",
-          "requestTime":"$context.requestTime",
-          "httpMethod":"$context.httpMethod",
-          "path":"$context.path",
-          "routeKey":"$context.routeKey",
-          "status":"$context.status",
-          "protocol":"$context.protocol",
-          "responseLatency":"$context.responseLatency",
-          "responseLength":"$context.responseLength"
-          }
-      TracingEnabled: true
-      Name: !Sub "kbv-cri-private-${AWS::StackName}"
-      StageName: !Ref Environment
-      DefinitionBody:
-        openapi: "3.0.1" # workaround to get `sam validate` to work
-        paths: # workaround to get `sam validate` to work
-          /never-created:
-            options: { } # workaround to get `sam validate` to work
-        Fn::Transform:
-          Name: AWS::Include
-          Parameters:
-            Location: './private-api.yaml'
-      OpenApiVersion: 3.0.1
-      EndpointConfiguration:
-        Type: REGIONAL
+            #FIXME: Workaround for incorrect order of transforms - need at least one policy in the list
+            - Effect: Allow
+              Resource: execute-api:/*
+              Action: execute-api:Invoke
+              Principal: "*"
+            - !If
+              - IsLocalDevEnvironment
+              - !Ref AWS::NoValue
+              - Effect: Deny
+                Resource: execute-api:/*
+                Action: execute-api:Invoke
+                Principal: "*"
+                Condition:
+                  StringNotEquals:
+                    aws:SourceVpce: !ImportValue cri-vpc-ApiGatewayVpcEndpointId
 
   PublicKBVApiAccessLogGroup:
     Type: AWS::Logs::LogGroup
@@ -348,16 +305,8 @@ Resources:
 
   PrivateKBVApiAccessLogGroup:
     Type: AWS::Logs::LogGroup
-    Condition: IsNotDevEnvironment
     Properties:
       LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-${PrivateKBVApi}-private-AccessLogs
-      RetentionInDays: 30
-
-  DevOnlyKBVApiAccessLogGroup:
-    Type: AWS::Logs::LogGroup
-    Condition: IsDevEnvironment
-    Properties:
-      LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-${DevOnlyKBVApi}-private-AccessLogs
       RetentionInDays: 30
 
   PrivateKBVApiAccessLogGroupSubscriptionFilterCSLS:
@@ -1191,7 +1140,7 @@ Outputs:
 
   PrivateKBVApiGatewayId:
     Description: "API GatewayID of the private KBV CRI API"
-    Value: !If [IsNotDevEnvironment, !Ref PrivateKBVApi, !Ref DevOnlyKBVApi]
+    Value: !Ref PrivateKBVApi
     Export:
       Name: !Sub ${AWS::StackName}-PrivateKBVApiGatewayId
 

--- a/integration-tests/src/test/resources/features/KbvApiAbandonPath.feature
+++ b/integration-tests/src/test/resources/features/KbvApiAbandonPath.feature
@@ -1,7 +1,7 @@
 Feature: User goes through 3-out-of-4 question strategy and 2-out-of-3 question strategy.
   Tests are run against the KBV Stub. User chooses to abandon the question during KBV flow
 
-  @pre_merge_abandon_medium_confidence
+  @abandon_medium_confidence
   Scenario: 3-out-of-4 question strategy user abandons first question
     Given user has the test-identity 197 in the form of a signed JWT string
 
@@ -17,7 +17,7 @@ Feature: User goes through 3-out-of-4 question strategy and 2-out-of-3 question 
     When user chooses to abandon the question
     Then user gets status code 200
 
-  @pre_merge_abandon_medium_confidence
+  @abandon_medium_confidence
   Scenario Outline: 3-out-of-4 question strategy user abandons second question
     Given user has the test-identity <user> in the form of a signed JWT string
 
@@ -43,7 +43,7 @@ Feature: User goes through 3-out-of-4 question strategy and 2-out-of-3 question 
       | user |
       | 197  |
   
-  @pre_merge_abandon_low_confidence
+  @abandon_low_confidence
   Scenario: 2-out-of-3 question strategy user abandons first question
     Given user has the test-identity 197 and verificationScore of 1 in the form of a signed JWT string
 
@@ -59,7 +59,7 @@ Feature: User goes through 3-out-of-4 question strategy and 2-out-of-3 question 
     When user chooses to abandon the question
     Then user gets status code 200
 
-  @pre_merge_abandon_low_confidence
+  @abandon_low_confidence
   Scenario Outline: 2-out-of-3 question strategy user abandons second question
     Given user has the test-identity <user> and verificationScore of 1 in the form of a signed JWT string
 

--- a/integration-tests/src/test/resources/features/KbvApiHappyPath.feature
+++ b/integration-tests/src/test/resources/features/KbvApiHappyPath.feature
@@ -2,7 +2,7 @@ Feature: User goes through 3-out-of-4 question strategy. User answers 3 question
   User goes through 2-out-of-3 question strategy. User answers 2 questions correctly and gets a valid JWT credential issuer with a score of 1.
   Tests are run against the KBV Stub.
 
-  @pre_merge_happy_with_device_information_header
+  @happy_with_device_information_header
   Scenario Outline: User answers 3 questions correctly in 3-out-of-4 question strategy with device information header
     Given user has the test-identity <user> in the form of a signed JWT string
 
@@ -60,7 +60,7 @@ Feature: User goes through 3-out-of-4 question strategy. User answers 3 question
       | 197  | false |
       | 1188 | true |
 
-  @pre_merge_happy_medium_confidence
+  @happy_medium_confidence
   Scenario Outline: User answers 3 questions correctly in 3-out-of-4 question strategy
     Given user has the test-identity <user> in the form of a signed JWT string
 
@@ -115,7 +115,7 @@ Feature: User goes through 3-out-of-4 question strategy. User answers 3 question
       | user |
       | 197  |
 
-  @pre_merge_happy_low_confidence
+  @happy_low_confidence
   Scenario Outline: User answers 2 questions correctly in 2-out-of-3 question strategy
     Given user has the test-identity <user> and verificationScore of 1 in the form of a signed JWT string
 
@@ -164,7 +164,7 @@ Feature: User goes through 3-out-of-4 question strategy. User answers 3 question
       | user |
       | 197  |
 
-  @pre_merge_happy_low_confidence
+  @happy_low_confidence
   Scenario Outline: User answers 2 out of 3 questions correctly with in 2-out-of-3 question strategy
     Given user has the test-identity <user> and verificationScore of 1 in the form of a signed JWT string
 

--- a/integration-tests/src/test/resources/features/KbvApiUnhappyPath.feature
+++ b/integration-tests/src/test/resources/features/KbvApiUnhappyPath.feature
@@ -2,7 +2,7 @@ Feature: User goes through 3-out-of-4 question strategy. User answers 2 question
   User goes through 2-out-of-3 question strategy. User answers 2 questions incorrectly and fails with a vc score of 0.
   Tests are run against the KBV Stub.
 
-  @pre_merge_unhappy_medium_confidence
+  @unhappy_medium_confidence
   Scenario Outline: 3-out-of-4 question strategy user answers 2 questions incorrectly
     Given user has the test-identity <user> in the form of a signed JWT string
 
@@ -45,7 +45,7 @@ Feature: User goes through 3-out-of-4 question strategy. User answers 2 question
       | user |
       | 197  |
 
-  @pre_merge_unhappy_low_confidence
+  @unhappy_low_confidence
   Scenario Outline: 2-out-of-3 question strategy user answers 2 questions incorrectly
     Given user has the test-identity <user> and verificationScore of 1 in the form of a signed JWT string
 


### PR DESCRIPTION
**OJ-2255: Add localdev environment to the template**

- Delete `DevOnlyKBVApi` and use the private API in dev instead
  - Set the endpoint configuration and access based on the `localdev` variable
  - Add mappings for the `localdev` environment (mirrors `dev`)

- Update the deploy script to use the `localdev` environment
- Add a `samconfig.toml` file with the correct config for `localdev`
- Update the Preview workflow to use the `localdev` environment

- Update integration tests to run with the localdev env
  Remove the `pre_merge` prefix from integration test tags since they are all "pre-merge" and adding the same qualifier to each test doesn't help to differentiate between them.

**OJ-2255: Update APIs**

- Update the API config to match other templates
- Use references to the log groups and stages to let CF create dependencies between the resources and avoid mistakes.
- Use the Globals sections for the API resources to keep the config more concise
- Use the referenceable properties created by SAM to get the API stage names rather than hardcoding the environment value

- Add a comment about reversing the order of the transforms
  The correct order is with the language extensions transform being first - the reversed order causes a bug in SAM/CF when creating the APIs. Reversing the order fixes the bug but also causes a non-zero-downtime deployment - this will be addressed separately.

---

- BAU: Use the latest shared GitHub Actions
  - Update the preview workflow to fix an issue with PR deployments where the lambdas wouldn't get updated.
    Refresh cache on changes to the lambdas source code.
    Retrieve the cache using the keys from the build action.
  - Allow the Check PR workflow to be triggered manually for any branch.

- BAU: Allow integration tests to run in parallel
  This can be reverted now that we have switched to using the test harness for Audit Events and SQS, and there's no longer interference between tests.