### PR TITLE
feat: update IssueCredentialHandler to use the SQSClient provided by the ServiceFactory

### DIFF
--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/IssueCredentialHandler.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/IssueCredentialHandler.java
@@ -14,11 +14,8 @@ import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.token.AccessTokenType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.http.HttpStatusCode;
-import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.lambda.powertools.logging.CorrelationIdPathConstants;
 import software.amazon.lambda.powertools.logging.Logging;
 import software.amazon.lambda.powertools.metrics.Metrics;
@@ -96,11 +93,7 @@ public class IssueCredentialHandler
         this.eventProbe = new EventProbe();
         this.auditService =
                 new AuditService(
-                        SqsClient.builder()
-                                .credentialsProvider(
-                                        EnvironmentVariableCredentialsProvider.create())
-                                .region(Region.of(System.getenv("AWS_REGION")))
-                                .build(),
+                        serviceFactory.getSqsClient(),
                         configurationService,
                         new ObjectMapper(),
                         new AuditEventFactory(configurationService, Clock.systemUTC()));


### PR DESCRIPTION
## Proposed changes

### What changed
SQSClient is being referenced from the ServiceFactory instead of manually creating it.

### Why did it change
To support SnapStart, we have to handle credentials differently. The ServiceFactory is a wrapper over ConfigurationService which is provided from ipv-cri-lib. The ConfigurationService gives us a SnapStart suitable reference of the SQSClient that we can use. 

### Issue tracking
- [OJ-3065](https://govukverify.atlassian.net/browse/OJ-3065)


[OJ-3065]: https://govukverify.atlassian.net/browse/OJ-3065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ