### PR TITLE
OJ-2842: token retry during journey

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/gateway/IdentityIQWrapper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/gateway/IdentityIQWrapper.java
@@ -5,68 +5,48 @@ import com.experian.uk.schema.experian.identityiq.services.webservice.RTQRequest
 import com.experian.uk.schema.experian.identityiq.services.webservice.RTQResponse2;
 import com.experian.uk.schema.experian.identityiq.services.webservice.SAARequest;
 import com.experian.uk.schema.experian.identityiq.services.webservice.SAAResponse2;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import uk.gov.di.ipv.cri.kbv.api.exception.InvalidSoapTokenException;
 import uk.gov.di.ipv.cri.kbv.api.security.KBVClientFactory;
 import uk.gov.di.ipv.cri.kbv.api.security.SoapTokenRetriever;
 
-import java.util.function.Supplier;
-
-import static uk.gov.di.ipv.cri.kbv.api.util.SoapTokenUtils.getTokenExpiryAsDateTime;
-
 public class IdentityIQWrapper {
-    private static final Logger LOGGER = LogManager.getLogger();
-    private final Supplier<KBVClientFactory> kbvClientFactorySupplier;
-    private final Supplier<SoapTokenRetriever> soapTokenRetrieverSupplier;
+    private final KBVClientFactory kbvClientFactory;
 
-    private String soapToken;
+    private String currentToken;
     private IdentityIQWebServiceSoap identityIQWebServiceSoap;
     private SoapTokenRetriever soapTokenRetriever;
 
     public IdentityIQWrapper(
-            Supplier<KBVClientFactory> kbvClientFactorySupplier,
-            Supplier<SoapTokenRetriever> soapTokenRetriever) {
+            KBVClientFactory kbvClientFactory, SoapTokenRetriever soapTokenRetriever) {
 
-        this.kbvClientFactorySupplier = kbvClientFactorySupplier;
-        this.soapTokenRetrieverSupplier = soapTokenRetriever;
+        this.kbvClientFactory = kbvClientFactory;
+        this.soapTokenRetriever = soapTokenRetriever;
 
-        refreshClient();
+        this.refreshSoapToken();
     }
 
     public SAAResponse2 saa(SAARequest sAARequest) {
-        refreshSoapToken();
+        this.refreshSoapToken();
+
         return identityIQWebServiceSoap.saa(sAARequest);
     }
 
     public RTQResponse2 rtq(RTQRequest rTQRequest) {
         refreshSoapToken();
+
         return identityIQWebServiceSoap.rtq(rTQRequest);
     }
 
     private void refreshSoapToken() {
         try {
-            if (soapTokenRetriever.isTokenValidWithinThreshold(soapToken)) {
-                LOGGER.info("SOAP Token is valid - not expired.");
-                return;
+            String newSoapToken = soapTokenRetriever.getSoapToken();
+            if (this.currentToken == null || !this.currentToken.equalsIgnoreCase(newSoapToken)) {
+                this.currentToken = newSoapToken;
+                this.identityIQWebServiceSoap = kbvClientFactory.createClient();
             }
-
-            String tokenExpiryAsDateTime = getTokenExpiryAsDateTime(soapToken);
-            LOGGER.info("SOAP Token is outside threshold: {}", tokenExpiryAsDateTime);
-
-            refreshClient();
-
-            tokenExpiryAsDateTime = getTokenExpiryAsDateTime(soapTokenRetriever.getSoapToken());
-            LOGGER.info("New SOAP Token retrieved with expiry: {}", tokenExpiryAsDateTime);
         } catch (Exception e) {
             throw new InvalidSoapTokenException(
                     "SOAP Token could not be refreshed: " + e.getMessage());
         }
-    }
-
-    private void refreshClient() {
-        this.soapTokenRetriever = soapTokenRetrieverSupplier.get();
-        this.soapToken = soapTokenRetriever.getSoapToken();
-        this.identityIQWebServiceSoap = kbvClientFactorySupplier.get().createClient();
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/gateway/IdentityIQWrapper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/gateway/IdentityIQWrapper.java
@@ -1,0 +1,72 @@
+package uk.gov.di.ipv.cri.kbv.api.gateway;
+
+import com.experian.uk.schema.experian.identityiq.services.webservice.IdentityIQWebServiceSoap;
+import com.experian.uk.schema.experian.identityiq.services.webservice.RTQRequest;
+import com.experian.uk.schema.experian.identityiq.services.webservice.RTQResponse2;
+import com.experian.uk.schema.experian.identityiq.services.webservice.SAARequest;
+import com.experian.uk.schema.experian.identityiq.services.webservice.SAAResponse2;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.ipv.cri.kbv.api.exception.InvalidSoapTokenException;
+import uk.gov.di.ipv.cri.kbv.api.security.KBVClientFactory;
+import uk.gov.di.ipv.cri.kbv.api.security.SoapTokenRetriever;
+import uk.gov.di.ipv.cri.kbv.api.util.SoapTokenUtils;
+
+import java.util.function.Supplier;
+
+public class IdentityIQWrapper {
+    private static final Logger LOGGER = LogManager.getLogger();
+    private final Supplier<KBVClientFactory> kbvClientFactorySupplier;
+    private final Supplier<SoapTokenRetriever> soapTokenRetrieverSupplier;
+
+    private String soapToken;
+    private IdentityIQWebServiceSoap identityIQWebServiceSoap;
+    private SoapTokenRetriever soapTokenRetriever;
+
+    public IdentityIQWrapper(
+            Supplier<KBVClientFactory> kbvClientFactorySupplier,
+            Supplier<SoapTokenRetriever> soapTokenRetriever) {
+
+        this.kbvClientFactorySupplier = kbvClientFactorySupplier;
+        this.soapTokenRetrieverSupplier = soapTokenRetriever;
+
+        refreshClient();
+    }
+
+    public SAAResponse2 saa(SAARequest sAARequest) {
+        refreshSoapToken();
+        return identityIQWebServiceSoap.saa(sAARequest);
+    }
+
+    public RTQResponse2 rtq(RTQRequest rTQRequest) {
+        refreshSoapToken();
+        return identityIQWebServiceSoap.rtq(rTQRequest);
+    }
+
+    private void refreshSoapToken() {
+        try {
+            if (!SoapTokenUtils.isTokenValidWithinThreshold(soapToken)) {
+                LOGGER.info("SOAP Token is valid - not expired.");
+                return;
+            }
+
+            LOGGER.info("SOAP Token has expired: {}", SoapTokenUtils.getTokenExpiry(soapToken));
+
+            refreshClient();
+
+            LOGGER.info(
+                    "New SOAP Token retrieved with expiry: {}",
+                    SoapTokenUtils.getTokenExpiry(soapTokenRetriever.getSoapToken()));
+        } catch (JsonProcessingException e) {
+            throw new InvalidSoapTokenException(
+                    "SOAP Token could not be refreshed: " + e.getMessage());
+        }
+    }
+
+    private void refreshClient() {
+        this.soapTokenRetriever = soapTokenRetrieverSupplier.get();
+        this.soapToken = soapTokenRetriever.getSoapToken();
+        this.identityIQWebServiceSoap = kbvClientFactorySupplier.get().createClient();
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/gateway/IdentityIQWrapper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/gateway/IdentityIQWrapper.java
@@ -5,15 +5,15 @@ import com.experian.uk.schema.experian.identityiq.services.webservice.RTQRequest
 import com.experian.uk.schema.experian.identityiq.services.webservice.RTQResponse2;
 import com.experian.uk.schema.experian.identityiq.services.webservice.SAARequest;
 import com.experian.uk.schema.experian.identityiq.services.webservice.SAAResponse2;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.ipv.cri.kbv.api.exception.InvalidSoapTokenException;
 import uk.gov.di.ipv.cri.kbv.api.security.KBVClientFactory;
 import uk.gov.di.ipv.cri.kbv.api.security.SoapTokenRetriever;
-import uk.gov.di.ipv.cri.kbv.api.util.SoapTokenUtils;
 
 import java.util.function.Supplier;
+
+import static uk.gov.di.ipv.cri.kbv.api.util.SoapTokenUtils.getTokenExpiryAsDateTime;
 
 public class IdentityIQWrapper {
     private static final Logger LOGGER = LogManager.getLogger();
@@ -46,19 +46,19 @@ public class IdentityIQWrapper {
 
     private void refreshSoapToken() {
         try {
-            if (!SoapTokenUtils.isTokenValidWithinThreshold(soapToken)) {
+            if (soapTokenRetriever.isTokenValidWithinThreshold(soapToken)) {
                 LOGGER.info("SOAP Token is valid - not expired.");
                 return;
             }
 
-            LOGGER.info("SOAP Token has expired: {}", SoapTokenUtils.getTokenExpiry(soapToken));
+            String tokenExpiryAsDateTime = getTokenExpiryAsDateTime(soapToken);
+            LOGGER.info("SOAP Token is outside threshold: {}", tokenExpiryAsDateTime);
 
             refreshClient();
 
-            LOGGER.info(
-                    "New SOAP Token retrieved with expiry: {}",
-                    SoapTokenUtils.getTokenExpiry(soapTokenRetriever.getSoapToken()));
-        } catch (JsonProcessingException e) {
+            tokenExpiryAsDateTime = getTokenExpiryAsDateTime(soapTokenRetriever.getSoapToken());
+            LOGGER.info("New SOAP Token retrieved with expiry: {}", tokenExpiryAsDateTime);
+        } catch (Exception e) {
             throw new InvalidSoapTokenException(
                     "SOAP Token could not be refreshed: " + e.getMessage());
         }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/gateway/KBVGateway.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/gateway/KBVGateway.java
@@ -3,7 +3,6 @@ package uk.gov.di.ipv.cri.kbv.api.gateway;
 import com.experian.uk.schema.experian.identityiq.services.webservice.ArrayOfString;
 import com.experian.uk.schema.experian.identityiq.services.webservice.Control;
 import com.experian.uk.schema.experian.identityiq.services.webservice.Error;
-import com.experian.uk.schema.experian.identityiq.services.webservice.IdentityIQWebServiceSoap;
 import com.experian.uk.schema.experian.identityiq.services.webservice.RTQRequest;
 import com.experian.uk.schema.experian.identityiq.services.webservice.RTQResponse2;
 import com.experian.uk.schema.experian.identityiq.services.webservice.Results;
@@ -36,14 +35,14 @@ public class KBVGateway {
     private final StartAuthnAttemptRequestMapper saaRequestMapper;
     private final ResponseToQuestionMapper responseToQuestionMapper;
     private final QuestionsResponseMapper questionsResponseMapper;
-    private final IdentityIQWebServiceSoap identityIQWebServiceSoap;
+    private final IdentityIQWrapper identityIQWebServiceSoap;
     private final MetricsService metricsService;
 
     KBVGateway(
             StartAuthnAttemptRequestMapper saaRequestMapper,
             ResponseToQuestionMapper responseToQuestionMapper,
             QuestionsResponseMapper questionsResponseMapper,
-            IdentityIQWebServiceSoap identityIQWebServiceSoap,
+            IdentityIQWrapper identityIQWebServiceSoap,
             MetricsService metricsService) {
         this.identityIQWebServiceSoap =
                 Objects.requireNonNull(

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/gateway/KBVGatewayFactory.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/gateway/KBVGatewayFactory.java
@@ -7,23 +7,21 @@ import uk.gov.di.ipv.cri.kbv.api.security.KBVClientFactory;
 import uk.gov.di.ipv.cri.kbv.api.security.SoapTokenRetriever;
 import uk.gov.di.ipv.cri.kbv.api.service.MetricsService;
 
-import java.util.function.Supplier;
-
 public class KBVGatewayFactory {
     private final KeyStoreLoader keyStoreLoader;
     private final ConfigurationService configurationService;
-    private final Supplier<KBVClientFactory> kbvClientFactorySupplier;
-    private final Supplier<SoapTokenRetriever> soapTokenRetrieverSupplier;
+    private final SoapTokenRetriever soapTokenRetriever;
+    private final KBVClientFactory kbvClientFactory;
 
     public KBVGatewayFactory(
             KeyStoreLoader keyStoreLoader,
-            Supplier<KBVClientFactory> kbvClientFactorySupplier,
+            KBVClientFactory kbvClientFactory,
             ConfigurationService configurationService,
-            Supplier<SoapTokenRetriever> soapTokenRetrieverSupplier) {
+            SoapTokenRetriever soapTokenRetriever) {
         this.keyStoreLoader = keyStoreLoader;
-        this.kbvClientFactorySupplier = kbvClientFactorySupplier;
+        this.kbvClientFactory = kbvClientFactory;
         this.configurationService = configurationService;
-        this.soapTokenRetrieverSupplier = soapTokenRetrieverSupplier;
+        this.soapTokenRetriever = soapTokenRetriever;
     }
 
     public KBVGateway create() {
@@ -40,7 +38,7 @@ public class KBVGatewayFactory {
                 new StartAuthnAttemptRequestMapper(configurationService),
                 new ResponseToQuestionMapper(),
                 new QuestionsResponseMapper(),
-                new IdentityIQWrapper(kbvClientFactorySupplier, soapTokenRetrieverSupplier),
+                new IdentityIQWrapper(kbvClientFactory, soapTokenRetriever),
                 new MetricsService(new EventProbe()));
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/security/HeaderHandler.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/security/HeaderHandler.java
@@ -19,6 +19,8 @@ import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
 
+import static uk.gov.di.ipv.cri.kbv.api.util.SoapTokenUtils.hasTokenExpired;
+
 public class HeaderHandler implements SOAPHandler<SOAPMessageContext> {
     private final SoapTokenRetriever tokenRetriever;
 
@@ -82,7 +84,7 @@ public class HeaderHandler implements SOAPHandler<SOAPMessageContext> {
             throw new InvalidSoapTokenException("The SOAP token contains an error: " + tokenValue);
         }
 
-        if (tokenRetriever.hasTokenExpired(tokenValue)) {
+        if (hasTokenExpired(tokenValue)) {
             throw new InvalidSoapTokenException("The SOAP token is expired");
         }
 

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/security/SoapTokenRetriever.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/security/SoapTokenRetriever.java
@@ -5,7 +5,6 @@ import org.apache.logging.log4j.Logger;
 import uk.gov.di.ipv.cri.kbv.api.util.SoapTokenUtils;
 
 import static uk.gov.di.ipv.cri.kbv.api.util.SoapTokenUtils.isTokenPayloadValid;
-import static uk.gov.di.ipv.cri.kbv.api.util.SoapTokenUtils.isTokenValidWithinThreshold;
 
 public class SoapTokenRetriever {
     private static final Logger LOGGER = LogManager.getLogger();
@@ -68,8 +67,8 @@ public class SoapTokenRetriever {
         return this.cachedToken;
     }
 
-    public boolean hasTokenExpired(String tokenValue) {
-        return SoapTokenUtils.hasTokenExpired(tokenValue);
+    public boolean isTokenValidWithinThreshold(String tokenValue) {
+        return SoapTokenUtils.isTokenValidWithinThreshold(tokenValue);
     }
 
     private static void sleepBeforeRetry(int currentIteration) {

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/security/SoapTokenRetriever.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/security/SoapTokenRetriever.java
@@ -1,32 +1,24 @@
 package uk.gov.di.ipv.cri.kbv.api.security;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.ipv.cri.kbv.api.util.SoapTokenUtils;
 
-import java.time.Instant;
-import java.util.concurrent.TimeUnit;
-
 import static uk.gov.di.ipv.cri.kbv.api.util.SoapTokenUtils.isTokenPayloadValid;
+import static uk.gov.di.ipv.cri.kbv.api.util.SoapTokenUtils.isTokenValidWithinThreshold;
 
 public class SoapTokenRetriever {
     private static final Logger LOGGER = LogManager.getLogger();
     private static final int MAX_NUMBER_OF_TOKEN_RETRIES = 3;
     private static final long DELAY_BETWEEN_RETRY_MS = 500;
-    private static final long TOKEN_EXPIRY_THRESHOLD = TimeUnit.HOURS.toSeconds(2);
     public static final String UPDATED_CACHED_TOKEN_WITH_RECEIVED_EXPERIAN_TOKEN =
             "Updated cached token with the one received from Experian. "
                     + "The token given by Experian is valid but not "
                     + "within our threshold, using anyway...";
     public static final String EXPERIAN_TOKEN_THAT_IS_OUTSIDE_OUR_THRESHOLD_AND_INVALID =
             "Returning an Experian token that is outside our threshold and invalid, using anyway...";
-    public static final String CACHED_TOKEN_THAT_IS_OUTSIDE_OUR_THRESHOLD_USING_ANYWAY =
+    public static final String CACHED_TOKEN_THAT_IS_OUTSIDE_SET_THRESHOLD =
             "Returning a cached token that is outside our threshold, using anyway...";
-    public static final String TOKEN_EXPIRATION_CHECK_FAILED_JSON_PROCESSING_EXCEPTION =
-            "Token expiration check failed due to a JsonProcessingException error: {}";
-    public static final String FAILED_TO_EXTRACT_TOKEN_EXPIRY_JSON_PROCESSING_ERROR =
-            "Failed to extract token expiry due to JSON processing error: {}";
     private final SoapToken soapToken;
     private String cachedToken;
 
@@ -38,7 +30,7 @@ public class SoapTokenRetriever {
     public String getSoapToken() {
         if (cachedToken != null && isTokenValidWithinThreshold(cachedToken)) {
             LOGGER.info("Using cached SOAP token");
-            return cachedToken;
+            return this.cachedToken;
         }
 
         LOGGER.info("Retrieving SOAP token from Experian...");
@@ -55,7 +47,7 @@ public class SoapTokenRetriever {
                 if (isTokenValidWithinThreshold(token)) {
                     LOGGER.info("Successfully retrieved a valid token.");
                     this.cachedToken = token;
-                    return cachedToken;
+                    return this.cachedToken;
                 }
             } catch (Exception e) {
                 LOGGER.error("Error while getting SOAP token: {}", e.getMessage());
@@ -66,37 +58,18 @@ public class SoapTokenRetriever {
             this.cachedToken = token;
             LOGGER.info(UPDATED_CACHED_TOKEN_WITH_RECEIVED_EXPERIAN_TOKEN);
         } else if (isTokenPayloadValid(cachedToken)) {
-            LOGGER.info(CACHED_TOKEN_THAT_IS_OUTSIDE_OUR_THRESHOLD_USING_ANYWAY);
+            LOGGER.info(CACHED_TOKEN_THAT_IS_OUTSIDE_SET_THRESHOLD);
             return this.cachedToken;
         } else if (token != null) {
             LOGGER.info(EXPERIAN_TOKEN_THAT_IS_OUTSIDE_OUR_THRESHOLD_AND_INVALID);
-            cachedToken = token;
-            return cachedToken;
+            this.cachedToken = token;
+            return this.cachedToken;
         }
-        return cachedToken;
+        return this.cachedToken;
     }
 
-    public boolean hasTokenExpired(String cachedToken) {
-        try {
-            return SoapTokenUtils.getTokenExpiry(cachedToken) < Instant.now().getEpochSecond();
-        } catch (JsonProcessingException e) {
-            LOGGER.error(TOKEN_EXPIRATION_CHECK_FAILED_JSON_PROCESSING_EXCEPTION, e.getMessage());
-            return true;
-        } catch (Exception e) {
-            LOGGER.debug("Token expiration check failed due to an error: {}", e.getMessage());
-            return true;
-        }
-    }
-
-    private static boolean isTokenValidWithinThreshold(String tokenPayload) {
-        try {
-            return isTokenPayloadValid(tokenPayload)
-                    && SoapTokenUtils.getTokenExpiry(tokenPayload)
-                            > Instant.now().getEpochSecond() + TOKEN_EXPIRY_THRESHOLD;
-        } catch (JsonProcessingException e) {
-            LOGGER.debug(FAILED_TO_EXTRACT_TOKEN_EXPIRY_JSON_PROCESSING_ERROR, e.getMessage());
-            return false;
-        }
+    public boolean hasTokenExpired(String tokenValue) {
+        return SoapTokenUtils.hasTokenExpired(tokenValue);
     }
 
     private static void sleepBeforeRetry(int currentIteration) {

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/ServiceFactory.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/ServiceFactory.java
@@ -23,7 +23,6 @@ import uk.gov.di.ipv.cri.kbv.api.security.SoapToken;
 import uk.gov.di.ipv.cri.kbv.api.security.SoapTokenRetriever;
 
 import java.time.Clock;
-import java.util.function.Supplier;
 
 public class ServiceFactory {
     private static final String APPLICATION = "GDS DI";
@@ -85,8 +84,7 @@ public class ServiceFactory {
         return this.kbvGateway;
     }
 
-    KBVGateway getKbvGateway(
-            KeyStoreLoader keyStoreLoader, Supplier<KBVClientFactory> kbvClientFactory) {
+    KBVGateway getKbvGateway(KeyStoreLoader keyStoreLoader, KBVClientFactory kbvClientFactory) {
         return new KBVGatewayFactory(
                         keyStoreLoader,
                         kbvClientFactory,
@@ -95,18 +93,15 @@ public class ServiceFactory {
                 .create();
     }
 
-    private Supplier<KBVClientFactory> getKbvClientFactory() {
-        return () ->
-                new KBVClientFactory(
-                        new IdentityIQWebService(),
-                        new HeaderHandlerResolver(new HeaderHandler(getSoapTokenRetriever().get())),
-                        getConfigurationService());
+    private KBVClientFactory getKbvClientFactory() {
+        return new KBVClientFactory(
+                new IdentityIQWebService(),
+                new HeaderHandlerResolver(new HeaderHandler(getSoapTokenRetriever())),
+                getConfigurationService());
     }
 
-    private Supplier<SoapTokenRetriever> getSoapTokenRetriever() {
-        return () ->
-                new SoapTokenRetriever(
-                        new SoapToken(
-                                APPLICATION, true, new TokenService(), getConfigurationService()));
+    private SoapTokenRetriever getSoapTokenRetriever() {
+        return new SoapTokenRetriever(
+                new SoapToken(APPLICATION, true, new TokenService(), getConfigurationService()));
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/util/SoapTokenUtils.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/util/SoapTokenUtils.java
@@ -7,10 +7,17 @@ import org.apache.logging.log4j.Logger;
 
 import java.time.Instant;
 import java.util.Base64;
+import java.util.concurrent.TimeUnit;
 
 public class SoapTokenUtils {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final Logger LOGGER = LogManager.getLogger();
+    private static final long TOKEN_EXPIRY_THRESHOLD = TimeUnit.HOURS.toSeconds(2);
+    public static final String TOKEN_EXPIRATION_CHECK_FAILED_JSON_PROCESSING_EXCEPTION =
+            "Token expiration check failed due to a JsonProcessingException error: {}";
+
+    public static final String FAILED_TO_EXTRACT_TOKEN_EXPIRY_JSON_PROCESSING_ERROR =
+            "Failed to extract token expiry due to JSON processing error: {}";
 
     private SoapTokenUtils() {
         throw new IllegalStateException("Utility class");
@@ -18,6 +25,29 @@ public class SoapTokenUtils {
 
     public static long getTokenExpiry(String tokenPayload) throws JsonProcessingException {
         return OBJECT_MAPPER.readTree(decodeTokenPayload(tokenPayload)).get("exp").asLong();
+    }
+
+    public static boolean isTokenValidWithinThreshold(String tokenPayload) {
+        try {
+            return isTokenPayloadValid(tokenPayload)
+                    && getTokenExpiry(tokenPayload)
+                            > Instant.now().getEpochSecond() + TOKEN_EXPIRY_THRESHOLD;
+        } catch (JsonProcessingException e) {
+            LOGGER.debug(FAILED_TO_EXTRACT_TOKEN_EXPIRY_JSON_PROCESSING_ERROR, e.getMessage());
+            return false;
+        }
+    }
+
+    public static boolean hasTokenExpired(String cachedToken) {
+        try {
+            return SoapTokenUtils.getTokenExpiry(cachedToken) < Instant.now().getEpochSecond();
+        } catch (JsonProcessingException e) {
+            LOGGER.error(TOKEN_EXPIRATION_CHECK_FAILED_JSON_PROCESSING_EXCEPTION, e.getMessage());
+            return true;
+        } catch (Exception e) {
+            LOGGER.debug("Token expiration check failed due to an error: {}", e.getMessage());
+            return true;
+        }
     }
 
     public static boolean isTokenPayloadValid(String tokenPayload) {

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/util/SoapTokenUtils.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/util/SoapTokenUtils.java
@@ -6,13 +6,16 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Base64;
 import java.util.concurrent.TimeUnit;
 
 public class SoapTokenUtils {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final Logger LOGGER = LogManager.getLogger();
-    private static final long TOKEN_EXPIRY_THRESHOLD = TimeUnit.HOURS.toSeconds(2);
+    public static final long TOKEN_EXPIRY_THRESHOLD = TimeUnit.HOURS.toSeconds(2);
     public static final String TOKEN_EXPIRATION_CHECK_FAILED_JSON_PROCESSING_EXCEPTION =
             "Token expiration check failed due to a JsonProcessingException error: {}";
 
@@ -21,6 +24,19 @@ public class SoapTokenUtils {
 
     private SoapTokenUtils() {
         throw new IllegalStateException("Utility class");
+    }
+
+    public static String getTokenExpiryAsDateTime(String tokenPayload) {
+        try {
+            LocalDateTime dateTime =
+                    Instant.ofEpochSecond(getTokenExpiry(tokenPayload))
+                            .atZone(ZoneId.systemDefault())
+                            .toLocalDateTime();
+            return dateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+        } catch (JsonProcessingException e) {
+            LOGGER.error("Failed to parse token expiry date: {}", e.getMessage());
+            return "Invalid Token";
+        }
     }
 
     public static long getTokenExpiry(String tokenPayload) throws JsonProcessingException {
@@ -40,7 +56,8 @@ public class SoapTokenUtils {
 
     public static boolean hasTokenExpired(String cachedToken) {
         try {
-            return SoapTokenUtils.getTokenExpiry(cachedToken) < Instant.now().getEpochSecond();
+            return SoapTokenUtils.getTokenExpiry(cachedToken)
+                    < Instant.now().getEpochSecond() + TOKEN_EXPIRY_THRESHOLD;
         } catch (JsonProcessingException e) {
             LOGGER.error(TOKEN_EXPIRATION_CHECK_FAILED_JSON_PROCESSING_EXCEPTION, e.getMessage());
             return true;

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/gateway/IdentityIQWrapperTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/gateway/IdentityIQWrapperTest.java
@@ -1,0 +1,119 @@
+package uk.gov.di.ipv.cri.kbv.api.gateway;
+
+import com.experian.uk.schema.experian.identityiq.services.webservice.IdentityIQWebServiceSoap;
+import com.experian.uk.schema.experian.identityiq.services.webservice.RTQRequest;
+import com.experian.uk.schema.experian.identityiq.services.webservice.RTQResponse2;
+import com.experian.uk.schema.experian.identityiq.services.webservice.SAARequest;
+import com.experian.uk.schema.experian.identityiq.services.webservice.SAAResponse2;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.cri.kbv.api.security.KBVClientFactory;
+import uk.gov.di.ipv.cri.kbv.api.security.SoapTokenRetriever;
+
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.cri.kbv.api.util.SoapTokenUtilsTest.generateToken;
+
+@ExtendWith(MockitoExtension.class)
+class IdentityIQWrapperTest {
+    public static final String GENERATE_TOKEN =
+            generateToken(
+                    String.format(
+                            "{\"exp\": %d}",
+                            Instant.now().getEpochSecond() + TimeUnit.DAYS.toSeconds(2)));
+
+    @Mock private Supplier<KBVClientFactory> kbvClientFactorySupplier;
+    @Mock private Supplier<SoapTokenRetriever> soapTokenRetrieverSupplier;
+    @Mock private KBVClientFactory kbvClientFactory;
+    @Mock private SoapTokenRetriever mockTokenRetriever;
+    @Mock private IdentityIQWebServiceSoap identityIQWebServiceSoap;
+
+    private IdentityIQWrapper identityIQWrapper;
+
+    @BeforeEach
+    void setUp() {
+        when(kbvClientFactorySupplier.get()).thenReturn(kbvClientFactory);
+        when(soapTokenRetrieverSupplier.get()).thenReturn(mockTokenRetriever);
+        when(kbvClientFactory.createClient()).thenReturn(identityIQWebServiceSoap);
+        when(mockTokenRetriever.getSoapToken()).thenReturn(GENERATE_TOKEN);
+
+        identityIQWrapper =
+                new IdentityIQWrapper(kbvClientFactorySupplier, soapTokenRetrieverSupplier);
+    }
+
+    @Test
+    void callsSAAEndPointWithAValidToken() {
+        SAARequest request = new SAARequest();
+        SAAResponse2 response = new SAAResponse2();
+
+        when(identityIQWebServiceSoap.saa(request)).thenReturn(response);
+
+        SAAResponse2 result = identityIQWrapper.saa(request);
+
+        assertEquals(response, result);
+        verify(identityIQWebServiceSoap).saa(request);
+    }
+
+    @Test
+    void callsRTQEndPointWithAValidToken() {
+        RTQRequest rTQRequest = new RTQRequest();
+        RTQResponse2 response = new RTQResponse2();
+
+        when(identityIQWebServiceSoap.rtq(rTQRequest)).thenReturn(response);
+
+        RTQResponse2 result = identityIQWrapper.rtq(rTQRequest);
+
+        assertEquals(response, result);
+        verify(identityIQWebServiceSoap).rtq(rTQRequest);
+    }
+
+    @Test
+    void callsSAARefreshSoapTokenWhenTokenIsExpired() {
+        SAARequest sAARequest = new SAARequest();
+        SAAResponse2 response = new SAAResponse2();
+
+        KBVClientFactory mockNewKbvClientFactory = mock(KBVClientFactory.class);
+        IdentityIQWebServiceSoap mockNewIdentityIQWebServiceSoap =
+                mock(IdentityIQWebServiceSoap.class);
+
+        when(kbvClientFactorySupplier.get()).thenReturn(mockNewKbvClientFactory);
+        when(mockNewIdentityIQWebServiceSoap.saa(sAARequest)).thenReturn(response);
+        when(kbvClientFactorySupplier.get()).thenReturn(mockNewKbvClientFactory);
+        when(mockNewKbvClientFactory.createClient()).thenReturn(mockNewIdentityIQWebServiceSoap);
+
+        identityIQWrapper.saa(sAARequest);
+
+        verify(kbvClientFactorySupplier, times(2)).get();
+        verify(mockNewKbvClientFactory).createClient();
+    }
+
+    @Test
+    void callsRTQRefreshSoapTokenWhenTokenIsExpired() {
+        RTQRequest rTQRequest = new RTQRequest();
+        RTQResponse2 response = new RTQResponse2();
+
+        KBVClientFactory mockNewKbvClientFactory = mock(KBVClientFactory.class);
+        IdentityIQWebServiceSoap mockNewIdentityIQWebServiceSoap =
+                mock(IdentityIQWebServiceSoap.class);
+
+        when(kbvClientFactorySupplier.get()).thenReturn(mockNewKbvClientFactory);
+        when(mockNewIdentityIQWebServiceSoap.rtq(rTQRequest)).thenReturn(response);
+        when(kbvClientFactorySupplier.get()).thenReturn(mockNewKbvClientFactory);
+        when(mockNewKbvClientFactory.createClient()).thenReturn(mockNewIdentityIQWebServiceSoap);
+
+        identityIQWrapper.rtq(rTQRequest);
+
+        verify(kbvClientFactorySupplier, times(2)).get();
+        verify(mockNewKbvClientFactory).createClient();
+    }
+}

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/gateway/KBVGatewayFactoryTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/gateway/KBVGatewayFactoryTest.java
@@ -1,7 +1,6 @@
 package uk.gov.di.ipv.cri.kbv.api.gateway;
 
 import com.experian.uk.schema.experian.identityiq.services.webservice.IdentityIQWebServiceSoap;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -13,7 +12,6 @@ import uk.gov.di.ipv.cri.kbv.api.security.KBVClientFactory;
 import uk.gov.di.ipv.cri.kbv.api.security.SoapTokenRetriever;
 
 import java.io.IOException;
-import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -23,21 +21,15 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.cri.kbv.api.gateway.IdentityIQWrapperTest.GENERATE_TOKEN;
 
 @ExtendWith(MockitoExtension.class)
 class KBVGatewayFactoryTest {
-    private Supplier<SoapTokenRetriever> mockSoapTokenRetrieverSupplier;
-    private Supplier<KBVClientFactory> mockKbvClientFactorySupplier;
     @Mock private KeyStoreLoader keyStoreLoaderMock;
     @Mock private KBVClientFactory kbvClientFactoryMock;
     @Mock private SoapTokenRetriever soapTokenRetrieverMock;
-    @InjectMocks private KBVGatewayFactory kbvGatewayFactory;
 
-    @BeforeEach
-    void setUp() {
-        mockSoapTokenRetrieverSupplier = () -> soapTokenRetrieverMock;
-        mockKbvClientFactorySupplier = () -> kbvClientFactoryMock;
-    }
+    @InjectMocks private KBVGatewayFactory kbvGatewayFactory;
 
     @Test
     void shouldCreateKbvGatewaySuccessfully() throws IOException {
@@ -47,14 +39,16 @@ class KBVGatewayFactoryTest {
                 mock(IdentityIQWebServiceSoap.class);
 
         doNothing().when(keyStoreLoaderMock).load();
+
+        when(soapTokenRetrieverMock.getSoapToken()).thenReturn(GENERATE_TOKEN);
         when(kbvClientFactoryMock.createClient()).thenReturn(identityIQWebServiceSoapMock);
 
         kbvGatewayFactory =
                 new KBVGatewayFactory(
                         keyStoreLoaderMock,
-                        mockKbvClientFactorySupplier,
+                        kbvClientFactoryMock,
                         configurationServiceMock,
-                        mockSoapTokenRetrieverSupplier);
+                        soapTokenRetrieverMock);
 
         KBVGateway kbvGateway = kbvGatewayFactory.create();
 

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/gateway/KBVGatewayFactoryTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/gateway/KBVGatewayFactoryTest.java
@@ -1,6 +1,7 @@
 package uk.gov.di.ipv.cri.kbv.api.gateway;
 
 import com.experian.uk.schema.experian.identityiq.services.webservice.IdentityIQWebServiceSoap;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -9,8 +10,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
 import uk.gov.di.ipv.cri.kbv.api.exception.KBVGatewayCreationException;
 import uk.gov.di.ipv.cri.kbv.api.security.KBVClientFactory;
+import uk.gov.di.ipv.cri.kbv.api.security.SoapTokenRetriever;
 
 import java.io.IOException;
+import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -23,9 +26,18 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class KBVGatewayFactoryTest {
+    private Supplier<SoapTokenRetriever> mockSoapTokenRetrieverSupplier;
+    private Supplier<KBVClientFactory> mockKbvClientFactorySupplier;
     @Mock private KeyStoreLoader keyStoreLoaderMock;
     @Mock private KBVClientFactory kbvClientFactoryMock;
+    @Mock private SoapTokenRetriever soapTokenRetrieverMock;
     @InjectMocks private KBVGatewayFactory kbvGatewayFactory;
+
+    @BeforeEach
+    void setUp() {
+        mockSoapTokenRetrieverSupplier = () -> soapTokenRetrieverMock;
+        mockKbvClientFactorySupplier = () -> kbvClientFactoryMock;
+    }
 
     @Test
     void shouldCreateKbvGatewaySuccessfully() throws IOException {
@@ -39,7 +51,10 @@ class KBVGatewayFactoryTest {
 
         kbvGatewayFactory =
                 new KBVGatewayFactory(
-                        keyStoreLoaderMock, kbvClientFactoryMock, configurationServiceMock);
+                        keyStoreLoaderMock,
+                        mockKbvClientFactorySupplier,
+                        configurationServiceMock,
+                        mockSoapTokenRetrieverSupplier);
 
         KBVGateway kbvGateway = kbvGatewayFactory.create();
 
@@ -52,30 +67,10 @@ class KBVGatewayFactoryTest {
         doThrow(new RuntimeException("KeyStore loading failed")).when(keyStoreLoaderMock).load();
 
         KBVGatewayCreationException exception =
-                assertThrows(
-                        KBVGatewayCreationException.class,
-                        () -> {
-                            kbvGatewayFactory.create();
-                        });
+                assertThrows(KBVGatewayCreationException.class, kbvGatewayFactory::create);
 
         assertEquals(
                 "Failed to create KBVGateway: KeyStore loading failed", exception.getMessage());
-        verify(keyStoreLoaderMock).load();
-    }
-
-    @Test
-    void shouldThrowKbvGatewayCreationExceptionWhenOtherErrorOccurs() throws IOException {
-        doNothing().when(keyStoreLoaderMock).load();
-        doThrow(new RuntimeException("Unknown error")).when(kbvClientFactoryMock).createClient();
-
-        KBVGatewayCreationException exception =
-                assertThrows(
-                        KBVGatewayCreationException.class,
-                        () -> {
-                            kbvGatewayFactory.create();
-                        });
-
-        assertEquals("Failed to create KBVGateway: Unknown error", exception.getMessage());
         verify(keyStoreLoaderMock).load();
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/gateway/KBVGatewayTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/gateway/KBVGatewayTest.java
@@ -1,6 +1,5 @@
 package uk.gov.di.ipv.cri.kbv.api.gateway;
 
-import com.experian.uk.schema.experian.identityiq.services.webservice.IdentityIQWebServiceSoap;
 import com.experian.uk.schema.experian.identityiq.services.webservice.RTQRequest;
 import com.experian.uk.schema.experian.identityiq.services.webservice.RTQResponse2;
 import com.experian.uk.schema.experian.identityiq.services.webservice.SAARequest;
@@ -29,7 +28,7 @@ class KBVGatewayTest {
     @Mock private StartAuthnAttemptRequestMapper mockSAARequestMapper;
     @Mock private ResponseToQuestionMapper mockResponseToQuestionMapper;
     @Mock private QuestionsResponseMapper mockQuestionsResponseMapper;
-    @Mock private IdentityIQWebServiceSoap mockIdentityIQWebServiceSoap;
+    @Mock private IdentityIQWrapper mockIdentityIQWebServiceSoap;
     @Mock private MetricsService mockMetricsService;
     @InjectMocks private KBVGateway kbvGateway;
 

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/security/HeaderHandlerTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/security/HeaderHandlerTest.java
@@ -144,7 +144,6 @@ class HeaderHandlerTest {
             String token = "{}." + encodeBase64Url(String.format("{\"exp\": \"%d\"}", 0)) + ".{}";
 
             when(soapTokenRetrieverMock.getSoapToken()).thenReturn(token);
-            when(soapTokenRetrieverMock.hasTokenExpired(token)).thenReturn(true);
             when(soapMessageContextMock.get(MessageContext.MESSAGE_OUTBOUND_PROPERTY))
                     .thenReturn(true);
             Exception exception =
@@ -166,7 +165,7 @@ class HeaderHandlerTest {
                                     String.format(
                                             "{\"exp\": \"%d\"}",
                                             Instant.now().getEpochSecond()
-                                                    + TimeUnit.HOURS.toSeconds(1)))
+                                                    + TimeUnit.HOURS.toSeconds(3)))
                             + ".{}";
 
             when(soapTokenRetrieverMock.getSoapToken()).thenReturn(token);

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/security/SoapTokenRetrieverTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/security/SoapTokenRetrieverTest.java
@@ -40,12 +40,12 @@ class SoapTokenRetrieverTest {
     }
 
     @Test
-    void hasTokenExpiredReturnsFalseWhenThereIsNoToken() {
+    void isTokenValidWithinThresholdReturnsFalseWhenThereIsNoToken() {
         assertFalse(soapTokenRetriever.isTokenValidWithinThreshold(null));
     }
 
     @Test
-    void hasTokenExpiredReturnsTrueWhenTokenIsValid() {
+    void isTokenValidWithinThresholdReturnsTrueWhenTokenIsValid() {
         assertTrue(soapTokenRetriever.isTokenValidWithinThreshold(generateValidToken2()));
     }
 

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/security/SoapTokenRetrieverTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/security/SoapTokenRetrieverTest.java
@@ -40,13 +40,13 @@ class SoapTokenRetrieverTest {
     }
 
     @Test
-    void hasTokenExpiredReturnsTrueWhenTheirIsNoToken() {
-        assertTrue(soapTokenRetriever.hasTokenExpired(null));
+    void hasTokenExpiredReturnsFalseWhenThereIsNoToken() {
+        assertFalse(soapTokenRetriever.isTokenValidWithinThreshold(null));
     }
 
     @Test
-    void hasTokenExpiredReturnsFalseWhenTokenIsValid() {
-        assertFalse(soapTokenRetriever.hasTokenExpired(generateValidToken2()));
+    void hasTokenExpiredReturnsTrueWhenTokenIsValid() {
+        assertTrue(soapTokenRetriever.isTokenValidWithinThreshold(generateValidToken2()));
     }
 
     @Test

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/security/SoapTokenTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/security/SoapTokenTest.java
@@ -65,7 +65,7 @@ class SoapTokenTest {
         when(soapFaultException.getMessage()).thenReturn("SOAP Fault");
 
         InvalidSoapTokenException exception =
-                assertThrows(InvalidSoapTokenException.class, () -> soapToken.getToken());
+                assertThrows(InvalidSoapTokenException.class, soapToken::getToken);
 
         verify(tokenServiceMock).getTokenServiceSoap();
         verify(configurationServiceMock).getSecretValue("experian/iiq-wasp-service");
@@ -78,7 +78,7 @@ class SoapTokenTest {
                 .thenThrow(new WebServiceException("Web Service error"));
 
         InvalidSoapTokenException exception =
-                assertThrows(InvalidSoapTokenException.class, () -> soapToken.getToken());
+                assertThrows(InvalidSoapTokenException.class, soapToken::getToken);
 
         verify(tokenServiceMock).getTokenServiceSoap();
         verify(configurationServiceMock).getSecretValue("experian/iiq-wasp-service");
@@ -91,7 +91,7 @@ class SoapTokenTest {
                 .thenThrow(new RuntimeException("Unexpected error"));
 
         InvalidSoapTokenException exception =
-                assertThrows(InvalidSoapTokenException.class, () -> soapToken.getToken());
+                assertThrows(InvalidSoapTokenException.class, soapToken::getToken);
 
         verify(tokenServiceMock).getTokenServiceSoap();
         verify(configurationServiceMock).getSecretValue("experian/iiq-wasp-service");

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/ServiceFactoryTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/ServiceFactoryTest.java
@@ -17,8 +17,6 @@ import uk.gov.di.ipv.cri.kbv.api.gateway.KBVGateway;
 import uk.gov.di.ipv.cri.kbv.api.gateway.KeyStoreLoader;
 import uk.gov.di.ipv.cri.kbv.api.security.KBVClientFactory;
 
-import java.util.function.Supplier;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -28,15 +26,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class ServiceFactoryTest {
-    @Mock private Supplier<KBVClientFactory> mockKbvClientFactorySupplier;
     @Mock private ClientProviderFactory clientProviderFactory;
-
     @Mock private SSMProvider ssmProvider;
-
     @Mock private DynamoDbEnhancedClient dynamoDbEnhancedClient;
-
     @Mock private SecretsProvider secretsProvider;
-
     @Mock private SqsClient sqsClient;
 
     @InjectMocks private ServiceFactory serviceFactory;
@@ -106,10 +99,9 @@ class ServiceFactoryTest {
                 mock(IdentityIQWebServiceSoap.class);
 
         when(kbvClientFactoryMock.createClient()).thenReturn(identityIQWebServiceSoapMock);
-        when(mockKbvClientFactorySupplier.get()).thenReturn(kbvClientFactoryMock);
 
         KBVGateway kbvGateway =
-                serviceFactory.getKbvGateway(keyStoreLoaderMock, mockKbvClientFactorySupplier);
+                serviceFactory.getKbvGateway(keyStoreLoaderMock, kbvClientFactoryMock);
 
         assertNotNull(kbvGateway);
     }

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/ServiceFactoryTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/ServiceFactoryTest.java
@@ -17,6 +17,8 @@ import uk.gov.di.ipv.cri.kbv.api.gateway.KBVGateway;
 import uk.gov.di.ipv.cri.kbv.api.gateway.KeyStoreLoader;
 import uk.gov.di.ipv.cri.kbv.api.security.KBVClientFactory;
 
+import java.util.function.Supplier;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -26,7 +28,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class ServiceFactoryTest {
-
+    @Mock private Supplier<KBVClientFactory> mockKbvClientFactorySupplier;
     @Mock private ClientProviderFactory clientProviderFactory;
 
     @Mock private SSMProvider ssmProvider;
@@ -104,8 +106,10 @@ class ServiceFactoryTest {
                 mock(IdentityIQWebServiceSoap.class);
 
         when(kbvClientFactoryMock.createClient()).thenReturn(identityIQWebServiceSoapMock);
+        when(mockKbvClientFactorySupplier.get()).thenReturn(kbvClientFactoryMock);
+
         KBVGateway kbvGateway =
-                serviceFactory.getKbvGateway(keyStoreLoaderMock, kbvClientFactoryMock);
+                serviceFactory.getKbvGateway(keyStoreLoaderMock, mockKbvClientFactorySupplier);
 
         assertNotNull(kbvGateway);
     }
@@ -114,8 +118,7 @@ class ServiceFactoryTest {
     void testGetKbvGatewayReturnsExceptionWhenCreationFails() {
 
         KBVGatewayCreationException exception =
-                assertThrows(
-                        KBVGatewayCreationException.class, () -> serviceFactory.getKbvGateway());
+                assertThrows(KBVGatewayCreationException.class, serviceFactory::getKbvGateway);
 
         assertEquals(
                 "Failed to create KBVGateway: Persist keystore to file failed: null",

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/util/SoapTokenUtilsTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/util/SoapTokenUtilsTest.java
@@ -1,8 +1,11 @@
 package uk.gov.di.ipv.cri.kbv.api.util;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Instant;
@@ -13,69 +16,144 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.gov.di.ipv.cri.kbv.api.util.SoapTokenUtils.TOKEN_EXPIRY_THRESHOLD;
 
 @ExtendWith(MockitoExtension.class)
 public class SoapTokenUtilsTest {
-    @Test
-    void hasTokenExpiredReturnsTrueWhenTheirIsNoToken() {
-        assertTrue(SoapTokenUtils.hasTokenExpired(null));
+    @Nested
+    class TokenExpiry {
+        @Test
+        void shouldReturnTokenExpiry() throws JsonProcessingException {
+            String payload = generateToken("{\"exp\":123456}");
+
+            assertEquals(123456, SoapTokenUtils.getTokenExpiry(payload));
+        }
+
+        @Test
+        void shouldThrowWhenNoExpField() {
+            String payload = generateToken("{\"foo\":123456}");
+            assertThrows(Exception.class, () -> SoapTokenUtils.getTokenExpiry(payload));
+        }
+
+        @Test
+        void shouldThrowWhenMalformedJson() {
+            String payload = generateToken("dummy");
+
+            assertThrows(Exception.class, () -> SoapTokenUtils.getTokenExpiry(payload));
+        }
+
+        @Test
+        void shouldDefaultWhenNonIntExp() throws JsonProcessingException {
+            String payload = generateToken("{\"exp\":\"foo\"}");
+
+            assertEquals(0, SoapTokenUtils.getTokenExpiry(payload));
+        }
     }
 
-    @Test
-    void hasTokenExpiredReturnsFalseWhenTokenIsValid() {
-        String payload =
-                generateToken(
-                        String.format(
-                                "{\"exp\": %d}",
-                                Instant.now().getEpochSecond() + TimeUnit.DAYS.toSeconds(2)));
+    @Nested
+    class TokenExpiryAsDateTime {
+        @Test
+        void returnsTokenExpiryAsDateTimeFromZeroEpoch() {
+            String tokenPayload = generateToken("dummy");
+            String actualDateTime = SoapTokenUtils.getTokenExpiryAsDateTime(tokenPayload);
 
-        assertFalse(SoapTokenUtils.hasTokenExpired(payload));
+            assertEquals("Invalid Token", actualDateTime);
+        }
+
+        @ParameterizedTest
+        @CsvSource({"1700000000, '2023-11-14 22:13:20'", "32503680000, '3000-01-01 00:00:00'"})
+        void convertEpochsToDateTime(long epochSeconds, String expectedDateTime) {
+            String tokenPayload = generateToken("{\"exp\": " + epochSeconds + "}");
+
+            String actualDateTime = SoapTokenUtils.getTokenExpiryAsDateTime(tokenPayload);
+
+            assertEquals(expectedDateTime, actualDateTime);
+        }
     }
 
-    @Test
-    void shouldReturnTokenExpiry() throws JsonProcessingException {
-        String payload = generateToken("{\"exp\":123456}");
+    @Nested
+    class TokenHasExpiry {
+        @Test
+        void hasTokenExpiredReturnsTrueWhenThereIsNoToken() {
+            assertTrue(SoapTokenUtils.hasTokenExpired(null));
+        }
 
-        assertEquals(123456, SoapTokenUtils.getTokenExpiry(payload));
+        @Test
+        void hasTokenExpiredReturnsTrueWhenTokenIsMalformed() {
+            assertTrue(SoapTokenUtils.hasTokenExpired(generateToken("dummy")));
+        }
+
+        @Test
+        void hasTokenExpiredReturnsTrueWhenTokenHasExpired() {
+            String payload =
+                    generateToken(
+                            String.format(
+                                    "{\"exp\": %d}",
+                                    Instant.now().getEpochSecond() + TimeUnit.DAYS.toSeconds(-2)));
+
+            assertTrue(SoapTokenUtils.hasTokenExpired(payload));
+        }
+
+        @Test
+        void hasTokenExpiredReturnsFalseWhenTokenIsValid() {
+            String payload =
+                    generateToken(
+                            String.format(
+                                    "{\"exp\": %d}",
+                                    Instant.now().getEpochSecond() + TimeUnit.DAYS.toSeconds(2)));
+
+            assertFalse(SoapTokenUtils.hasTokenExpired(payload));
+        }
     }
 
-    @Test
-    void shouldThrowWhenNoExpField() {
-        String payload = generateToken("{\"foo\":123456}");
-        assertThrows(Exception.class, () -> SoapTokenUtils.getTokenExpiry(payload));
+    @Nested
+    class TokenValidWithinThresHold {
+        @Test
+        void tokenIsValidWithinThresHold() {
+            long futureExpiry = Instant.now().getEpochSecond() + TOKEN_EXPIRY_THRESHOLD + 10;
+
+            String aValidToken = generateToken("{\"exp\": " + futureExpiry + "}");
+
+            assertTrue(SoapTokenUtils.isTokenValidWithinThreshold(aValidToken));
+        }
+
+        @Test
+        void expiredTokenIsNotValidWithThresHold() {
+            long pastExpiry = Instant.now().getEpochSecond() - 10;
+
+            String anExpiredToken = generateToken("{\"exp\": " + pastExpiry + "}");
+
+            assertFalse(SoapTokenUtils.isTokenValidWithinThreshold(anExpiredToken));
+        }
+
+        @Test
+        void malFormedTokenIsNotValidWithThresHold() {
+            String aMalformedToken = generateToken("dummy");
+
+            assertFalse(SoapTokenUtils.isTokenValidWithinThreshold(aMalformedToken));
+        }
     }
 
-    @Test
-    void shouldThrowWhenMalformedJson() {
-        String payload = generateToken("dummy");
+    @Nested
+    class TokenPayloadValid {
+        @Test
+        void shouldNotValidateIfTokenIsError() {
+            assertFalse(SoapTokenUtils.isTokenPayloadValid("error"));
+        }
 
-        assertThrows(Exception.class, () -> SoapTokenUtils.getTokenExpiry(payload));
-    }
+        @Test
+        void shouldNotValidateIfTokenIsExpired() {
+            String payload = generateToken("{\"exp\":\"0\"}");
+            String token = generateToken(payload);
 
-    @Test
-    void shouldDefaultWhenNonIntExp() throws JsonProcessingException {
-        String payload = generateToken("{\"exp\":\"foo\"}");
+            assertFalse(SoapTokenUtils.isTokenPayloadValid(token));
+        }
 
-        assertEquals(0, SoapTokenUtils.getTokenExpiry(payload));
-    }
+        @Test
+        void shouldNotValidateIfTokenIsEmpty() {
 
-    @Test
-    void shouldNotValidateIfTokenIsError() {
-        assertFalse(SoapTokenUtils.isTokenPayloadValid("error"));
-    }
-
-    @Test
-    void shouldNotValidateIfTokenIsExpired() {
-        String payload = generateToken("{\"exp\":\"0\"}");
-        String token = generateToken(payload);
-
-        assertFalse(SoapTokenUtils.isTokenPayloadValid(token));
-    }
-
-    @Test
-    void shouldNotValidateIfTokenIsEmpty() {
-
-        assertFalse(SoapTokenUtils.isTokenPayloadValid(generateToken("")));
+            assertFalse(SoapTokenUtils.isTokenPayloadValid(generateToken("")));
+        }
     }
 
     private static final String TOKEN_HEADER =

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/util/SoapTokenUtilsTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/util/SoapTokenUtilsTest.java
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MockitoExtension.class)
-class SoapTokenUtilsTest {
+public class SoapTokenUtilsTest {
     @Test
     void hasTokenExpiredReturnsTrueWhenTheirIsNoToken() {
         assertTrue(SoapTokenUtils.hasTokenExpired(null));

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/util/SoapTokenUtilsTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/util/SoapTokenUtilsTest.java
@@ -5,14 +5,32 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.Instant;
 import java.util.Base64;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MockitoExtension.class)
 class SoapTokenUtilsTest {
+    @Test
+    void hasTokenExpiredReturnsTrueWhenTheirIsNoToken() {
+        assertTrue(SoapTokenUtils.hasTokenExpired(null));
+    }
+
+    @Test
+    void hasTokenExpiredReturnsFalseWhenTokenIsValid() {
+        String payload =
+                generateToken(
+                        String.format(
+                                "{\"exp\": %d}",
+                                Instant.now().getEpochSecond() + TimeUnit.DAYS.toSeconds(2)));
+
+        assertFalse(SoapTokenUtils.hasTokenExpired(payload));
+    }
 
     @Test
     void shouldReturnTokenExpiry() throws JsonProcessingException {


### PR DESCRIPTION
## Proposed changes

In the event of a long running session the SOAP Token can expiry, this PR aims to refresh the token
mid-flow when the question /answer lambda has not had a chance to restart. 

The refresh cycle is currently based on `isTokenValidWithinThreshold ` any token outside the 2-hour window will be subject to being refreshed. 

In the unlikely event that getting a fresh token after the 2-hours is not possible, the last valid cache token will be used. This means a chatty API, an alternative could have been to conduct the refresh based on an offset on the expiry maybe 30mins or an hour before expiry, given that token life time is about 9 hours. This is a trade-off that has been made.

### What changed

The IdentityIQWrapper class, wraps IdentityIQWebServiceSoap class
It will manage the token refresh on expiry of a long running
call to SAA and RTQ endpoints

To ensure that the HeaderHandler get called on refresh, (_this is where the SOAP Token get
attached to the SOAP Security header._)

The creation of SoapToken, SoapRetriever and binding to the HeaderHandlerResolver
is delayed until the `.get`of the suppliers are called for instance
the following suppliers are specified in the ServiceFactory.

The `refreshSoapToken()` use the `soapTokenRetriever.getSoapToken()` to get a token into `newSoapToken`
the `currentToken` will be null the first time the wrapper is created. On subsequent calls it won't be null and could
be the same value as the cachedToken, and therefore it can still be used because `isTokenValidWithinThreshold(cachedToken))` inside the SoapTokenRetriever is true as soon as a different token is available then rebind to the new token to the security header by calling

 `this.identityIQWebServiceSoap = kbvClientFactory.createClient();`

- Overall test coverage has been increased

### Why did it change

- [OJ-2842](https://govukverify.atlassian.net/browse/OJ-2842)

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[OJ-2842]: https://govukverify.atlassian.net/browse/OJ-2842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ