### PR TITLE
OJ-2908: SOAP token cache

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/security/HeaderHandler.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/security/HeaderHandler.java
@@ -82,7 +82,7 @@ public class HeaderHandler implements SOAPHandler<SOAPMessageContext> {
             throw new InvalidSoapTokenException("The SOAP token contains an error: " + tokenValue);
         }
 
-        if (tokenRetriever.hasTokenExpired()) {
+        if (tokenRetriever.hasTokenExpired(tokenValue)) {
             throw new InvalidSoapTokenException("The SOAP token is expired");
         }
 

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/security/SoapTokenRetriever.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/security/SoapTokenRetriever.java
@@ -39,7 +39,7 @@ public class SoapTokenRetriever {
                 token = soapToken.getToken();
                 validTokenFetch = isTokenValid(SoapTokenUtils.decodeTokenPayload(token));
             } catch (Exception e) {
-                LOGGER.error("Error while getting soap token", e);
+                LOGGER.error("Error while getting soap token: {}", e.getMessage());
             }
             retry++;
         }
@@ -52,8 +52,8 @@ public class SoapTokenRetriever {
                     LOGGER.info(
                             "Updated cached token with the one received from Experian. The token given by Experian is valid but not within our threshold, using anyway...");
                 }
-            } catch (Exception ignore) {
-                LOGGER.warn("Cached SOAP token and token from Experian are both invalid");
+            } catch (Exception e) {
+                LOGGER.warn("Cached SOAP token and token from Experian are both invalid: {}.", e.getMessage());
             }
 
             return token;

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/security/SoapTokenRetriever.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/security/SoapTokenRetriever.java
@@ -53,7 +53,9 @@ public class SoapTokenRetriever {
                             "Updated cached token with the one received from Experian. The token given by Experian is valid but not within our threshold, using anyway...");
                 }
             } catch (Exception e) {
-                LOGGER.warn("Cached SOAP token and token from Experian are both invalid: {}.", e.getMessage());
+                LOGGER.warn(
+                        "Cached SOAP token and token from Experian are both invalid: {}.",
+                        e.getMessage());
             }
 
             return token;

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/security/SoapTokenRetriever.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/security/SoapTokenRetriever.java
@@ -8,6 +8,9 @@ import uk.gov.di.ipv.cri.kbv.api.util.SoapTokenUtils;
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 
+import static uk.gov.di.ipv.cri.kbv.api.util.SoapTokenUtils.decodeTokenPayload;
+import static uk.gov.di.ipv.cri.kbv.api.util.SoapTokenUtils.isTokenPayloadValid;
+
 public class SoapTokenRetriever {
     private static final Logger LOGGER = LogManager.getLogger();
     private static final int MAX_NUMBER_OF_TOKEN_RETRIES = 3;
@@ -27,49 +30,58 @@ public class SoapTokenRetriever {
             LOGGER.info("Using cached SOAP token");
             return cachedToken;
         }
-
         LOGGER.info("Retrieving SOAP token from Experian...");
         String token = null;
 
         for (int retry = 0; retry < MAX_NUMBER_OF_TOKEN_RETRIES; retry++) {
-            sleepIfRetry(retry);
+            sleepBeforeRetry(retry);
             try {
                 token = soapToken.getToken();
-                if (isTokenValidWithinThreshold(SoapTokenUtils.decodeTokenPayload(token))) {
+                if (isTokenValidWithinThreshold(decodeTokenPayload(token))) {
                     LOGGER.info("Successfully retrieved a valid token.");
                     cachedToken = token;
                     return cachedToken;
                 }
+            } catch (NullPointerException e) {
+                LOGGER.debug("Error while getting SOAP token: {}", e.getMessage());
             } catch (Exception e) {
                 LOGGER.error("Error while getting SOAP token: {}", e.getMessage());
             }
         }
 
-        if (token != null && !isCachedTokenValid()) {
-            try {
-                if (SoapTokenUtils.isTokenPayloadValid(SoapTokenUtils.decodeTokenPayload(token))) {
-                    cachedToken = token;
-                    LOGGER.info(
-                            "Updated cached token with the one received from Experian. The token given by Experian is valid but not within our threshold, using anyway...");
-                }
-            } catch (Exception e) {
-                LOGGER.warn(
-                        "Cached SOAP token and retrieved token are both invalid: {}",
-                        e.getMessage());
-            }
-            return token;
-        }
+        String fallbackToken = cacheExperianTokenOutsideThreshold(token);
 
+        if (fallbackToken != null) {
+            return fallbackToken;
+        }
         LOGGER.warn(
                 "Received an invalid SOAP token from Experian after retries, using valid cached token for now...");
         return cachedToken;
     }
 
+    private String cacheExperianTokenOutsideThreshold(String token) {
+        if (token != null && !isCachedTokenValid()) {
+            try {
+                if (isTokenPayloadValid(decodeTokenPayload(token))) {
+                    cachedToken = token;
+                    LOGGER.info(
+                            "Updated cached token with the one received from Experian. "
+                                    + "The token given by Experian is valid but not "
+                                    + "within our threshold, using anyway...");
+                }
+            } catch (Exception e) {
+                LOGGER.warn(
+                        "Cached SOAP token and token from Experian token are both invalid: {}",
+                        e.getMessage());
+            }
+            return token;
+        }
+        return null;
+    }
+
     public boolean isCachedTokenValid() {
         try {
-            return cachedToken != null
-                    && SoapTokenUtils.isTokenPayloadValid(
-                            SoapTokenUtils.decodeTokenPayload(cachedToken));
+            return cachedToken != null && isTokenPayloadValid(decodeTokenPayload(cachedToken));
         } catch (Exception e) {
             LOGGER.debug("Token validation failed due to an error: {}", e.getMessage());
             return false;
@@ -79,21 +91,37 @@ public class SoapTokenRetriever {
     public boolean isCachedTokenValidAndWithinThreshold() {
         try {
             return cachedToken != null
-                    && isTokenValidWithinThreshold(SoapTokenUtils.decodeTokenPayload(cachedToken));
+                    && isTokenValidWithinThreshold(decodeTokenPayload(cachedToken));
         } catch (Exception e) {
             LOGGER.debug("Threshold validation failed due to error: {}", e.getMessage());
             return false;
         }
     }
 
+    public boolean hasTokenExpired() {
+        try {
+            return SoapTokenUtils.getTokenExpiry(
+                            SoapTokenUtils.decodeTokenPayload(this.getSoapToken()))
+                    < Instant.now().getEpochSecond();
+        } catch (JsonProcessingException e) {
+            LOGGER.error(
+                    "Token expiration check failed due to a JsonProcessingException error: {}",
+                    e.getMessage());
+            return true;
+        } catch (Exception e) {
+            LOGGER.debug("Token expiration check failed due to an error: {}", e.getMessage());
+            return true;
+        }
+    }
+
     private static boolean isTokenValidWithinThreshold(String decodeTokenPayload)
             throws JsonProcessingException {
         long tokenExpiry = SoapTokenUtils.getTokenExpiry(decodeTokenPayload);
-        return SoapTokenUtils.isTokenPayloadValid(decodeTokenPayload)
+        return isTokenPayloadValid(decodeTokenPayload)
                 && tokenExpiry > (Instant.now().getEpochSecond() + TOKEN_EXPIRY_THRESHOLD);
     }
 
-    private static void sleepIfRetry(int currentIteration) {
+    private static void sleepBeforeRetry(int currentIteration) {
         if (currentIteration > 0) {
             try {
                 Thread.sleep(DELAY_BETWEEN_RETRY_MS * currentIteration);

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/util/SoapTokenUtils.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/util/SoapTokenUtils.java
@@ -14,14 +14,8 @@ public class SoapTokenUtils {
     }
 
     public static String decodeTokenPayload(String token) {
-        String[] jwtParts = token.split("\\.");
-        String encodedPayload = jwtParts[1];
-        String decodedToken = encodedPayload.replace('-', '+').replace('_', '/');
-        int paddingLength = 4 - (decodedToken.length() % 4);
-        if (paddingLength < 4) {
-            decodedToken += "=".repeat(paddingLength);
-        }
-        return new String(Base64.getDecoder().decode(decodedToken));
+        String encodedPayload = token.split("\\.", 3)[1];
+        return new String(Base64.getUrlDecoder().decode(encodedPayload));
     }
 
     public static long getTokenExpiry(String tokenPayload) throws JsonProcessingException {

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/util/SoapTokenUtils.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/util/SoapTokenUtils.java
@@ -2,12 +2,15 @@ package uk.gov.di.ipv.cri.kbv.api.util;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.time.Instant;
 import java.util.Base64;
 
 public class SoapTokenUtils {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final Logger LOGGER = LogManager.getLogger();
 
     private SoapTokenUtils() {
         throw new IllegalStateException("Utility class");
@@ -22,13 +25,14 @@ public class SoapTokenUtils {
         return OBJECT_MAPPER.readTree(tokenPayload).get("exp").asLong();
     }
 
-    public static boolean isTokenValid(String tokenPayload) {
+    public static boolean isTokenPayloadValid(String tokenPayload) {
         try {
             return tokenPayload != null
                     && !tokenPayload.isEmpty()
                     && !tokenPayload.toLowerCase().contains("error")
                     && getTokenExpiry(tokenPayload) > Instant.now().getEpochSecond();
         } catch (Exception e) {
+            LOGGER.debug("Token Payload validation failed due to an error: {}", e.getMessage());
             return false;
         }
     }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/util/SoapTokenUtils.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/util/SoapTokenUtils.java
@@ -16,13 +16,8 @@ public class SoapTokenUtils {
         throw new IllegalStateException("Utility class");
     }
 
-    public static String decodeTokenPayload(String token) {
-        String encodedPayload = token.split("\\.", 3)[1];
-        return new String(Base64.getUrlDecoder().decode(encodedPayload));
-    }
-
     public static long getTokenExpiry(String tokenPayload) throws JsonProcessingException {
-        return OBJECT_MAPPER.readTree(tokenPayload).get("exp").asLong();
+        return OBJECT_MAPPER.readTree(decodeTokenPayload(tokenPayload)).get("exp").asLong();
     }
 
     public static boolean isTokenPayloadValid(String tokenPayload) {
@@ -35,5 +30,11 @@ public class SoapTokenUtils {
             LOGGER.debug("Token Payload validation failed due to an error: {}", e.getMessage());
             return false;
         }
+    }
+
+    private static String decodeTokenPayload(String token) {
+        String encodedPayload = token.split("\\.", 3)[1];
+
+        return new String(Base64.getUrlDecoder().decode(encodedPayload));
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/security/HeaderHandlerTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/security/HeaderHandlerTest.java
@@ -144,7 +144,7 @@ class HeaderHandlerTest {
             String token = "{}." + encodeBase64Url(String.format("{\"exp\": \"%d\"}", 0)) + ".{}";
 
             when(soapTokenRetrieverMock.getSoapToken()).thenReturn(token);
-            when(soapTokenRetrieverMock.hasTokenExpired()).thenReturn(true);
+            when(soapTokenRetrieverMock.hasTokenExpired(token)).thenReturn(true);
             when(soapMessageContextMock.get(MessageContext.MESSAGE_OUTBOUND_PROPERTY))
                     .thenReturn(true);
             Exception exception =

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/security/HeaderHandlerTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/security/HeaderHandlerTest.java
@@ -144,6 +144,7 @@ class HeaderHandlerTest {
             String token = "{}." + encodeBase64Url(String.format("{\"exp\": \"%d\"}", 0)) + ".{}";
 
             when(soapTokenRetrieverMock.getSoapToken()).thenReturn(token);
+            when(soapTokenRetrieverMock.hasTokenExpired()).thenReturn(true);
             when(soapMessageContextMock.get(MessageContext.MESSAGE_OUTBOUND_PROPERTY))
                     .thenReturn(true);
             Exception exception =

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/security/SoapTokenRetrieverTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/security/SoapTokenRetrieverTest.java
@@ -40,23 +40,13 @@ class SoapTokenRetrieverTest {
     }
 
     @Test
-    void hasTokenExpiredReturnsTrueWhenTokenIsExpired() {
-        when(soapTokenMock.getToken()).thenReturn(null);
-
-        assertTrue(soapTokenRetriever.hasTokenExpired());
-
-        verify(soapTokenMock, times(3)).getToken();
+    void hasTokenExpiredReturnsTrueWhenTheirIsNoToken() {
+        assertTrue(soapTokenRetriever.hasTokenExpired(null));
     }
 
     @Test
     void hasTokenExpiredReturnsFalseWhenTokenIsValid() {
-        when(soapTokenMock.getToken())
-                .thenReturn(MOCKED_VALID_TOKEN_VALUE)
-                .thenReturn(generateValidToken2());
-
-        assertFalse(soapTokenRetriever.hasTokenExpired());
-
-        verify(soapTokenMock, times(1)).getToken();
+        assertFalse(soapTokenRetriever.hasTokenExpired(generateValidToken2()));
     }
 
     @Test

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/security/SoapTokenRetrieverTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/security/SoapTokenRetrieverTest.java
@@ -11,6 +11,7 @@ import java.util.Base64;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -36,6 +37,26 @@ class SoapTokenRetrieverTest {
         String token = soapTokenRetriever.getSoapToken();
 
         assertNull(token);
+    }
+
+    @Test
+    void hasTokenExpiredReturnsTrueWhenTokenIsExpired() {
+        when(soapTokenMock.getToken()).thenReturn(null);
+
+        assertTrue(soapTokenRetriever.hasTokenExpired());
+
+        verify(soapTokenMock, times(3)).getToken();
+    }
+
+    @Test
+    void hasTokenExpiredReturnsFalseWhenTokenIsValid() {
+        when(soapTokenMock.getToken())
+                .thenReturn(MOCKED_VALID_TOKEN_VALUE)
+                .thenReturn(generateValidToken2());
+
+        assertFalse(soapTokenRetriever.hasTokenExpired());
+
+        verify(soapTokenMock, times(1)).getToken();
     }
 
     @Test

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/security/SoapTokenRetrieverTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/security/SoapTokenRetrieverTest.java
@@ -10,7 +10,10 @@ import java.time.Instant;
 import java.util.Base64;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -257,10 +260,6 @@ class SoapTokenRetrieverTest {
     }
 
     public static String encodeBase64Url(String input) {
-        return Base64.getEncoder()
-                .encodeToString(input.getBytes())
-                .replace('+', '-')
-                .replace('/', '_')
-                .replace("=", "");
+        return Base64.getEncoder().withoutPadding().encodeToString(input.getBytes());
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/util/SoapTokenUtilsTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/util/SoapTokenUtilsTest.java
@@ -47,19 +47,19 @@ class SoapTokenUtilsTest {
 
     @Test
     void shouldNotValidateIfTokenIsError() {
-        assertFalse(SoapTokenUtils.isTokenValid("error"));
+        assertFalse(SoapTokenUtils.isTokenPayloadValid("error"));
     }
 
     @Test
     void shouldNotValidateIfTokenIsExpired() {
         String payload = "{\"exp\":\"0\"}";
         String token = generateToken(payload);
-        assertFalse(SoapTokenUtils.isTokenValid(token));
+        assertFalse(SoapTokenUtils.isTokenPayloadValid(token));
     }
 
     @Test
     void shouldNotValidateIfTokenIsEmpty() {
-        assertFalse(SoapTokenUtils.isTokenValid(""));
+        assertFalse(SoapTokenUtils.isTokenPayloadValid(""));
     }
 
     private static final String TOKEN_HEADER =

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/util/SoapTokenUtilsTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/util/SoapTokenUtilsTest.java
@@ -71,10 +71,6 @@ class SoapTokenUtilsTest {
     }
 
     public static String encodeBase64Url(String input) {
-        return Base64.getEncoder()
-                .encodeToString(input.getBytes())
-                .replace('+', '-')
-                .replace('/', '_')
-                .replace("=", "");
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(input.getBytes());
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/util/SoapTokenUtilsTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/util/SoapTokenUtilsTest.java
@@ -16,33 +16,29 @@ class SoapTokenUtilsTest {
 
     @Test
     void shouldReturnTokenExpiry() throws JsonProcessingException {
-        String payload = "{\"exp\":123456}";
+        String payload = generateToken("{\"exp\":123456}");
+
         assertEquals(123456, SoapTokenUtils.getTokenExpiry(payload));
     }
 
     @Test
     void shouldThrowWhenNoExpField() {
-        String payload = "{\"foo\":123456}";
+        String payload = generateToken("{\"foo\":123456}");
         assertThrows(Exception.class, () -> SoapTokenUtils.getTokenExpiry(payload));
     }
 
     @Test
     void shouldThrowWhenMalformedJson() {
-        String payload = "dummy";
+        String payload = generateToken("dummy");
+
         assertThrows(Exception.class, () -> SoapTokenUtils.getTokenExpiry(payload));
     }
 
     @Test
     void shouldDefaultWhenNonIntExp() throws JsonProcessingException {
-        String payload = "{\"exp\":\"foo\"}";
-        assertEquals(0, SoapTokenUtils.getTokenExpiry(payload));
-    }
+        String payload = generateToken("{\"exp\":\"foo\"}");
 
-    @Test
-    void shouldDecodePayload() {
-        String payload = "{\"foo\":\"bar\"}";
-        String token = generateToken(payload);
-        assertEquals(payload, SoapTokenUtils.decodeTokenPayload(token));
+        assertEquals(0, SoapTokenUtils.getTokenExpiry(payload));
     }
 
     @Test
@@ -52,14 +48,16 @@ class SoapTokenUtilsTest {
 
     @Test
     void shouldNotValidateIfTokenIsExpired() {
-        String payload = "{\"exp\":\"0\"}";
+        String payload = generateToken("{\"exp\":\"0\"}");
         String token = generateToken(payload);
+
         assertFalse(SoapTokenUtils.isTokenPayloadValid(token));
     }
 
     @Test
     void shouldNotValidateIfTokenIsEmpty() {
-        assertFalse(SoapTokenUtils.isTokenPayloadValid(""));
+
+        assertFalse(SoapTokenUtils.isTokenPayloadValid(generateToken("")));
     }
 
     private static final String TOKEN_HEADER =


### PR DESCRIPTION
## Proposed changes

### What changed
Added caching to the SOAP token.

A token is considered invalid if it's expiry is passed our threshold (2 hours).

If the token expiry is over our threshold, when calling getSoapToken() we will fetch a new token.

If the token is over our expiry and we fail to get a new token from experian, we will use the valid (but past our threshold) cached token. 

If both experian and our cache is invalid then we will return the token received and let the existing error handling continue. 


### Why did it change
So that we do not always making a call to Experian. If the LoginWithCertificate breaks, we can still fall back to our cached valid token. 

### Issue tracking
- [OJ-2908](https://govukverify.atlassian.net/browse/OJ-2908)


[OJ-2908]: https://govukverify.atlassian.net/browse/OJ-2908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ