### PR TITLE
test: create integration test for /healthcheck/thirdparty

### DIFF
--- a/integration-tests/src/test/java/gov/uk/kbv/api/stepdefinitions/HealthCheckEndpointStepDefinition.java
+++ b/integration-tests/src/test/java/gov/uk/kbv/api/stepdefinitions/HealthCheckEndpointStepDefinition.java
@@ -1,0 +1,65 @@
+package gov.uk.kbv.api.stepdefinitions;
+
+import io.cucumber.java.en.And;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import uk.gov.di.ipv.cri.common.library.client.ClientConfigurationService;
+import uk.gov.di.ipv.cri.common.library.client.HttpHeaders;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class HealthCheckEndpointStepDefinition {
+    private final ClientConfigurationService clientConfigurationService;
+    private final String baseURL;
+
+    private HttpResponse<String> response;
+
+    public HealthCheckEndpointStepDefinition(ClientConfigurationService config) {
+        this.clientConfigurationService = config;
+        this.baseURL =
+                "%s/%s".formatted(config.getPublicApiEndpoint(), System.getenv("ENVIRONMENT"));
+    }
+
+    @Given("user makes a request to {string} without being on the VPN")
+    public void userMakesARequestToWithoutBeingOnTheVPN(String endpoint)
+            throws URISyntaxException, IOException, InterruptedException {
+        sendRequestToHealthCheckEndpoint(baseURL + endpoint);
+    }
+
+    @Then("they should see an access denied error")
+    public void theyShouldSeeAnAccessDeniedError() {
+        assertTrue(response.body().contains("anonymous is not authorized to perform"));
+    }
+
+    @And("the response status should be {int}")
+    public void theResponseStatusShouldBe(int expectedStatus) {
+        assertEquals(expectedStatus, response.statusCode());
+    }
+
+    private void sendRequestToHealthCheckEndpoint(String url)
+            throws URISyntaxException, IOException, InterruptedException {
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            HttpRequest request =
+                    HttpRequest.newBuilder()
+                            .method("GET", HttpRequest.BodyPublishers.noBody())
+                            .uri(new URI(url))
+                            .header(
+                                    HttpHeaders.API_KEY,
+                                    clientConfigurationService.getPublicApiKey())
+                            .build();
+
+            response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+            assertNotNull(response);
+        }
+    }
+}

--- a/integration-tests/src/test/resources/features/HealthCheckEndpoint.feature
+++ b/integration-tests/src/test/resources/features/HealthCheckEndpoint.feature
@@ -1,0 +1,11 @@
+Feature: User visits the "/healthcheck/thirdparty/info" endpoint to see system information
+
+  Scenario: The API is only accessible via the GDS VPN
+
+    Given user makes a request to "/healthcheck/thirdparty" without being on the VPN
+    Then they should see an access denied error
+    And the response status should be 403
+
+    Given user makes a request to "/healthcheck/thirdparty/info" without being on the VPN
+    Then they should see an access denied error
+    And the response status should be 403


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Added tests for the `/healthcheck/thirdparty` endpoint to assert that it is not accessible outside the VPN.

These tests do not cover functionality of the endpoint i.e. the data returned, that responsibility is left to the unit tests. Additionally, it'll be a challenge to expose the endpoint for localdev. 

### Issue tracking
- [OJ-3168](https://govukverify.atlassian.net/browse/OJ-3168)


[OJ-3168]: https://govukverify.atlassian.net/browse/OJ-3168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ