### PR TITLE
OJ-2845: Refactor experian request duration metric

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/MetricsService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/MetricsService.java
@@ -1,6 +1,7 @@
 package uk.gov.di.ipv.cri.kbv.api.service;
 
 import com.nimbusds.oauth2.sdk.util.StringUtils;
+import software.amazon.cloudwatchlogs.emf.model.Unit;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.kbv.api.domain.KbvResult;
 
@@ -10,39 +11,29 @@ import java.util.Objects;
 public class MetricsService {
 
     public static final String OUTCOME = "outcome";
-    public static final String TRANS_ID = "transition_id";
     public static final String ERROR_CODE = "error_code";
-    public static final String EXECUTION_DURATION = "execution_duration";
+
     private final EventProbe eventProbe;
 
     public MetricsService(EventProbe eventProbe) {
         this.eventProbe = eventProbe;
     }
 
-    public void sendErrorMetric(String errorCode, String metricName) {
+    public void sendDurationMetric(String durationMetricName, long executionDuration) {
+        eventProbe.counterMetric(durationMetricName, executionDuration, Unit.MILLISECONDS);
+    }
+
+    public void sendErrorMetric(String metricName, String errorCode) {
         if (StringUtils.isNotBlank(errorCode)) {
             eventProbe.addDimensions(Map.of(ERROR_CODE, errorCode));
             eventProbe.counterMetric(metricName);
         }
     }
 
-    public void sendResultMetric(KbvResult result, String metricName, long executionDuration) {
-        if (Objects.nonNull(result)) {
-            String transIds = "";
-            if (Objects.nonNull(result.getNextTransId()) && result.getNextTransId().length > 0) {
-                transIds = String.join(",", result.getNextTransId());
-            }
-            if (StringUtils.isNotBlank(result.getOutcome())) {
-                eventProbe.addDimensions(
-                        Map.of(
-                                OUTCOME,
-                                result.getOutcome(),
-                                TRANS_ID,
-                                transIds,
-                                EXECUTION_DURATION,
-                                String.valueOf(executionDuration)));
-                eventProbe.counterMetric(metricName);
-            }
+    public void sendResultMetric(String metricName, KbvResult result) {
+        if (Objects.nonNull(result) && StringUtils.isNotBlank(result.getOutcome())) {
+            eventProbe.addDimensions(Map.of(OUTCOME, result.getOutcome()));
+            eventProbe.counterMetric(metricName);
         }
     }
 

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/ServiceFactory.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/ServiceFactory.java
@@ -13,6 +13,7 @@ import uk.gov.di.ipv.cri.common.library.service.AuditService;
 import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
 import uk.gov.di.ipv.cri.common.library.service.SessionService;
 import uk.gov.di.ipv.cri.common.library.util.ClientProviderFactory;
+import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.kbv.api.gateway.KBVGateway;
 import uk.gov.di.ipv.cri.kbv.api.gateway.KBVGatewayFactory;
 import uk.gov.di.ipv.cri.kbv.api.gateway.KeyStoreLoader;
@@ -102,6 +103,11 @@ public class ServiceFactory {
 
     private SoapTokenRetriever getSoapTokenRetriever() {
         return new SoapTokenRetriever(
-                new SoapToken(APPLICATION, true, new TokenService(), getConfigurationService()));
+                new SoapToken(
+                        APPLICATION,
+                        true,
+                        new TokenService(),
+                        getConfigurationService(),
+                        new MetricsService(new EventProbe())));
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/gateway/KBVGatewayTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/gateway/KBVGatewayTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.kbv.api.domain.KbvResult;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionAnswerRequest;
 import uk.gov.di.ipv.cri.kbv.api.domain.QuestionRequest;
@@ -45,14 +44,13 @@ class KBVGatewayTest {
         when(mockIdentityIQWebServiceSoap.saa(mockSaaRequest)).thenReturn(mockSaaResponse);
         when(mockQuestionsResponseMapper.mapSAAResponse(mockSaaResponse))
                 .thenReturn(mockQuestionsResponse);
-        when(mockMetricsService.getEventProbe()).thenReturn(mock(EventProbe.class));
         kbvGateway.getQuestions(questionRequest);
 
         verify(mockSAARequestMapper).mapQuestionRequest(questionRequest);
         verify(mockIdentityIQWebServiceSoap).saa(mockSaaRequest);
         verify(mockQuestionsResponseMapper).mapSAAResponse(mockSaaResponse);
-        verify(mockMetricsService)
-                .sendResultMetric(eq(mockKbvResult), eq("initial_questions_response"), anyLong());
+        verify(mockMetricsService).sendDurationMetric(eq("get_questions_duration"), anyLong());
+        verify(mockMetricsService).sendResultMetric("initial_questions_response", mockKbvResult);
     }
 
     @Test
@@ -68,14 +66,13 @@ class KBVGatewayTest {
         when(mockIdentityIQWebServiceSoap.rtq(mockRtqRequest)).thenReturn(mockRtqResponse);
         when(mockQuestionsResponseMapper.mapRTQResponse(mockRtqResponse))
                 .thenReturn(mockQuestionsResponse);
-        when(mockMetricsService.getEventProbe()).thenReturn(mock(EventProbe.class));
         kbvGateway.submitAnswers(questionAnswerRequest);
 
         verify(mockResponseToQuestionMapper).mapQuestionAnswersRtqRequest(questionAnswerRequest);
         verify(mockIdentityIQWebServiceSoap).rtq(mockRtqRequest);
         verify(mockQuestionsResponseMapper).mapRTQResponse(mockRtqResponse);
-        verify(mockMetricsService)
-                .sendResultMetric(eq(mockKbvResult), eq("submit_questions_response"), anyLong());
+        verify(mockMetricsService).sendDurationMetric(eq("submit_answers_duration"), anyLong());
+        verify(mockMetricsService).sendResultMetric("submit_questions_response", mockKbvResult);
     }
 
     @Test

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/security/SoapTokenTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/security/SoapTokenTest.java
@@ -9,6 +9,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
 import uk.gov.di.ipv.cri.kbv.api.exception.InvalidSoapTokenException;
+import uk.gov.di.ipv.cri.kbv.api.service.MetricsService;
 
 import javax.xml.ws.BindingProvider;
 import javax.xml.ws.WebServiceException;
@@ -17,6 +18,8 @@ import javax.xml.ws.soap.SOAPFaultException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -27,6 +30,8 @@ class SoapTokenTest {
     @Mock private TokenService tokenServiceMock;
     @Mock private ConfigurationService configurationServiceMock;
     @Mock private TokenServiceSoap tokenServiceSoapMock;
+    @Mock private MetricsService mockMetricsService;
+
     private SoapToken soapToken;
     private final String application = "testApplication";
     private Boolean checkIp = true;
@@ -39,7 +44,13 @@ class SoapTokenTest {
         tokenServiceSoapMock =
                 mock(TokenServiceSoap.class, withSettings().extraInterfaces(BindingProvider.class));
 
-        soapToken = new SoapToken(application, checkIp, tokenServiceMock, configurationServiceMock);
+        soapToken =
+                new SoapToken(
+                        application,
+                        checkIp,
+                        tokenServiceMock,
+                        configurationServiceMock,
+                        mockMetricsService);
 
         when(configurationServiceMock.getSecretValue("experian/iiq-wasp-service"))
                 .thenReturn(endpointUrl);
@@ -54,6 +65,7 @@ class SoapTokenTest {
 
         verify(tokenServiceMock).getTokenServiceSoap();
         verify(configurationServiceMock).getSecretValue("experian/iiq-wasp-service");
+        verify(mockMetricsService).sendDurationMetric(eq("get_soap_token_duration"), anyLong());
         assertEquals(token, result);
     }
 

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/MetricsServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/MetricsServiceTest.java
@@ -5,17 +5,18 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.cloudwatchlogs.emf.model.Unit;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.kbv.api.domain.KbvResult;
 
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static uk.gov.di.ipv.cri.kbv.api.service.MetricsService.ERROR_CODE;
-import static uk.gov.di.ipv.cri.kbv.api.service.MetricsService.EXECUTION_DURATION;
 import static uk.gov.di.ipv.cri.kbv.api.service.MetricsService.OUTCOME;
-import static uk.gov.di.ipv.cri.kbv.api.service.MetricsService.TRANS_ID;
 
 @ExtendWith(MockitoExtension.class)
 class MetricsServiceTest {
@@ -28,31 +29,61 @@ class MetricsServiceTest {
     void shouldSendResultsMetric() {
         String resultOutcome = "outcome";
         String resultTransId = "transId";
-        long executionDuration = 7500l;
         KbvResult kbvResult = new KbvResult();
         kbvResult.setOutcome(resultOutcome);
         kbvResult.setNextTransId(new String[] {resultTransId});
 
-        this.metricsService.sendResultMetric(kbvResult, "baz", executionDuration);
+        this.metricsService.sendResultMetric("baz", kbvResult);
 
         verify(eventProbe).counterMetric("baz");
-        verify(eventProbe)
-                .addDimensions(
-                        Map.of(
-                                OUTCOME,
-                                resultOutcome,
-                                TRANS_ID,
-                                resultTransId,
-                                EXECUTION_DURATION,
-                                String.valueOf(executionDuration)));
+        verify(eventProbe).addDimensions(Map.of(OUTCOME, resultOutcome));
+    }
+
+    @Test
+    void shouldNotSendResultsMetricWithoutResult() {
+        this.metricsService.sendResultMetric("baz", null);
+
+        verify(eventProbe, never()).counterMetric("baz");
+        verify(eventProbe, never()).addDimensions(Map.of(OUTCOME, anyString()));
+    }
+
+    @Test
+    void shouldNotSendResultsMetricWithoutResultOutcome() {
+        KbvResult kbvResult = new KbvResult();
+
+        this.metricsService.sendResultMetric("baz", kbvResult);
+
+        verify(eventProbe, never()).counterMetric("baz");
+        verify(eventProbe, never()).addDimensions(Map.of(OUTCOME, anyString()));
+    }
+
+    @Test
+    void shouldSendDurationMetric() {
+        long executionDuration = 7500;
+
+        this.metricsService.sendDurationMetric("baz_duration", executionDuration);
+
+        verify(eventProbe).counterMetric("baz_duration", executionDuration, Unit.MILLISECONDS);
     }
 
     @Test
     void shouldSendErrorMetric() {
         String errorCode = "error-code";
-        this.metricsService.sendErrorMetric(errorCode, "baz");
+
+        this.metricsService.sendErrorMetric("baz", errorCode);
+
         verify(eventProbe).counterMetric("baz");
         verify(eventProbe).addDimensions(Map.of(ERROR_CODE, errorCode));
+    }
+
+    @Test
+    void shouldNotSendErrorMetric() {
+        String errorCode = "";
+
+        this.metricsService.sendErrorMetric("baz", errorCode);
+
+        verify(eventProbe, never()).counterMetric("baz");
+        verify(eventProbe, never()).addDimensions(Map.of(ERROR_CODE, errorCode));
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

### What changed

Added `sendDurationMetric` method to MetricsService to be used by handlers after sending a request to Experian.

Removed;
- Duplicate duration calculation logic
- Removed execution_duration dimension from Result metric as duration is a metric not a dimension.
- Removed transition_id dimension from Result metric as it's no longer needed.

I have kept the duration metric names the same to keep easily viewable with historic data.

### Why did it change

De-duplicate latency metric code, 

### Issue tracking
- [OJ-2845](https://govukverify.atlassian.net/browse/OJ-2845)

[OJ-2845]: https://govukverify.atlassian.net/browse/OJ-2845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ