### PR TITLE
feat: use kms client from ServiceFactory in VerifiableCredentialService

### DIFF
--- a/lambdas/issuecredential/build.gradle
+++ b/lambdas/issuecredential/build.gradle
@@ -14,7 +14,8 @@ dependencies {
 			configurations.nimbus,
 			configurations.dynamodb,
 			configurations.jackson,
-			configurations.sqs
+			configurations.sqs,
+			configurations.kms
 
 	aspect configurations.powertools
 

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/IssueCredentialHandler.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/IssueCredentialHandler.java
@@ -87,7 +87,9 @@ public class IssueCredentialHandler
         ServiceFactory serviceFactory = new ServiceFactory();
         ConfigurationService configurationService = serviceFactory.getConfigurationService();
 
-        this.verifiableCredentialService = new VerifiableCredentialService(configurationService);
+        this.verifiableCredentialService =
+                new VerifiableCredentialService(
+                        configurationService, serviceFactory.getKMSClient());
         this.kbvStorageService = new KBVStorageService(configurationService);
         this.sessionService = serviceFactory.getSessionService();
         this.eventProbe = new EventProbe();

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/VerifiableCredentialService.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/VerifiableCredentialService.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jwt.SignedJWT;
+import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.lambda.powertools.tracing.Tracing;
 import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.Address;
@@ -48,13 +49,15 @@ public class VerifiableCredentialService {
     private final EvidenceFactory evidenceFactory;
 
     @ExcludeFromGeneratedCoverageReport
-    public VerifiableCredentialService(ConfigurationService configurationService)
+    public VerifiableCredentialService(
+            ConfigurationService configurationService, KmsClient kmsClient)
             throws JsonProcessingException {
         this.configurationService = configurationService;
         this.signedJwtFactory =
                 new SignedJWTFactory(
                         new KMSSigner(
-                                configurationService.getVerifiableCredentialKmsSigningKeyId()));
+                                configurationService.getVerifiableCredentialKmsSigningKeyId(),
+                                kmsClient));
         this.objectMapper =
                 new ObjectMapper()
                         .registerModule(new Jdk8Module())

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -23,7 +23,8 @@ dependencies {
 			configurations.hibernate,
 			configurations.nimbus,
 			configurations.soap,
-			configurations.sqs
+			configurations.sqs,
+			configurations.kms
 
 	aspect configurations.powertools
 

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/ServiceFactory.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/ServiceFactory.java
@@ -4,6 +4,7 @@ import com.experian.uk.schema.experian.identityiq.services.webservice.IdentityIQ
 import com.experian.uk.wasp.TokenService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.lambda.powertools.parameters.SSMProvider;
 import software.amazon.lambda.powertools.parameters.SecretsProvider;
@@ -55,6 +56,10 @@ public class ServiceFactory {
 
     public SqsClient getSqsClient() {
         return clientProviderFactory.getSqsClient();
+    }
+
+    public KmsClient getKMSClient() {
+        return clientProviderFactory.getKMSClient();
     }
 
     public ConfigurationService getConfigurationService() {


### PR DESCRIPTION
## Proposed changes

### What changed
KMSClient is being referenced from the ServiceFactory instead of manually creating it.

### Why did it change
To support SnapStart, we have to handle credentials differently. The ServiceFactory is a wrapper over ConfigurationService which is provided from ipv-cri-lib. The ConfigurationService gives us a SnapStart suitable reference of the KMSClient that we can use.

### Issue tracking
- [OJ-3064](https://govukverify.atlassian.net/browse/OJ-3064)


[OJ-3064]: https://govukverify.atlassian.net/browse/OJ-3064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ