### PR TITLE
OJ-3080: Add alarms for jwt_verification_failed

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -891,6 +891,54 @@ Resources:
             Period: 300
             Stat: Sum
 
+  SessionLambdaFailedToVerifyJWTAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: Errors verifying JWTs that have been been received by the session lambda.
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue core-infrastructure-AlarmTopic
+      OKActions:
+        - !ImportValue core-infrastructure-AlarmTopic
+      InsufficientDataActions: []
+      MetricName: jwt_verification_failed
+      AlarmName: !Sub ${AWS::StackName}-${Environment}-SessionLambdaFailedToVerifyJWTAlarm
+      Namespace: !Sub "${CriIdentifier}"
+      Statistic: Sum
+      Dimensions:
+        - Name: service
+          Value: !Sub "${CriIdentifier}-sessionTS"
+      Period: 300
+      DatapointsToAlarm: 3
+      EvaluationPeriods: 3
+      Threshold: 1
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  TokenLambdaFailedToVerifyJWTAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: Errors verifying JWTs that have been been received by the token lambda.
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue core-infrastructure-AlarmTopic
+      OKActions:
+        - !ImportValue core-infrastructure-AlarmTopic
+      InsufficientDataActions: []
+      MetricName: jwt_verification_failed
+      AlarmName: !Sub ${AWS::StackName}-${Environment}-TokenLambdaFailedToVerifyJWTAlarm
+      Namespace: !Sub "${CriIdentifier}"
+      Statistic: Sum
+      Dimensions:
+        - Name: service
+          Value: !Sub "${CriIdentifier}-access-token-2"
+      Period: 300
+      DatapointsToAlarm: 3
+      EvaluationPeriods: 3
+      Threshold: 1
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
   ExperianKBVQuestionFunction5xxCanaryErrors:
     Type: AWS::CloudWatch::Alarm
     Condition: UseCanaryDeploymentAlarms


### PR DESCRIPTION
## Proposed changes

### What changed

Add new SessionLambdaFailedToVerifyJWTAlarm and TokenLambdaFailedToVerifyJWTAlarm alarms

### Why did it change

So that we are quickly alerted when there is an issue verifying the JWTs that core is sending address CRI.

The new metric has been added in common lambdas https://github.com/govuk-one-login/ipv-cri-common-lambdas/pull/473

### Issue tracking
- [OJ-3080](https://govukverify.atlassian.net/browse/OJ-3080)

### Screenshot

![image](https://github.com/user-attachments/assets/5352a714-a68c-422f-ad25-13de4e7786de)
![image](https://github.com/user-attachments/assets/0b336108-a25a-4455-92b6-192b8eb66c60)


[OJ-3080]: https://govukverify.atlassian.net/browse/OJ-3080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ