### PR TITLE
IPS-1213: Add permissions only

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -757,6 +757,34 @@ Resources:
       FunctionName: !GetAtt IssueCredentialFunction.Arn
       Principal: apigateway.amazonaws.com
 
+  KBVQuestionFunctionAliasPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref KBVQuestionFunction.Alias
+      Principal: apigateway.amazonaws.com
+
+  KBVAnswerFunctionAliasPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref KBVAnswerFunction.Alias
+      Principal: apigateway.amazonaws.com
+
+  KBVAbandonFunctionAliasPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref KBVAbandonFunction.Alias
+      Principal: apigateway.amazonaws.com
+
+  IssueCredentialFunctionAliasPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref IssueCredentialFunction.Alias
+      Principal: apigateway.amazonaws.com
+
   LoggingKmsKey:
     Type: AWS::KMS::Key
     Properties:


### PR DESCRIPTION
### What changed

- Add additional Alias perms in separate PR

### Why did it change

- Cloudwatch does not update resources in a particular order
- Merging this PR before any API changes ensures that the additional permissions are in place before updating the spec

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-1213](https://govukverify.atlassian.net/browse/IPS-1213)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[IPS-1213]: https://govukverify.atlassian.net/browse/IPS-1213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ