### PR TITLE
OJ-2840: Collect SOAP token latency as a metric

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/security/SoapToken.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/security/SoapToken.java
@@ -2,18 +2,25 @@ package uk.gov.di.ipv.cri.kbv.api.security;
 
 import com.experian.uk.wasp.TokenService;
 import com.experian.uk.wasp.TokenServiceSoap;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import software.amazon.cloudwatchlogs.emf.model.Unit;
 import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
+import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.kbv.api.exception.InvalidSoapTokenException;
+import uk.gov.di.ipv.cri.kbv.api.service.MetricsService;
 
 import javax.xml.ws.BindingProvider;
 import javax.xml.ws.WebServiceException;
 import javax.xml.ws.soap.SOAPFaultException;
 
 public class SoapToken {
+    private static final Logger LOGGER = LogManager.getLogger();
     private final TokenService tokenService;
     private final String application;
     private final boolean checkIp;
     private final ConfigurationService configurationService;
+    private final MetricsService metricsService = new MetricsService(new EventProbe());
 
     public SoapToken(
             String application,
@@ -27,6 +34,8 @@ public class SoapToken {
     }
 
     public String getToken() {
+        long startTime = System.nanoTime();
+
         try {
             TokenServiceSoap tokenServiceSoap = tokenService.getTokenServiceSoap();
 
@@ -37,8 +46,17 @@ public class SoapToken {
                             BindingProvider.ENDPOINT_ADDRESS_PROPERTY,
                             configurationService.getSecretValue("experian/iiq-wasp-service"));
 
-            return tokenServiceSoap.loginWithCertificate(application, checkIp);
+            String token = tokenServiceSoap.loginWithCertificate(application, checkIp);
 
+            long totalTimeInMs = (System.nanoTime() - startTime) / 1000000;
+
+            LOGGER.info("SoapToken#getToken latency is {}ms", totalTimeInMs);
+
+            metricsService
+                    .getEventProbe()
+                    .counterMetric("get_soap_token_duration", totalTimeInMs, Unit.MILLISECONDS);
+
+            return token;
         } catch (SOAPFaultException e) {
             throw new InvalidSoapTokenException("SOAP Fault occurred: " + e.getMessage());
         } catch (WebServiceException e) {


### PR DESCRIPTION
## Proposed changes

### What changed
Collecting latency for the soap token call. This PR creates a new metric called `get_soap_token_duration` so that we can understand how we can make our system more performant.

### Issue tracking
- [OJ-2840](https://govukverify.atlassian.net/browse/OJ-2840)


[OJ-2840]: https://govukverify.atlassian.net/browse/OJ-2840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ