### PR TITLE
OJ-3049: Unpin sam-version from preview action

### DIFF
--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -50,7 +50,6 @@ jobs:
           pull-repository: false
           cache-name: kbv-api
           source-dir: lambdas
-          sam-version: 1.132.0
 
   deploy:
     name: Deploy stack

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -21,7 +21,7 @@ Parameters:
   PermissionsBoundary:
     Description: "The ARN of the permissions boundary to apply when creating IAM roles"
     Type: String
-    Default: "none"
+    Default: ""
   SecretPrefix:
     Description: Secrets name prefix
     Type: String
@@ -49,7 +49,7 @@ Parameters:
 
 Conditions:
   UseSecretPrefix: !Not [!Equals [!Ref SecretPrefix, "none"]]
-  UsePermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundary, "none"]]
+  UsePermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundary, ""]]
   UseCodeSigningConfigArn: !Not [!Equals [!Ref CodeSigningConfigArn, "none"]]
   UseCanaryDeploymentAlarms: !Not [!Equals [!Ref LambdaDeploymentPreference, AllAtOnce]]
   IsDevEnvironment: !Or [!Equals [!Ref Environment, dev], !Condition IsLocalDevEnvironment]


### PR DESCRIPTION
## Proposed changes

### What changed

Unpin sam version from preview stack. 
Reverts https://github.com/govuk-one-login/ipv-cri-kbv-api/pull/452 but keeps the newer version of the action.

Set`PermissionsBoundary` default value to `""` instead of `"none"`.  For some reason cfn-lint was flagging an E3033 linting error if there was a value, possibly something to do with the transforms.

### Why did it change

No longer requires pinning as the linting bug was fixed in Sam CLI 1.135.0 which ubuntu-latest image now uses.

Fix `E3033 'none' is shorter than 20` being flagged on `PermissionsBoundary` default value. 

### Issue tracking

- [OJ-3049](https://govukverify.atlassian.net/browse/OJ-3049)

[OJ-3049]: https://govukverify.atlassian.net/browse/OJ-3049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ