### PR TITLE
feat: add trust manager entries to output & fix soap connection issue

### DIFF
--- a/lambdas/healthcheck/src/main/java/uk/gov/di/ipv/cri/kbv/healthcheck/handler/assertions/soap/Certificate.java
+++ b/lambdas/healthcheck/src/main/java/uk/gov/di/ipv/cri/kbv/healthcheck/handler/assertions/soap/Certificate.java
@@ -1,0 +1,3 @@
+package uk.gov.di.ipv.cri.kbv.healthcheck.handler.assertions.soap;
+
+public record Certificate(String subject, String issuer) {}

--- a/lambdas/healthcheck/src/main/java/uk/gov/di/ipv/cri/kbv/healthcheck/handler/assertions/soap/CustomTrustManager.java
+++ b/lambdas/healthcheck/src/main/java/uk/gov/di/ipv/cri/kbv/healthcheck/handler/assertions/soap/CustomTrustManager.java
@@ -8,7 +8,12 @@ import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.security.KeyManagementException;
 import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
@@ -69,7 +74,13 @@ public class CustomTrustManager implements X509TrustManager {
         return serverCertificates;
     }
 
-    public static CustomTrustManager bind(byte[] keystore, char[] password) throws Exception {
+    public static CustomTrustManager bind(byte[] keystore, char[] password)
+            throws NoSuchAlgorithmException,
+                    IOException,
+                    KeyManagementException,
+                    KeyStoreException,
+                    CertificateException,
+                    UnrecoverableKeyException {
         TrustManagerFactory trustManagerFactory =
                 TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
 

--- a/lambdas/healthcheck/src/main/java/uk/gov/di/ipv/cri/kbv/healthcheck/handler/assertions/soap/CustomTrustManager.java
+++ b/lambdas/healthcheck/src/main/java/uk/gov/di/ipv/cri/kbv/healthcheck/handler/assertions/soap/CustomTrustManager.java
@@ -1,0 +1,101 @@
+package uk.gov.di.ipv.cri.kbv.healthcheck.handler.assertions.soap;
+
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
+
+import java.io.ByteArrayInputStream;
+import java.security.KeyStore;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.List;
+
+public class CustomTrustManager implements X509TrustManager {
+    private final X509TrustManager defaultTrustManager;
+    private final List<Certificate> clientCertificates;
+    private final List<Certificate> serverCertificates;
+
+    public CustomTrustManager(X509TrustManager defaultTrustManager) {
+        this.defaultTrustManager = defaultTrustManager;
+        this.clientCertificates = new ArrayList<>();
+        this.serverCertificates = new ArrayList<>();
+    }
+
+    @Override
+    public void checkClientTrusted(X509Certificate[] chain, String authType)
+            throws CertificateException {
+        cacheClientCertificate(chain);
+        defaultTrustManager.checkClientTrusted(chain, authType);
+    }
+
+    @Override
+    public void checkServerTrusted(X509Certificate[] chain, String authType)
+            throws CertificateException {
+        cacheServerCertificate(chain);
+        defaultTrustManager.checkServerTrusted(chain, authType);
+    }
+
+    @Override
+    public X509Certificate[] getAcceptedIssuers() {
+        return defaultTrustManager.getAcceptedIssuers();
+    }
+
+    private void cacheServerCertificate(X509Certificate[] chain) {
+        for (X509Certificate cert : chain) {
+            serverCertificates.add(toCertificate(cert));
+        }
+    }
+
+    private void cacheClientCertificate(X509Certificate[] chain) {
+        for (X509Certificate cert : chain) {
+            clientCertificates.add(toCertificate(cert));
+        }
+    }
+
+    private Certificate toCertificate(X509Certificate cert) {
+        return new Certificate(
+                cert.getSubjectX500Principal().getName(), cert.getIssuerX500Principal().getName());
+    }
+
+    public List<Certificate> getClientCertificates() {
+        return clientCertificates;
+    }
+
+    public List<Certificate> getServerCertificates() {
+        return serverCertificates;
+    }
+
+    public static CustomTrustManager bind(byte[] keystore, char[] password) throws Exception {
+        TrustManagerFactory trustManagerFactory =
+                TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+
+        trustManagerFactory.init((KeyStore) null);
+
+        KeyStore clientKeyStore = KeyStore.getInstance("PKCS12");
+
+        try (ByteArrayInputStream keystoreStream = new ByteArrayInputStream(keystore)) {
+            clientKeyStore.load(keystoreStream, password);
+        }
+
+        KeyManagerFactory keyManagerFactory =
+                KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        keyManagerFactory.init(clientKeyStore, password);
+
+        CustomTrustManager customTrustManager =
+                new CustomTrustManager(
+                        (X509TrustManager) trustManagerFactory.getTrustManagers()[0]);
+
+        SSLContext sslContext = SSLContext.getInstance("TLS");
+        sslContext.init(
+                keyManagerFactory.getKeyManagers(), new TrustManager[] {customTrustManager}, null);
+
+        SSLContext.setDefault(sslContext);
+        HttpsURLConnection.setDefaultSSLSocketFactory(sslContext.getSocketFactory());
+
+        return customTrustManager;
+    }
+}

--- a/lambdas/healthcheck/src/main/java/uk/gov/di/ipv/cri/kbv/healthcheck/handler/assertions/soap/SOAPRequestAssertion.java
+++ b/lambdas/healthcheck/src/main/java/uk/gov/di/ipv/cri/kbv/healthcheck/handler/assertions/soap/SOAPRequestAssertion.java
@@ -1,28 +1,20 @@
 package uk.gov.di.ipv.cri.kbv.healthcheck.handler.assertions.soap;
 
 import uk.gov.di.ipv.cri.kbv.api.util.SoapTokenUtils;
-import uk.gov.di.ipv.cri.kbv.healthcheck.exceptions.SOAPException;
 import uk.gov.di.ipv.cri.kbv.healthcheck.handler.assertions.Assertion;
 import uk.gov.di.ipv.cri.kbv.healthcheck.handler.assertions.FailReport;
 import uk.gov.di.ipv.cri.kbv.healthcheck.handler.assertions.Report;
-import uk.gov.di.ipv.cri.kbv.healthcheck.util.keystore.Keystore;
-import uk.gov.di.ipv.cri.kbv.healthcheck.util.keytool.Keytool;
 
-import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.SSLContext;
-
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
-import java.net.HttpURLConnection;
 import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
 
 public class SOAPRequestAssertion implements Assertion {
     private static final String SOAP_ENVELOPE =
@@ -46,34 +38,36 @@ public class SOAPRequestAssertion implements Assertion {
 
     private static final String CONTENT_TYPE = "text/xml; charset=utf-8";
 
-    private final String keystorePassword;
     private final String waspUrl;
-    private final String jksFileLocation;
+    private final char[] keystorePassword;
+    private final byte[] keystore;
 
-    public SOAPRequestAssertion(String keystorePassword, String waspUrl, String keystore)
-            throws IOException {
-        this.keystorePassword = keystorePassword;
+    public SOAPRequestAssertion(String keystorePassword, String waspUrl, String keystore) {
+        this.keystorePassword = keystorePassword.toCharArray();
         this.waspUrl = waspUrl;
-        this.jksFileLocation = Keystore.createKeyStoreFile(keystore);
+        this.keystore = Base64.getDecoder().decode(keystore);
     }
 
     @Override
     public Report run() {
         Report report = new Report();
 
-        String pfx = "/tmp/%d.pfx".formatted(System.currentTimeMillis());
-        Keytool.importCertificate(pfx, jksFileLocation, keystorePassword);
-
         try {
-            SSLContext sslContext = initializeSSLContext();
-            HttpURLConnection connection = setupConnection(waspUrl, sslContext);
-            sendRequest(connection);
+            CustomTrustManager customTrustManager =
+                    CustomTrustManager.bind(keystore, keystorePassword);
+
+            HttpResponse<String> response = sendRequest();
 
             AtomicBoolean success = new AtomicBoolean(false);
-            report.addAttributes("soap_request", processResponse(success, connection));
+            report.addAttributes("soap_request", processResponse(success, response));
+            report.addAttributes(
+                    "trust_manager",
+                    Map.of(
+                            "server", customTrustManager.getServerCertificates(),
+                            "client", customTrustManager.getClientCertificates()));
+
             report.setPassed(success.get());
 
-            connection.disconnect();
         } catch (Exception e) {
             return new FailReport(e);
         }
@@ -82,43 +76,21 @@ public class SOAPRequestAssertion implements Assertion {
     }
 
     private static Map<String, Object> processResponse(
-            AtomicBoolean success, HttpURLConnection connection) throws IOException {
-        int statusCode = connection.getResponseCode();
-        long date = connection.getDate();
-        int contentLength = connection.getContentLength();
+            AtomicBoolean success, HttpResponse<String> response) {
+        int statusCode = response.statusCode();
+        String body = response.body();
+        Map<String, List<String>> headers = response.headers().map();
 
-        Map<String, List<String>> headers =
-                connection.getHeaderFields().entrySet().stream()
-                        .filter(entry -> entry.getKey() != null)
-                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-
-        boolean valid = isSoapResponseBodyValid(readResponse(connection));
+        boolean valid = isSoapResponseBodyValid(body);
         success.set(valid);
 
         Map<String, Object> result = new HashMap<>();
         result.put("status", statusCode);
-        result.put("date", date);
-        result.put("contentLength", contentLength);
+        result.put("contentLength", body.length());
         result.put("headers", headers);
         result.put("soapTokenValid", valid);
 
         return result;
-    }
-
-    private static String readResponse(HttpURLConnection connection) {
-        try {
-            BufferedReader reader =
-                    new BufferedReader(new InputStreamReader(connection.getInputStream()));
-            StringBuilder response = new StringBuilder();
-            String line;
-            while ((line = reader.readLine()) != null) {
-                response.append(line);
-            }
-            reader.close();
-            return response.toString();
-        } catch (Exception e) {
-            return null;
-        }
     }
 
     private static boolean isSoapResponseBodyValid(String token) {
@@ -137,33 +109,21 @@ public class SOAPRequestAssertion implements Assertion {
         return false;
     }
 
-    private static void sendRequest(HttpURLConnection connection) throws IOException {
-        try (OutputStream os = connection.getOutputStream()) {
-            os.write(SOAP_ENVELOPE.getBytes(StandardCharsets.UTF_8));
-            os.flush();
-        }
-    }
+    private HttpResponse<String> sendRequest() throws Exception {
+        System.out.println(waspUrl);
 
-    private static SSLContext initializeSSLContext() {
-        try {
-            SSLContext sslContext = SSLContext.getInstance("TLS");
-            sslContext.init(null, null, null);
-            return sslContext;
-        } catch (Exception e) {
-            throw new SOAPException("Failed to initialize SSL context", e);
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            HttpRequest request =
+                    HttpRequest.newBuilder()
+                            .uri(URI.create(waspUrl))
+                            .header("SOAPAction", SOAP_ACTION)
+                            .header("Content-Type", CONTENT_TYPE)
+                            .method(
+                                    "POST",
+                                    HttpRequest.BodyPublishers.ofByteArray(
+                                            SOAP_ENVELOPE.getBytes(StandardCharsets.UTF_8)))
+                            .build();
+            return client.send(request, HttpResponse.BodyHandlers.ofString());
         }
-    }
-
-    private static HttpURLConnection setupConnection(String url, SSLContext sslContext)
-            throws IOException {
-        HttpURLConnection connection = (HttpURLConnection) URI.create(url).toURL().openConnection();
-        if (connection instanceof HttpsURLConnection httpsURLConnection) {
-            httpsURLConnection.setSSLSocketFactory(sslContext.getSocketFactory());
-        }
-        connection.setRequestMethod("POST");
-        connection.setDoOutput(true);
-        connection.setRequestProperty("Content-Type", CONTENT_TYPE);
-        connection.setRequestProperty("SOAPAction", SOAP_ACTION);
-        return connection;
     }
 }

--- a/lambdas/healthcheck/src/main/java/uk/gov/di/ipv/cri/kbv/healthcheck/handler/assertions/soap/SOAPRequestAssertion.java
+++ b/lambdas/healthcheck/src/main/java/uk/gov/di/ipv/cri/kbv/healthcheck/handler/assertions/soap/SOAPRequestAssertion.java
@@ -5,6 +5,7 @@ import uk.gov.di.ipv.cri.kbv.healthcheck.handler.assertions.Assertion;
 import uk.gov.di.ipv.cri.kbv.healthcheck.handler.assertions.FailReport;
 import uk.gov.di.ipv.cri.kbv.healthcheck.handler.assertions.Report;
 
+import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -68,8 +69,8 @@ public class SOAPRequestAssertion implements Assertion {
 
             report.setPassed(success.get());
 
-        } catch (Exception e) {
-            return new FailReport(e);
+        } catch (Exception e) { // NOSONAR
+            return new FailReport(e); // NOSONAR
         }
 
         return report;
@@ -109,9 +110,7 @@ public class SOAPRequestAssertion implements Assertion {
         return false;
     }
 
-    private HttpResponse<String> sendRequest() throws Exception {
-        System.out.println(waspUrl);
-
+    private HttpResponse<String> sendRequest() throws IOException, InterruptedException {
         try (HttpClient client = HttpClient.newHttpClient()) {
             HttpRequest request =
                     HttpRequest.newBuilder()

--- a/lambdas/healthcheck/src/test/java/uk/gov/di/ipv/cri/kbv/healthcheck/handler/assertions/soap/CustomTrustManagerTest.java
+++ b/lambdas/healthcheck/src/test/java/uk/gov/di/ipv/cri/kbv/healthcheck/handler/assertions/soap/CustomTrustManagerTest.java
@@ -1,0 +1,72 @@
+package uk.gov.di.ipv.cri.kbv.healthcheck.handler.assertions.soap;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.net.ssl.X509TrustManager;
+import javax.security.auth.x500.X500Principal;
+
+import java.security.cert.X509Certificate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class CustomTrustManagerTest {
+
+    private X509TrustManager mockDefaultTrustManager;
+    private CustomTrustManager customTrustManager;
+
+    @BeforeEach
+    void setUp() {
+        mockDefaultTrustManager = mock(X509TrustManager.class);
+        customTrustManager = new CustomTrustManager(mockDefaultTrustManager);
+    }
+
+    @Test
+    void shouldCacheClientCertificatesOnCheckClientTrusted() throws Exception {
+        X509Certificate cert1 = mock(X509Certificate.class);
+        X509Certificate[] chain = new X509Certificate[] {cert1};
+
+        when(cert1.getSubjectX500Principal()).thenReturn(new X500Principal("CN=ClientSubject"));
+        when(cert1.getIssuerX500Principal()).thenReturn(new X500Principal("CN=ClientIssuer"));
+
+        customTrustManager.checkClientTrusted(chain, "RSA");
+
+        verify(mockDefaultTrustManager).checkClientTrusted(chain, "RSA");
+
+        List<Certificate> cachedClientCerts = customTrustManager.getClientCertificates();
+        assertEquals(1, cachedClientCerts.size());
+        assertEquals("CN=ClientSubject", cachedClientCerts.get(0).subject());
+        assertEquals("CN=ClientIssuer", cachedClientCerts.get(0).issuer());
+    }
+
+    @Test
+    void shouldCacheServerCertificatesOnCheckServerTrusted() throws Exception {
+        X509Certificate cert1 = mock(X509Certificate.class);
+        X509Certificate[] chain = new X509Certificate[] {cert1};
+
+        when(cert1.getSubjectX500Principal()).thenReturn(new X500Principal("CN=ServerSubject"));
+        when(cert1.getIssuerX500Principal()).thenReturn(new X500Principal("CN=ServerIssuer"));
+
+        customTrustManager.checkServerTrusted(chain, "RSA");
+
+        verify(mockDefaultTrustManager).checkServerTrusted(chain, "RSA");
+
+        List<Certificate> cachedServerCerts = customTrustManager.getServerCertificates();
+        assertEquals(1, cachedServerCerts.size());
+        assertEquals("CN=ServerSubject", cachedServerCerts.get(0).subject());
+        assertEquals("CN=ServerIssuer", cachedServerCerts.get(0).issuer());
+    }
+
+    @Test
+    void shouldReturnAcceptedIssuersFromDefaultTrustManager() {
+        X509Certificate[] issuers = new X509Certificate[0];
+        when(mockDefaultTrustManager.getAcceptedIssuers()).thenReturn(issuers);
+
+        X509Certificate[] result = customTrustManager.getAcceptedIssuers();
+        assertSame(issuers, result);
+    }
+}


### PR DESCRIPTION
## Proposed changes

### What changed
Fixed SOAP request not working in staging & prod. Re-added trust manager reporting as this was previously removed to debug (incase that was the reason SOAP request was not working). 

### Why did it change
SOAP request was not working in staging/prod

### Issue tracking
- [OJ-3168](https://govukverify.atlassian.net/browse/OJ-3168)


[OJ-3168]: https://govukverify.atlassian.net/browse/OJ-3168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ