### PR TITLE
feat: show certificates checked in trust manager when calling SOAP API

### DIFF
--- a/lambdas/healthcheck/src/main/java/uk/gov/di/ipv/cri/kbv/healthcheck/handler/HealthCheckHandler.java
+++ b/lambdas/healthcheck/src/main/java/uk/gov/di/ipv/cri/kbv/healthcheck/handler/HealthCheckHandler.java
@@ -85,9 +85,12 @@ public class HealthCheckHandler
         List<Assertion> tests =
                 List.of(
                         new SSLHandshakeAssertion(Configuration.WASP_HOST, Configuration.WASP_PORT),
-                        new SOAPRequestAssertion(keystorePassword, waspURL, keystoreSecret),
                         new KeyToolAssertion(keystoreSecret, keystorePassword),
-                        new KeyStoreAssertion(keystoreSecret, keystorePassword));
+                        new KeyStoreAssertion(keystoreSecret, keystorePassword),
+                        new SOAPRequestAssertion(
+                                keystorePassword,
+                                waspURL,
+                                keystoreSecret)); // Run SOAPRequestAssertion Last!
 
         for (Assertion assertion : tests) {
             String name = assertion.getClass().getSimpleName();

--- a/lambdas/healthcheck/src/main/java/uk/gov/di/ipv/cri/kbv/healthcheck/handler/assertions/soap/Certificate.java
+++ b/lambdas/healthcheck/src/main/java/uk/gov/di/ipv/cri/kbv/healthcheck/handler/assertions/soap/Certificate.java
@@ -1,0 +1,3 @@
+package uk.gov.di.ipv.cri.kbv.healthcheck.handler.assertions.soap;
+
+public record Certificate(String subject, String issuer) {}

--- a/lambdas/healthcheck/src/main/java/uk/gov/di/ipv/cri/kbv/healthcheck/handler/assertions/soap/CustomX509TrustManager.java
+++ b/lambdas/healthcheck/src/main/java/uk/gov/di/ipv/cri/kbv/healthcheck/handler/assertions/soap/CustomX509TrustManager.java
@@ -1,0 +1,64 @@
+package uk.gov.di.ipv.cri.kbv.healthcheck.handler.assertions.soap;
+
+import javax.net.ssl.X509TrustManager;
+
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.List;
+
+public class CustomX509TrustManager implements X509TrustManager {
+    private final X509TrustManager defaultTrustManager;
+    private final List<Certificate> clientCertificates;
+    private final List<Certificate> serverCertificates;
+
+    public CustomX509TrustManager(X509TrustManager defaultTrustManager) {
+        this.defaultTrustManager = defaultTrustManager;
+        this.clientCertificates = new ArrayList<>();
+        this.serverCertificates = new ArrayList<>();
+    }
+
+    @Override
+    public void checkClientTrusted(X509Certificate[] chain, String authType)
+            throws CertificateException {
+        cacheClientCertificate(chain);
+        defaultTrustManager.checkClientTrusted(chain, authType);
+    }
+
+    @Override
+    public void checkServerTrusted(X509Certificate[] chain, String authType)
+            throws CertificateException {
+        cacheServerCertificate(chain);
+        defaultTrustManager.checkServerTrusted(chain, authType);
+    }
+
+    @Override
+    public X509Certificate[] getAcceptedIssuers() {
+        return defaultTrustManager.getAcceptedIssuers();
+    }
+
+    private void cacheServerCertificate(X509Certificate[] chain) {
+        for (X509Certificate cert : chain) {
+            serverCertificates.add(toCertificate(cert));
+        }
+    }
+
+    private void cacheClientCertificate(X509Certificate[] chain) {
+        for (X509Certificate cert : chain) {
+            clientCertificates.add(toCertificate(cert));
+        }
+    }
+
+    private Certificate toCertificate(X509Certificate cert) {
+        return new Certificate(
+                cert.getSubjectX500Principal().getName(), cert.getIssuerX500Principal().getName());
+    }
+
+    public List<Certificate> getClientCertificates() {
+        return clientCertificates;
+    }
+
+    public List<Certificate> getServerCertificates() {
+        return serverCertificates;
+    }
+}

--- a/lambdas/healthcheck/src/main/java/uk/gov/di/ipv/cri/kbv/healthcheck/handler/assertions/soap/SOAPRequestAssertion.java
+++ b/lambdas/healthcheck/src/main/java/uk/gov/di/ipv/cri/kbv/healthcheck/handler/assertions/soap/SOAPRequestAssertion.java
@@ -10,6 +10,9 @@ import uk.gov.di.ipv.cri.kbv.healthcheck.util.keytool.Keytool;
 
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -18,6 +21,7 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.security.KeyStore;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -50,6 +54,8 @@ public class SOAPRequestAssertion implements Assertion {
     private final String waspUrl;
     private final String jksFileLocation;
 
+    private static CustomX509TrustManager customTrustManager;
+
     public SOAPRequestAssertion(String keystorePassword, String waspUrl, String keystore)
             throws IOException {
         this.keystorePassword = keystorePassword;
@@ -71,6 +77,11 @@ public class SOAPRequestAssertion implements Assertion {
 
             AtomicBoolean success = new AtomicBoolean(false);
             report.addAttributes("soap_request", processResponse(success, connection));
+            report.addAttributes(
+                    "trust_manager",
+                    Map.of(
+                            "server", customTrustManager.getServerCertificates(),
+                            "client", customTrustManager.getClientCertificates()));
             report.setPassed(success.get());
 
             connection.disconnect();
@@ -146,8 +157,23 @@ public class SOAPRequestAssertion implements Assertion {
 
     private static SSLContext initializeSSLContext() {
         try {
+            TrustManagerFactory factory =
+                    TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            factory.init((KeyStore) null);
+
+            X509TrustManager defaultTrustManager = null;
+
+            for (TrustManager trustManager : factory.getTrustManagers()) {
+                if (trustManager instanceof X509TrustManager x509TrustManager) {
+                    defaultTrustManager = x509TrustManager;
+                    break;
+                }
+            }
+
+            customTrustManager = new CustomX509TrustManager(defaultTrustManager);
+
             SSLContext sslContext = SSLContext.getInstance("TLS");
-            sslContext.init(null, null, null);
+            sslContext.init(null, new TrustManager[] {customTrustManager}, null);
 
             return sslContext;
         } catch (Exception e) {

--- a/lambdas/healthcheck/src/test/java/uk/gov/di/ipv/cri/kbv/healthcheck/handler/HealthCheckHandlerTest.java
+++ b/lambdas/healthcheck/src/test/java/uk/gov/di/ipv/cri/kbv/healthcheck/handler/HealthCheckHandlerTest.java
@@ -87,6 +87,21 @@ class HealthCheckHandlerTest {
     }
 
     @Test
+    void sOAPRequestAssertionContainsTrustManager() throws JsonProcessingException {
+        APIGatewayProxyRequestEvent request = new APIGatewayProxyRequestEvent().withPath("/info");
+        APIGatewayProxyResponseEvent response = handler.handleRequest(request, mock(Context.class));
+
+        JsonNode body = OBJECT_MAPPER.readTree(response.getBody());
+        JsonNode soapReport = body.get("SOAPRequestAssertion");
+        JsonNode attributes = soapReport.get("attributes");
+        JsonNode trustManager = attributes.get("trust_manager");
+
+        assertTrue(attributes.has("trust_manager"));
+        assertTrue(trustManager.has("server"));
+        assertTrue(trustManager.has("client"));
+    }
+
+    @Test
     void shouldReturnEmptyBody() {
         APIGatewayProxyRequestEvent request = new APIGatewayProxyRequestEvent();
         APIGatewayProxyResponseEvent response = handler.handleRequest(request, mock(Context.class));

--- a/lambdas/healthcheck/src/test/java/uk/gov/di/ipv/cri/kbv/healthcheck/handler/assertions/soap/CustomX509TrustManagerTest.java
+++ b/lambdas/healthcheck/src/test/java/uk/gov/di/ipv/cri/kbv/healthcheck/handler/assertions/soap/CustomX509TrustManagerTest.java
@@ -1,0 +1,64 @@
+package uk.gov.di.ipv.cri.kbv.healthcheck.handler.assertions.soap;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.net.ssl.X509TrustManager;
+import javax.security.auth.x500.X500Principal;
+
+import java.security.cert.X509Certificate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CustomX509TrustManagerTest {
+
+    private X509TrustManager mockTrustManager;
+    private CustomX509TrustManager customTrustManager;
+    private X509Certificate mockCert;
+
+    @BeforeEach
+    void setUp() {
+        mockTrustManager = mock(X509TrustManager.class);
+        customTrustManager = new CustomX509TrustManager(mockTrustManager);
+
+        mockCert = mock(X509Certificate.class);
+        when(mockCert.getSubjectX500Principal()).thenReturn(new X500Principal("CN=TestSubject"));
+        when(mockCert.getIssuerX500Principal()).thenReturn(new X500Principal("CN=TestIssuer"));
+    }
+
+    @Test
+    void testCheckClientTrustedCachesCertificate() throws Exception {
+        X509Certificate[] chain = new X509Certificate[] {mockCert};
+
+        customTrustManager.checkClientTrusted(chain, "RSA");
+
+        List<Certificate> cached = customTrustManager.getClientCertificates();
+
+        verify(mockTrustManager).checkClientTrusted(chain, "RSA");
+        assertEquals(1, cached.size());
+        assertEquals("CN=TestSubject", cached.get(0).subject());
+        assertEquals("CN=TestIssuer", cached.get(0).issuer());
+    }
+
+    @Test
+    void testCheckServerTrustedCachesCertificate() throws Exception {
+        X509Certificate[] chain = new X509Certificate[] {mockCert};
+
+        customTrustManager.checkServerTrusted(chain, "RSA");
+
+        List<Certificate> cached = customTrustManager.getServerCertificates();
+
+        verify(mockTrustManager).checkServerTrusted(chain, "RSA");
+
+        assertEquals(1, cached.size());
+        assertEquals("CN=TestSubject", cached.get(0).subject());
+        assertEquals("CN=TestIssuer", cached.get(0).issuer());
+    }
+}


### PR DESCRIPTION
## Proposed changes

### What changed
Added a section to the report to show which certificates were checked against the system trust store. 

### Why did it change
Experian changed their root CA to use Sectigo. This PR shows visibility on what certificates Experian uses so that we can confirm/verify our trust with Experians server. 

Note: These changes are not secret and show the subject/issuer of the publicly known CAs. 

**Added section to SOAPRequestAssertion**
```json
      "trust_manager" : {
        "server" : [ {
          "subject" : "CN=*.execute-api.eu-west-2.amazonaws.com",
          "issuer" : "CN=Amazon RSA 2048 M03,O=Amazon,C=US"
        }, {
          "subject" : "CN=Amazon RSA 2048 M03,O=Amazon,C=US",
          "issuer" : "CN=Amazon Root CA 1,O=Amazon,C=US"
        }, {
          "subject" : "CN=Amazon Root CA 1,O=Amazon,C=US",
          "issuer" : "CN=Starfield Services Root Certificate Authority - G2,O=Starfield Technologies\\, Inc.,L=Scottsdale,ST=Arizona,C=US"
        }, {
          "subject" : "CN=Starfield Services Root Certificate Authority - G2,O=Starfield Technologies\\, Inc.,L=Scottsdale,ST=Arizona,C=US",
          "issuer" : "OU=Starfield Class 2 Certification Authority,O=Starfield Technologies\\, Inc.,C=US"
        } ],
        "client" : [ ]
      }
```

### Issue tracking
- [OJ-3168](https://govukverify.atlassian.net/browse/OJ-3168)


[OJ-3168]: https://govukverify.atlassian.net/browse/OJ-3168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ