### PR TITLE
OJ-3168: update SSL test to use correct host

### DIFF
--- a/lambdas/healthcheck/src/main/java/uk/gov/di/ipv/cri/kbv/healthcheck/handler/HealthCheckHandler.java
+++ b/lambdas/healthcheck/src/main/java/uk/gov/di/ipv/cri/kbv/healthcheck/handler/HealthCheckHandler.java
@@ -84,7 +84,8 @@ public class HealthCheckHandler
 
         List<Assertion> tests =
                 List.of(
-                        new SSLHandshakeAssertion(Configuration.WASP_HOST, Configuration.WASP_PORT),
+                        new SSLHandshakeAssertion(
+                                experianSecrets.getWaspUrl(), Configuration.WASP_PORT),
                         new KeyToolAssertion(keystoreSecret, keystorePassword),
                         new KeyStoreAssertion(keystoreSecret, keystorePassword),
                         new SOAPRequestAssertion(

--- a/lambdas/healthcheck/src/main/java/uk/gov/di/ipv/cri/kbv/healthcheck/handler/assertions/ssl/SSLHandshakeAssertion.java
+++ b/lambdas/healthcheck/src/main/java/uk/gov/di/ipv/cri/kbv/healthcheck/handler/assertions/ssl/SSLHandshakeAssertion.java
@@ -26,7 +26,8 @@ public class SSLHandshakeAssertion implements Assertion {
     private final int port;
 
     public SSLHandshakeAssertion(String host, int port) {
-        this.host = host;
+        String domain = host.replace("https://", "");
+        this.host = domain.substring(0, domain.indexOf("/"));
         this.port = port;
     }
 

--- a/lambdas/healthcheck/src/main/java/uk/gov/di/ipv/cri/kbv/healthcheck/handler/config/Configuration.java
+++ b/lambdas/healthcheck/src/main/java/uk/gov/di/ipv/cri/kbv/healthcheck/handler/config/Configuration.java
@@ -1,7 +1,6 @@
 package uk.gov.di.ipv.cri.kbv.healthcheck.handler.config;
 
 public final class Configuration {
-    public static final String WASP_HOST = "secure.wasp.uk.experian.com";
     public static final int WASP_PORT = 443;
 
     public static final String WASP_URL_SECRET = System.getenv("WaspURLSecret");


### PR DESCRIPTION
## Proposed changes

### What changed
SSL test was hard coded to use Experian prod. This has been updated to use the provided url in secrets manager. 

### Why did it change
So that we can test UAT.

### Issue tracking
- [OJ-3168](https://govukverify.atlassian.net/browse/OJ-3168)


[OJ-3168]: https://govukverify.atlassian.net/browse/OJ-3168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ