### PR TITLE
OJ-2740: Update to latest cri-lib version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ ext {
 		mockito					 : "4.3.1",
 		glassfish_version        : "3.0.3",
 		powertools_version       : "1.12.3",
-		cri_common_lib           : "3.5.0",
+		cri_common_lib           : "3.6.0",
 		pact_provider_version    : "4.5.11",
 		webcompere_version       : "2.1.6",
 	]


### PR DESCRIPTION

### What changed

Update to latest common-library version

### Why did it change

To deprecate SQS implementation and ensure CRIs are using the latest common-library version

### Issue tracking

- [OJ-2740](https://govukverify.atlassian.net/browse/OJ-2740)

## Checklists

[OJ-2740]: https://govukverify.atlassian.net/browse/OJ-2740?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ