### PR TITLE
OJ-3085: upgrade to Java 21

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 21
           distribution: zulu
           cache: gradle
 

--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 21
           distribution: zulu
           cache: gradle
 

--- a/.github/workflows/package-for-build.yml
+++ b/.github/workflows/package-for-build.yml
@@ -19,10 +19,10 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
 
-      - name: Set up JDK 11
+      - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 21
           distribution: zulu
 
       - name: Setup Python

--- a/.github/workflows/package-for-dev.yml
+++ b/.github/workflows/package-for-dev.yml
@@ -18,10 +18,10 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
 
-      - name: Set up JDK 11
+      - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 21
           distribution: zulu
 
       - name: Setup Python

--- a/.github/workflows/run-pact-tests.yml
+++ b/.github/workflows/run-pact-tests.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 21
           distribution: zulu
           cache: gradle
 

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 21
           distribution: zulu
           cache: gradle
 

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,4 +1,4 @@
 # Enable auto-env through the sdkman_auto_env config
 # Add key=value pairs of SDKs to use below
-java=11.0.14-zulu
+java=21.0.7-amzn
 gradle=8.13

--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,8 @@ subprojects {
 	apply plugin: 'java'
 
 	java {
-		sourceCompatibility = JavaVersion.VERSION_11
-		targetCompatibility = JavaVersion.VERSION_11
+		sourceCompatibility = JavaVersion.VERSION_17
+		targetCompatibility = JavaVersion.VERSION_17
 	}
 
 	repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ sonar {
 spotless {
 	java {
 		target "**/src/**/*.java"
-		googleJavaFormat("1.13.0").aosp()
+		googleJavaFormat("1.17.0").aosp()
 		importOrder "", "javax", "java", "\\#"
 		endWithNewline()
 	}

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -68,7 +68,7 @@ Globals:
       !If [UseCodeSigningConfigArn, !Ref CodeSigningConfigArn, !Ref AWS::NoValue]
     Tracing: Active
     Timeout: 30 # seconds
-    Runtime: java11
+    Runtime: java21
     Architectures: [arm64]
     AutoPublishAlias: live
     SnapStart:

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactory.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/kbv/api/service/EvidenceFactory.java
@@ -68,6 +68,7 @@ public class EvidenceFactory {
 
         return new Map[] {objectMapper.convertValue(evidence, Map.class)};
     }
+
     /**
      * Return CheckDetail[] with CheckDetail elements that have kbvQuality values assigned according
      * to the following scenarios:

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/handler/IssueCredentialHandlerTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/handler/IssueCredentialHandlerTest.java
@@ -305,7 +305,10 @@ class IssueCredentialHandlerTest implements TestFixtures {
 
     @Test
     void shouldThrowNoSuchAlgorithmErrorWhenTheWrongKeyAlgorithmIsUsed()
-            throws NoSuchAlgorithmException, JOSEException, JsonProcessingException, ParseException,
+            throws NoSuchAlgorithmException,
+                    JOSEException,
+                    JsonProcessingException,
+                    ParseException,
                     SqsException {
         String issuer = "issuer";
         String kmsSigningKeyId = "kmsSigningId";

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/handler/util/PreLambdaHandler.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/handler/util/PreLambdaHandler.java
@@ -144,7 +144,10 @@ public class PreLambdaHandler implements HttpHandler {
     }
 
     private void translateResponse(APIGatewayProxyResponseEvent response, HttpExchange exchange)
-            throws IOException, ParseException, InvalidKeySpecException, NoSuchAlgorithmException,
+            throws IOException,
+                    ParseException,
+                    InvalidKeySpecException,
+                    NoSuchAlgorithmException,
                     JOSEException {
 
         Integer statusCode = response.getStatusCode();
@@ -165,7 +168,10 @@ public class PreLambdaHandler implements HttpHandler {
     }
 
     public String reOrderJwt(String body)
-            throws ParseException, JOSEException, InvalidKeySpecException, NoSuchAlgorithmException,
+            throws ParseException,
+                    JOSEException,
+                    InvalidKeySpecException,
+                    NoSuchAlgorithmException,
                     JsonProcessingException {
         JWT jwt = JWTParser.parse(body);
         JWSHeader jwsHeader = (JWSHeader) jwt.getHeader();

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/VerifiableCredentialServiceTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/VerifiableCredentialServiceTest.java
@@ -121,8 +121,11 @@ class VerifiableCredentialServiceTest implements TestFixtures {
                 int answeredInCorrectly,
                 int expectedVerificationScore,
                 ContraIndicator expectedContraIndicator)
-                throws JOSEException, InvalidKeySpecException, NoSuchAlgorithmException,
-                        ParseException, JsonProcessingException {
+                throws JOSEException,
+                        InvalidKeySpecException,
+                        NoSuchAlgorithmException,
+                        ParseException,
+                        JsonProcessingException {
             initMockConfigurationService();
             SignedJWTFactory signedJwtFactory =
                     new SignedJWTFactory(new ECDSASigner(getPrivateKey()));

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/gateway/KeyStoreLoaderTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/gateway/KeyStoreLoaderTest.java
@@ -57,7 +57,9 @@ class KeyStoreLoaderTest {
                             keyStoreLoader.load();
                         });
 
-        assertEquals("Persist keystore to file failed: null", exception.getMessage());
+        assertEquals(
+                "Persist keystore to file failed: Cannot invoke \"String.getBytes(java.nio.charset.Charset)\" because \"src\" is null",
+                exception.getMessage());
     }
 
     @Test

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/ServiceFactoryTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/service/ServiceFactoryTest.java
@@ -113,7 +113,7 @@ class ServiceFactoryTest {
                 assertThrows(KBVGatewayCreationException.class, serviceFactory::getKbvGateway);
 
         assertEquals(
-                "Failed to create KBVGateway: Persist keystore to file failed: null",
+                "Failed to create KBVGateway: Persist keystore to file failed: Cannot invoke \"String.getBytes(java.nio.charset.Charset)\" because \"src\" is null",
                 exception.getMessage());
     }
 }


### PR DESCRIPTION
## Proposed changes

### What changed
* Workflows use Java 21
* CloudFormation template updated to use Java 21
* Tests updated to match Java upgrade

**Note**: `JavaVersion.VERSION_17` in the compatibility section because `_21` isn't recognised and I cannot flat out remove this section because the tests require it set. No big deal at the moment. 

### Why did it change
These changes have been applied so that we can support Java 21. As per team manual, we should be using the latest LTS version. 

### Issue tracking
- [OJ-3085](https://govukverify.atlassian.net/browse/OJ-3157)


[OJ-3085]: https://govukverify.atlassian.net/browse/OJ-3085?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ