### PR TITLE
tests: update IPV_KBV_CRI_START schema to accept an array for the evidence block

### DIFF
--- a/integration-tests/src/test/resources/features/schema/IPV_KBV_CRI_START.json
+++ b/integration-tests/src/test/resources/features/schema/IPV_KBV_CRI_START.json
@@ -8,7 +8,7 @@
       "type": "object",
       "properties": {
         "evidence": {
-          "type": "object",
+          "type": "array",
           "items": {
             "type": "object",
             "properties": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
The evidence block has been changed to an array. This change was not reflected in KBV and the tests started failing once common lambdas was updated. 

The reason this was not captured before is because of how common lambdas is deployed. The last deployment of common-lambdas happened in 1st August 2024 - which did not contain the change to the START event. 

The next deployment happened on the 16th December 2024 which contained the array change. 

<img width="552" alt="Screenshot 2025-01-06 at 16 05 24" src="https://github.com/user-attachments/assets/aa02dae9-3b58-4ace-8b4d-2d9cd5f1cea2" />

