### PR TITLE
OJ-2841: SOAP token

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	aspect configurations.powertools
 
 	runtimeOnly configurations.logging_runtime
+	testImplementation configurations.logging_runtime
 	testImplementation configurations.tests
 	testRuntimeOnly configurations.test_runtime
 }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/security/HeaderHandler.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/security/HeaderHandler.java
@@ -1,7 +1,9 @@
 package uk.gov.di.ipv.cri.kbv.api.security;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import uk.gov.di.ipv.cri.kbv.api.exception.HeaderHandlerException;
 import uk.gov.di.ipv.cri.kbv.api.exception.InvalidSoapTokenException;
+import uk.gov.di.ipv.cri.kbv.api.util.SoapTokenUtils;
 
 import javax.xml.namespace.QName;
 import javax.xml.soap.Name;
@@ -15,15 +17,16 @@ import javax.xml.ws.handler.MessageContext;
 import javax.xml.ws.handler.soap.SOAPHandler;
 import javax.xml.ws.handler.soap.SOAPMessageContext;
 
+import java.time.Instant;
 import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
 
 public class HeaderHandler implements SOAPHandler<SOAPMessageContext> {
-    private final SoapToken token;
+    private final SoapTokenRetriever tokenRetriever;
 
-    public HeaderHandler(SoapToken token) {
-        this.token = token;
+    public HeaderHandler(SoapTokenRetriever tokenRetriever) {
+        this.tokenRetriever = tokenRetriever;
     }
 
     public boolean handleMessage(SOAPMessageContext smc) {
@@ -58,10 +61,10 @@ public class HeaderHandler implements SOAPHandler<SOAPMessageContext> {
                         "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd");
                 binarySecurityToken.addAttribute(new QName("EncodingType"), "wsse:Base64Binary");
                 binarySecurityToken.addAttribute(new QName("ValueType"), "ExperianWASP");
-                binarySecurityToken.setValue(retrieveTokenWithoutError(token));
+                binarySecurityToken.setValue(retrieveTokenWithoutError());
                 soapMessage.saveChanges();
 
-            } catch (SOAPException | RuntimeException e) {
+            } catch (SOAPException | RuntimeException | JsonProcessingException e) {
                 throw new HeaderHandlerException(
                         "Error in SOAP HeaderHandler: " + e.getMessage(), e);
             }
@@ -70,12 +73,23 @@ public class HeaderHandler implements SOAPHandler<SOAPMessageContext> {
         return true;
     }
 
-    private String retrieveTokenWithoutError(SoapToken token) {
-        String tokenValue = Objects.requireNonNull(token.getToken(), "The token must not be null");
+    private String retrieveTokenWithoutError() throws JsonProcessingException {
+        String tokenValue =
+                Objects.requireNonNull(tokenRetriever.getSoapToken(), "The token must not be null");
+
+        if (tokenValue.isEmpty()) {
+            throw new InvalidSoapTokenException("The SOAP token value must not be empty");
+        }
 
         if (tokenValue.toLowerCase().contains("error")) {
             throw new InvalidSoapTokenException("The SOAP token contains an error: " + tokenValue);
         }
+
+        if (SoapTokenUtils.getTokenExpiry(SoapTokenUtils.decodeTokenPayload(tokenValue))
+                < Instant.now().getEpochSecond()) {
+            throw new InvalidSoapTokenException("The SOAP token is expired");
+        }
+
         return tokenValue;
     }
 

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/security/SoapTokenRetriever.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/security/SoapTokenRetriever.java
@@ -1,0 +1,55 @@
+package uk.gov.di.ipv.cri.kbv.api.security;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.ipv.cri.kbv.api.util.SoapTokenUtils;
+
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+
+public class SoapTokenRetriever {
+    private static final Logger LOGGER = LogManager.getLogger();
+    private static final int MAX_NUMBER_OF_TOKEN_RETRIES = 3;
+    private static final long DELAY_BETWEEN_RETRY_MS = 500;
+    private static final long TOKEN_EXPIRY_THRESHOLD = TimeUnit.HOURS.toSeconds(2);
+
+    private final SoapToken soapToken;
+
+    public SoapTokenRetriever(SoapToken soapToken) {
+        this.soapToken = soapToken;
+    }
+
+    public String getSoapToken() {
+        int retry = 0;
+        String token = null;
+        boolean validTokenFetch = false;
+        while (retry < MAX_NUMBER_OF_TOKEN_RETRIES && !validTokenFetch) {
+            sleepIfRetry(retry);
+            try {
+                token = soapToken.getToken();
+                validTokenFetch = isTokenValid(SoapTokenUtils.decodeTokenPayload(token));
+            } catch (Exception e) {
+                LOGGER.error("Error while getting soap token", e);
+            }
+            retry++;
+        }
+        return token;
+    }
+
+    private static boolean isTokenValid(String decodeTokenPayload) throws JsonProcessingException {
+        long tokenExpiry = SoapTokenUtils.getTokenExpiry(decodeTokenPayload);
+        return SoapTokenUtils.isTokenValid(decodeTokenPayload)
+                && tokenExpiry > (Instant.now().getEpochSecond() + TOKEN_EXPIRY_THRESHOLD);
+    }
+
+    private static void sleepIfRetry(int currentIteration) {
+        if (currentIteration > 0) {
+            try {
+                Thread.sleep(DELAY_BETWEEN_RETRY_MS * currentIteration);
+            } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/ServiceFactory.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/ServiceFactory.java
@@ -20,6 +20,7 @@ import uk.gov.di.ipv.cri.kbv.api.security.HeaderHandler;
 import uk.gov.di.ipv.cri.kbv.api.security.HeaderHandlerResolver;
 import uk.gov.di.ipv.cri.kbv.api.security.KBVClientFactory;
 import uk.gov.di.ipv.cri.kbv.api.security.SoapToken;
+import uk.gov.di.ipv.cri.kbv.api.security.SoapTokenRetriever;
 
 import java.time.Clock;
 
@@ -91,7 +92,7 @@ public class ServiceFactory {
     private KBVClientFactory getKbvClientFactory() {
         TokenService tokenService = new TokenService();
         SoapToken soapToken = new SoapToken(APPLICATION, true, tokenService, configurationService);
-        HeaderHandler headerHandler = new HeaderHandler(soapToken);
+        HeaderHandler headerHandler = new HeaderHandler(new SoapTokenRetriever(soapToken));
         HeaderHandlerResolver headerResolver = new HeaderHandlerResolver(headerHandler);
 
         return new KBVClientFactory(

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/util/SoapTokenUtils.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/util/SoapTokenUtils.java
@@ -1,0 +1,41 @@
+package uk.gov.di.ipv.cri.kbv.api.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.time.Instant;
+import java.util.Base64;
+
+public class SoapTokenUtils {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private SoapTokenUtils() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    public static String decodeTokenPayload(String token) {
+        String[] jwtParts = token.split("\\.");
+        String encodedPayload = jwtParts[1];
+        String decodedToken = encodedPayload.replace('-', '+').replace('_', '/');
+        int paddingLength = 4 - (decodedToken.length() % 4);
+        if (paddingLength < 4) {
+            decodedToken += "=".repeat(paddingLength);
+        }
+        return new String(Base64.getDecoder().decode(decodedToken));
+    }
+
+    public static long getTokenExpiry(String tokenPayload) throws JsonProcessingException {
+        return OBJECT_MAPPER.readTree(tokenPayload).get("exp").asLong();
+    }
+
+    public static boolean isTokenValid(String tokenPayload) {
+        try {
+            return tokenPayload != null
+                    && getTokenExpiry(tokenPayload) > Instant.now().getEpochSecond()
+                    && !tokenPayload.trim().equalsIgnoreCase("error")
+                    && !tokenPayload.isEmpty();
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/security/HeaderHandlerTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/security/HeaderHandlerTest.java
@@ -21,7 +21,9 @@ import javax.xml.soap.SOAPPart;
 import javax.xml.ws.handler.MessageContext;
 import javax.xml.ws.handler.soap.SOAPMessageContext;
 
+import java.time.Instant;
 import java.util.Collections;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -32,11 +34,13 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.cri.kbv.api.security.SoapTokenRetrieverTest.encodeBase64Url;
+import static uk.gov.di.ipv.cri.kbv.api.security.SoapTokenRetrieverTest.generateValidToken;
 
 @ExtendWith(MockitoExtension.class)
 class HeaderHandlerTest {
-    private static final String MOCKED_TOKEN_VALUE = "mockedTokenValue";
-    @Mock private SoapToken soapTokenMock;
+    private static final String MOCKED_TOKEN_VALUE = generateValidToken();
+    @Mock private SoapTokenRetriever soapTokenRetrieverMock;
     @Mock private SOAPMessageContext soapMessageContextMock;
     @Mock private SOAPMessage soapMessageMock;
     @Mock private SOAPPart soapPartMock;
@@ -89,7 +93,8 @@ class HeaderHandlerTest {
 
         @Test
         void shouldHandleMessageOutbound() throws SOAPException {
-            when(soapTokenMock.getToken()).thenReturn(MOCKED_TOKEN_VALUE);
+            when(soapTokenRetrieverMock.getSoapToken()).thenReturn(MOCKED_TOKEN_VALUE);
+
             when(soapMessageContextMock.get(MessageContext.MESSAGE_OUTBOUND_PROPERTY))
                     .thenReturn(true);
             when(soapEnvelopeMock.getHeader()).thenReturn(soapHeader);
@@ -97,14 +102,14 @@ class HeaderHandlerTest {
             boolean result = headerHandler.handleMessage(soapMessageContextMock);
 
             verify(soapEnvelopeMock).addHeader();
-            verify(soapTokenMock).getToken();
+            verify(soapTokenRetrieverMock).getSoapToken();
             verify(soapMessageMock).saveChanges();
             assertTrue(result);
         }
 
         @Test
         void shouldDetachSoapCurrentHeaderIfNotNull() throws SOAPException {
-            when(soapTokenMock.getToken()).thenReturn(MOCKED_TOKEN_VALUE);
+            when(soapTokenRetrieverMock.getSoapToken()).thenReturn(MOCKED_TOKEN_VALUE);
             when(soapMessageContextMock.get(MessageContext.MESSAGE_OUTBOUND_PROPERTY))
                     .thenReturn(true);
             when(soapEnvelopeMock.getHeader()).thenReturn(soapHeader);
@@ -113,14 +118,14 @@ class HeaderHandlerTest {
 
             verify(soapHeader).detachNode();
             verify(soapEnvelopeMock).addHeader();
-            verify(soapTokenMock).getToken();
+            verify(soapTokenRetrieverMock).getSoapToken();
             verify(soapMessageMock).saveChanges();
             assertTrue(result);
         }
 
         @Test
         void shouldThrowHeaderHandlerExceptionWhenTokenIsNull() {
-            when(soapTokenMock.getToken()).thenReturn(null);
+            when(soapTokenRetrieverMock.getSoapToken()).thenReturn(null);
             when(soapMessageContextMock.get(MessageContext.MESSAGE_OUTBOUND_PROPERTY))
                     .thenReturn(true);
             Exception exception =
@@ -135,8 +140,44 @@ class HeaderHandlerTest {
         }
 
         @Test
+        void shouldThrowWhenTokenHasExpired() {
+            String token = "{}." + encodeBase64Url(String.format("{\"exp\": \"%d\"}", 0)) + ".{}";
+
+            when(soapTokenRetrieverMock.getSoapToken()).thenReturn(token);
+            when(soapMessageContextMock.get(MessageContext.MESSAGE_OUTBOUND_PROPERTY))
+                    .thenReturn(true);
+            Exception exception =
+                    assertThrows(
+                            HeaderHandlerException.class,
+                            () -> headerHandler.handleMessage(soapMessageContextMock),
+                            "Error in SOAP HeaderHandler");
+
+            assertEquals(
+                    "Error in SOAP HeaderHandler: The SOAP token is expired",
+                    exception.getMessage());
+        }
+
+        @Test
+        void shouldNotThrowWhenTokenIsNotExpired() {
+            String token =
+                    "{}."
+                            + encodeBase64Url(
+                                    String.format(
+                                            "{\"exp\": \"%d\"}",
+                                            Instant.now().getEpochSecond()
+                                                    + TimeUnit.HOURS.toSeconds(1)))
+                            + ".{}";
+
+            when(soapTokenRetrieverMock.getSoapToken()).thenReturn(token);
+            when(soapMessageContextMock.get(MessageContext.MESSAGE_OUTBOUND_PROPERTY))
+                    .thenReturn(true);
+
+            assertTrue(headerHandler.handleMessage(soapMessageContextMock));
+        }
+
+        @Test
         void shouldThrowHeaderHandlerExceptionWhenSoapTokenHasAnError() {
-            when(soapTokenMock.getToken()).thenReturn("Error");
+            when(soapTokenRetrieverMock.getSoapToken()).thenReturn("Error");
             when(soapMessageContextMock.get(MessageContext.MESSAGE_OUTBOUND_PROPERTY))
                     .thenReturn(true);
             Exception exception =
@@ -152,7 +193,7 @@ class HeaderHandlerTest {
 
         @Test
         void shouldThrowHeaderHandlerExceptionWhenThereIsASoapFault() {
-            when(soapTokenMock.getToken())
+            when(soapTokenRetrieverMock.getSoapToken())
                     .thenThrow(new InvalidSoapTokenException("SOAP Fault occurred"));
             when(soapMessageContextMock.get(MessageContext.MESSAGE_OUTBOUND_PROPERTY))
                     .thenReturn(true);

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/security/SoapTokenRetrieverTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/security/SoapTokenRetrieverTest.java
@@ -1,0 +1,209 @@
+package uk.gov.di.ipv.cri.kbv.api.security;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.Base64;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SoapTokenRetrieverTest {
+    private static final String MOCKED_VALID_TOKEN_VALUE = generateValidToken();
+    private static final String MOCKED_EXPIRED_TOKEN_VALUE = generateExpiredToken();
+    private static final String MOCKED_CLOSE_TO_EXPIRY_TOKEN = generateTokenExpiringIn5Mins();
+    private static final String MOCKED_MALFORMED_TOKEN = generateMalformedToken();
+    private static final String MOCKED_TOKEN_WITHOUT_EXP = generateTokenWithoutExpiryField();
+
+    @Mock private SoapToken soapTokenMock;
+    @InjectMocks private SoapTokenRetriever soapTokenRetriever;
+
+    @Test
+    void shouldReturnNullWhenTokenIsNull() {
+        when(soapTokenMock.getToken()).thenReturn(null);
+
+        String token = soapTokenRetriever.getSoapToken();
+
+        assertNull(token);
+    }
+
+    @Test
+    void shouldReturnEmptyStringWhenTokenIsEmpty() {
+        when(soapTokenMock.getToken()).thenReturn("");
+
+        String token = soapTokenRetriever.getSoapToken();
+
+        assertEquals("", token);
+    }
+
+    @Test
+    void shouldReturnValidToken() {
+        when(soapTokenMock.getToken()).thenReturn(MOCKED_VALID_TOKEN_VALUE);
+
+        String token = soapTokenRetriever.getSoapToken();
+
+        verify(soapTokenMock, times(1)).getToken();
+        assertEquals(MOCKED_VALID_TOKEN_VALUE, token);
+    }
+
+    @Test
+    void shouldReturnProvidedTokenWhenMalformed() {
+        when(soapTokenMock.getToken()).thenReturn(MOCKED_MALFORMED_TOKEN);
+
+        String token = soapTokenRetriever.getSoapToken();
+
+        verify(soapTokenMock, times(3)).getToken();
+        assertEquals(MOCKED_MALFORMED_TOKEN, token);
+    }
+
+    @Test
+    void shouldReturnProvidedTokenWhenNoExpiryField() {
+        when(soapTokenMock.getToken()).thenReturn(MOCKED_TOKEN_WITHOUT_EXP);
+
+        String token = soapTokenRetriever.getSoapToken();
+
+        verify(soapTokenMock, times(3)).getToken();
+        assertEquals(MOCKED_TOKEN_WITHOUT_EXP, token);
+    }
+
+    @Test
+    void shouldReturnValidTokenOnSecondRetry() {
+        when(soapTokenMock.getToken())
+                .thenReturn(MOCKED_EXPIRED_TOKEN_VALUE)
+                .thenReturn(MOCKED_VALID_TOKEN_VALUE);
+
+        String token = soapTokenRetriever.getSoapToken();
+
+        verify(soapTokenMock, times(2)).getToken();
+        assertEquals(MOCKED_VALID_TOKEN_VALUE, token);
+    }
+
+    @Test
+    void shouldReturnValidTokenOnThirdRetry() {
+        when(soapTokenMock.getToken())
+                .thenReturn(MOCKED_EXPIRED_TOKEN_VALUE)
+                .thenReturn(MOCKED_EXPIRED_TOKEN_VALUE)
+                .thenReturn(MOCKED_VALID_TOKEN_VALUE);
+
+        String token = soapTokenRetriever.getSoapToken();
+
+        verify(soapTokenMock, times(3)).getToken();
+        assertEquals(MOCKED_VALID_TOKEN_VALUE, token);
+    }
+
+    @Test
+    void shouldReturnNotRetryMoreThanThreeTimes() {
+        when(soapTokenMock.getToken())
+                .thenReturn(MOCKED_EXPIRED_TOKEN_VALUE)
+                .thenReturn(MOCKED_EXPIRED_TOKEN_VALUE)
+                .thenReturn(MOCKED_EXPIRED_TOKEN_VALUE)
+                .thenReturn(MOCKED_VALID_TOKEN_VALUE);
+
+        String token = soapTokenRetriever.getSoapToken();
+
+        verify(soapTokenMock, times(3)).getToken();
+        assertEquals(MOCKED_EXPIRED_TOKEN_VALUE, token);
+    }
+
+    @Test
+    void shouldRetryIfTokenIsExpiringSoon() {
+        when(soapTokenMock.getToken())
+                .thenReturn(MOCKED_CLOSE_TO_EXPIRY_TOKEN)
+                .thenReturn(MOCKED_VALID_TOKEN_VALUE);
+
+        String token = soapTokenRetriever.getSoapToken();
+
+        verify(soapTokenMock, times(2)).getToken();
+        assertEquals(MOCKED_VALID_TOKEN_VALUE, token);
+    }
+
+    @Test
+    void shouldRetryOnError() {
+        when(soapTokenMock.getToken()).thenReturn(MOCKED_EXPIRED_TOKEN_VALUE);
+
+        String token = soapTokenRetriever.getSoapToken();
+
+        verify(soapTokenMock, times(3)).getToken();
+        assertEquals(MOCKED_EXPIRED_TOKEN_VALUE, token);
+    }
+
+    @Test
+    void shouldSleepBetweenRetries() {
+        long expectedSleepDuration = 1000;
+        long start = System.currentTimeMillis();
+
+        when(soapTokenMock.getToken()).thenReturn(MOCKED_EXPIRED_TOKEN_VALUE);
+
+        String token = soapTokenRetriever.getSoapToken();
+
+        long end = System.currentTimeMillis();
+        long expectedElapse = start + expectedSleepDuration;
+
+        assertTrue(end >= expectedElapse);
+        verify(soapTokenMock, times(3)).getToken();
+        assertEquals(MOCKED_EXPIRED_TOKEN_VALUE, token);
+    }
+
+    private static final String TOKEN_HEADER =
+            encodeBase64Url("{\"kid\": \"dummy-kid\", \"alg\": \"RS256\"}");
+    private static final String TOKEN_SIGNATURE = encodeBase64Url("dummy-secret");
+
+    public static String generateValidToken() {
+        String encodedPayload =
+                encodeBase64Url(
+                        String.format(
+                                "{\"exp\": \"%d\"}",
+                                Instant.now().getEpochSecond() + TimeUnit.DAYS.toSeconds(1)));
+        return TOKEN_HEADER + "." + encodedPayload + "." + TOKEN_SIGNATURE;
+    }
+
+    private static String generateExpiredToken() {
+        String encodedPayload = encodeBase64Url(String.format("{\"exp\": \"%d\"}", 0));
+        return TOKEN_HEADER + "." + encodedPayload + "." + TOKEN_SIGNATURE;
+    }
+
+    private static String generateTokenExpiringIn5Mins() {
+        String encodedPayload =
+                encodeBase64Url(
+                        String.format(
+                                "{\"exp\": \"%d\"}",
+                                Instant.now().getEpochSecond() + TimeUnit.MINUTES.toSeconds(5)));
+        return TOKEN_HEADER + "." + encodedPayload + "." + TOKEN_SIGNATURE;
+    }
+
+    private static String generateMalformedToken() {
+        String encodedPayload =
+                encodeBase64Url(
+                        String.format(
+                                "{\"exp\": \"%d\"",
+                                Instant.now().getEpochSecond() + TimeUnit.MINUTES.toSeconds(5)));
+        return TOKEN_HEADER + "." + encodedPayload + "." + TOKEN_SIGNATURE;
+    }
+
+    private static String generateTokenWithoutExpiryField() {
+        String encodedPayload =
+                encodeBase64Url(
+                        String.format(
+                                "{\"foo\": \"%d\"}",
+                                Instant.now().getEpochSecond() + TimeUnit.MINUTES.toSeconds(5)));
+        return TOKEN_HEADER + "." + encodedPayload + "." + TOKEN_SIGNATURE;
+    }
+
+    public static String encodeBase64Url(String input) {
+        return Base64.getEncoder()
+                .encodeToString(input.getBytes())
+                .replace('+', '-')
+                .replace('/', '_')
+                .replace("=", "");
+    }
+}

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/util/SoapTokenUtilsTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/util/SoapTokenUtilsTest.java
@@ -1,0 +1,80 @@
+package uk.gov.di.ipv.cri.kbv.api.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockitoExtension.class)
+class SoapTokenUtilsTest {
+
+    @Test
+    void shouldReturnTokenExpiry() throws JsonProcessingException {
+        String payload = "{\"exp\":123456}";
+        assertEquals(123456, SoapTokenUtils.getTokenExpiry(payload));
+    }
+
+    @Test
+    void shouldThrowWhenNoExpField() {
+        String payload = "{\"foo\":123456}";
+        assertThrows(Exception.class, () -> SoapTokenUtils.getTokenExpiry(payload));
+    }
+
+    @Test
+    void shouldThrowWhenMalformedJson() {
+        String payload = "dummy";
+        assertThrows(Exception.class, () -> SoapTokenUtils.getTokenExpiry(payload));
+    }
+
+    @Test
+    void shouldDefaultWhenNonIntExp() throws JsonProcessingException {
+        String payload = "{\"exp\":\"foo\"}";
+        assertEquals(0, SoapTokenUtils.getTokenExpiry(payload));
+    }
+
+    @Test
+    void shouldDecodePayload() {
+        String payload = "{\"foo\":\"bar\"}";
+        String token = generateToken(payload);
+        assertEquals(payload, SoapTokenUtils.decodeTokenPayload(token));
+    }
+
+    @Test
+    void shouldNotValidateIfTokenIsError() {
+        assertFalse(SoapTokenUtils.isTokenValid("error"));
+    }
+
+    @Test
+    void shouldNotValidateIfTokenIsExpired() {
+        String payload = "{\"exp\":\"0\"}";
+        String token = generateToken(payload);
+        assertFalse(SoapTokenUtils.isTokenValid(token));
+    }
+
+    @Test
+    void shouldNotValidateIfTokenIsEmpty() {
+        assertFalse(SoapTokenUtils.isTokenValid(""));
+    }
+
+    private static final String TOKEN_HEADER =
+            encodeBase64Url("{\"kid\": \"dummy-kid\", \"alg\": \"RS256\"}");
+    private static final String TOKEN_SIGNATURE = encodeBase64Url("dummy-secret");
+
+    public static String generateToken(String payload) {
+        return TOKEN_HEADER + "." + encodeBase64Url(payload) + "." + TOKEN_SIGNATURE;
+    }
+
+    public static String encodeBase64Url(String input) {
+        return Base64.getEncoder()
+                .encodeToString(input.getBytes())
+                .replace('+', '-')
+                .replace('/', '_')
+                .replace("=", "");
+    }
+}


### PR DESCRIPTION
## Proposed changes

### What changed
Added an exponential retry logic for when the token is returned back to us by Experian as "error".

The retry logic works as follows:

1. Attempt to get a token
2. If the token is error sleep for 500ms * the current iteration
3. If after 3 retries the a valid token is not returned: return whatever Experian has provided

The threshold for expired tokens is 2 hours. 

### Why did it change
To mitigate against errors that can be solved by re-trying authentication with Experian.

### Issue tracking
- [OJ-2841](https://govukverify.atlassian.net/browse/OJ-2841)


[OJ-2841]: https://govukverify.atlassian.net/browse/OJ-2841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ