### PR TITLE
feat: run spotlessApply before build is run

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -200,3 +200,7 @@ gradle.projectsEvaluated {
 }
 
 defaultTasks 'clean', 'spotlessApply', 'build'
+
+tasks.build {
+	dependsOn("spotlessApply")
+}


### PR DESCRIPTION
## Proposed changes

### What changed
spotlessApply is automatically run when build is invoked.

### Why did it change
When developing locally, `gradle build` will fail when you forget to run spotless. This means a developer has to manually run spotless first and then build which can cause an inconvenience. 

By automatically running spotless, developers do not need to worry about running spotless themselves. 
The code-quality GHA will still flag spotless issues if it has not been applied before committing.