### PR TITLE
OJ-3063: Update to use clientProviderFactory dynamodbClient

### DIFF
--- a/lambdas/abandon/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/AbandonKbvHandler.java
+++ b/lambdas/abandon/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/AbandonKbvHandler.java
@@ -51,7 +51,10 @@ public class AbandonKbvHandler
     public AbandonKbvHandler() {
         ServiceFactory serviceFactory = new ServiceFactory();
         this.eventProbe = new EventProbe();
-        this.kbvStorageService = new KBVStorageService(serviceFactory.getConfigurationService());
+        this.kbvStorageService =
+                new KBVStorageService(
+                        serviceFactory.getConfigurationService(),
+                        serviceFactory.getDynamoDbEnhancedClient());
         this.sessionService = serviceFactory.getSessionService();
         this.auditService = serviceFactory.getAuditService();
     }

--- a/lambdas/answer/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandler.java
+++ b/lambdas/answer/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandler.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.http.HttpStatusCode;
 import software.amazon.lambda.powertools.logging.CorrelationIdPathConstants;
 import software.amazon.lambda.powertools.logging.Logging;
@@ -62,10 +63,13 @@ public class QuestionAnswerHandler
     @ExcludeFromGeneratedCoverageReport
     public QuestionAnswerHandler() {
         ServiceFactory serviceFactory = new ServiceFactory();
+        DynamoDbEnhancedClient dynamoDbEnhancedClient = serviceFactory.getDynamoDbEnhancedClient();
+
         this.configurationService = serviceFactory.getConfigurationService();
 
         this.objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
-        this.kbvStorageService = new KBVStorageService(configurationService);
+        this.kbvStorageService =
+                new KBVStorageService(configurationService, dynamoDbEnhancedClient);
         this.kbvService = new KBVService(serviceFactory.getKbvGateway());
         this.sessionService = serviceFactory.getSessionService();
         this.auditService = serviceFactory.getAuditService();

--- a/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionHandler.java
+++ b/lambdas/question/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionHandler.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.http.HttpStatusCode;
 import software.amazon.lambda.powertools.logging.CorrelationIdPathConstants;
 import software.amazon.lambda.powertools.logging.Logging;
@@ -82,6 +83,7 @@ public class QuestionHandler
     @ExcludeFromGeneratedCoverageReport
     public QuestionHandler() {
         ServiceFactory serviceFactory = new ServiceFactory();
+        DynamoDbEnhancedClient dynamoDbEnhancedClient = serviceFactory.getDynamoDbEnhancedClient();
         this.configurationService = serviceFactory.getConfigurationService();
 
         this.objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
@@ -91,7 +93,8 @@ public class QuestionHandler
                         serviceFactory.getDynamoDbEnhancedClient());
 
         this.kbvService = new KBVService(serviceFactory.getKbvGateway());
-        this.kbvStorageService = new KBVStorageService(this.configurationService);
+        this.kbvStorageService =
+                new KBVStorageService(configurationService, dynamoDbEnhancedClient);
         this.auditService = serviceFactory.getAuditService();
         this.sessionService = serviceFactory.getSessionService();
         this.eventProbe = new EventProbe();

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/KBVStorageService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/KBVStorageService.java
@@ -1,8 +1,8 @@
 package uk.gov.di.ipv.cri.kbv.api.service;
 
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.cri.common.library.persistence.DataStore;
-import uk.gov.di.ipv.cri.common.library.persistence.DynamoDbEnhancedClientFactory;
 import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
 import uk.gov.di.ipv.cri.kbv.api.domain.KBVItem;
 
@@ -13,20 +13,22 @@ public class KBVStorageService {
     private final DataStore<KBVItem> dataStore;
 
     @ExcludeFromGeneratedCoverageReport
-    public KBVStorageService(ConfigurationService configurationService) {
-        this.dataStore =
+    public KBVStorageService(
+            ConfigurationService configurationService,
+            DynamoDbEnhancedClient dynamoDbEnhancedClient) {
+        this(
                 new DataStore<>(
                         configurationService.getParameterValue("KBVTableName"),
                         KBVItem.class,
-                        new DynamoDbEnhancedClientFactory().getClient());
+                        dynamoDbEnhancedClient));
     }
 
-    public KBVStorageService(DataStore<KBVItem> datastore) {
-        this.dataStore = datastore;
+    KBVStorageService(DataStore<KBVItem> dataStore) {
+        this.dataStore = dataStore;
     }
 
     public Optional<KBVItem> getSessionId(String sessionId) {
-        return Optional.of(this.dataStore.getItem(sessionId));
+        return Optional.ofNullable(this.dataStore.getItem(sessionId));
     }
 
     public KBVItem getKBVItem(UUID sessionId) {

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/KBVStorageServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/KBVStorageServiceTest.java
@@ -1,0 +1,84 @@
+package uk.gov.di.ipv.cri.kbv.api.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.cri.common.library.persistence.DataStore;
+import uk.gov.di.ipv.cri.kbv.api.domain.KBVItem;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class KBVStorageServiceTest {
+    private static final UUID SESSION_ID = UUID.randomUUID();
+    @Mock private DataStore<KBVItem> dataStore;
+
+    private KBVStorageService kbvStorageService;
+
+    @BeforeEach
+    void setUp() {
+        kbvStorageService = new KBVStorageService(dataStore);
+    }
+
+    @Test
+    void getSessionIdReturnsKBVItemWhenItExists() {
+        KBVItem kbvItem = new KBVItem();
+        when(dataStore.getItem(SESSION_ID.toString())).thenReturn(kbvItem);
+
+        Optional<KBVItem> result = kbvStorageService.getSessionId(SESSION_ID.toString());
+
+        assertTrue(result.isPresent());
+        assertEquals(kbvItem, result.get());
+        verify(dataStore, times(1)).getItem(SESSION_ID.toString());
+    }
+
+    @Test
+    void getSessionIdReturnsEmptyOptionalKbvItemWhenNotExists() {
+        when(dataStore.getItem(SESSION_ID.toString())).thenReturn(null);
+
+        Optional<KBVItem> result = kbvStorageService.getSessionId(SESSION_ID.toString());
+
+        assertFalse(result.isPresent());
+        verify(dataStore, times(1)).getItem(SESSION_ID.toString());
+    }
+
+    @Test
+    void getKBVItemReturnsKBVItem() {
+        UUID sessionId = UUID.randomUUID();
+        KBVItem kbvItem = new KBVItem();
+
+        when(dataStore.getItem(sessionId.toString())).thenReturn(kbvItem);
+
+        KBVItem result = kbvStorageService.getKBVItem(sessionId);
+
+        assertEquals(kbvItem, result);
+        verify(dataStore, times(1)).getItem(sessionId.toString());
+    }
+
+    @Test
+    void updateCallsDataStoreUpdate() {
+        KBVItem kbvItem = new KBVItem();
+        kbvStorageService.update(kbvItem);
+
+        verify(dataStore, times(1)).update(kbvItem);
+    }
+
+    @Test
+    void saveCallsDataStoreCreate() {
+        KBVItem kbvItem = new KBVItem();
+
+        kbvStorageService.save(kbvItem);
+
+        verify(dataStore, times(1)).create(kbvItem);
+    }
+}


### PR DESCRIPTION
## Proposed changes

 The `KBVStorageService` now receives `configurationService` and `dynamodbClient` from cri-lib of`ClientProviderFactory`

There was no test for `KBVStorageService` so test have also been added


### Why did it change

As part of SnapStart, AWS credentials are loaded differently and thus changes need to be made. 

- [OJ-3063](https://govukverify.atlassian.net/browse/OJ-3063)


[OJ-3063]: https://govukverify.atlassian.net/browse/OJ-3063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ