### PR TITLE
feat: add logging on exception when the FailReport is created

### DIFF
--- a/lambdas/healthcheck/src/main/java/uk/gov/di/ipv/cri/kbv/healthcheck/handler/assertions/FailReport.java
+++ b/lambdas/healthcheck/src/main/java/uk/gov/di/ipv/cri/kbv/healthcheck/handler/assertions/FailReport.java
@@ -1,8 +1,13 @@
 package uk.gov.di.ipv.cri.kbv.healthcheck.handler.assertions;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.Map;
 
 public class FailReport extends Report {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FailReport.class);
+
     public FailReport(Exception exception) {
         String exceptionType = exception.getClass().getSimpleName();
         String exceptionMessage = exception.getMessage();
@@ -10,5 +15,7 @@ public class FailReport extends Report {
                 "exception",
                 Map.of("message", "%s: %s".formatted(exceptionType, exceptionMessage)));
         this.setPassed(false);
+
+        LOGGER.error("Exception has been thrown while generating report", exception);
     }
 }


### PR DESCRIPTION
## Proposed changes

### What changed
Add logging of exception for when a FailReport has been generated. 

### Why did it change
To give us more visibility of what the error cause is when debugging. 

### Issue tracking
- [OJ-3168](https://govukverify.atlassian.net/browse/OJ-3168)


[OJ-3168]: https://govukverify.atlassian.net/browse/OJ-3168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ