### PR TITLE
OJ-3243: Rename VerifyJWT alarms

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: detect-secrets
         args: ["--baseline", ".secrets.baseline"]
   - repo: https://github.com/aws-cloudformation/cfn-lint
-    rev: v0.83.5
+    rev: v1.36.1
     hooks:
       - id: cfn-lint
         files: .template\.ya?ml$

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -973,63 +973,189 @@ Resources:
             Period: 300
             Stat: Sum
 
-  SessionLambdaFailedToVerifyJWTAlarm:
+  SessionLambdaFailedToVerifyJWTWarningAlarm:
     Type: AWS::CloudWatch::Alarm
     Condition: DeployAlarms
     Properties:
+      AlarmName: !Sub ${AWS::StackName}-${Environment}-SessionLambdaFailedToVerifyJWTWarningAlarm
       AlarmDescription: !Sub
-        - "Errors verifying JWTs in Experian KBV that have been been received by the session lambda. Runbook: ${SupportManualURL}"
+        - "Errors verifying JWTs in Experian KBV (jwt_verification_failed) rate exceeds 10% of Session Lambda invocations consecutively for 3, 5 minute periods. Runbook: ${SupportManualURL}"
         - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
-      ActionsEnabled: true
-      AlarmActions:
-        # - !ImportValue core-infrastructure-AlarmTopic # OJ-3243: turning off pager duty notifications while we are seeing false positives
-        - !ImportValue platform-alarm-critical-alert-topic
-      OKActions:
-        # - !ImportValue core-infrastructure-AlarmTopic # OJ-3243: turning off pager duty notifications while we are seeing false positives
-        - !ImportValue platform-alarm-critical-alert-topic
-      InsufficientDataActions: []
-      MetricName: jwt_verification_failed
-      AlarmName: !Sub ${AWS::StackName}-${Environment}-SessionLambdaFailedToVerifyJWTAlarm
-      Namespace: !Sub "${CriIdentifier}"
-      Statistic: Sum
-      Dimensions:
-        - Name: service
-          Value: !Sub "${CriIdentifier}-sessionTS"
-      Period: 300
+      ComparisonOperator: GreaterThanThreshold
+      Threshold: 10
       DatapointsToAlarm: 3
       EvaluationPeriods: 3
-      Threshold: 1
-      ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      Metrics:
+        - Id: errors
+          Expression: IF(m2 != 0, (m1 / m2) * 100, 0)
+          Label: JWTErrorRate
+          ReturnData: true
+        - Id: m1
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: !Sub "${CriIdentifier}"
+              MetricName: jwt_verification_failed
+              Dimensions:
+                - Name: service
+                  Value: !Sub "${CriIdentifier}-sessionTS"
+            Period: 300
+            Stat: Sum
+        - Id: m2
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/Lambda
+              MetricName: Invocations
+              Dimensions:
+                - Name: FunctionName
+                  Value: !Sub ${CommonStackName}-SessionFunctionTS
+            Period: 300
+            Stat: Sum
 
-  TokenLambdaFailedToVerifyJWTAlarm:
+  SessionLambdaFailedToVerifyJWTCriticalAlarm:
     Type: AWS::CloudWatch::Alarm
     Condition: DeployAlarms
     Properties:
+      AlarmName: !Sub ${AWS::StackName}-${Environment}-SessionLambdaFailedToVerifyJWTCriticalAlarm
       AlarmDescription: !Sub
-        - "Errors verifying JWTs in Experian KBV that have been been received by the token lambda. Runbook: ${SupportManualURL}"
+        - "Errors verifying JWTs in Experian KBV (jwt_verification_failed) rate exceeds 80% of Session Lambda invocations consecutively for 3, 5 minute periods. Runbook: ${SupportManualURL}"
         - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
-      ActionsEnabled: true
-      AlarmActions:
-        # - !ImportValue core-infrastructure-AlarmTopic # OJ-3243: turning off pager duty notifications while we are seeing false positives
-        - !ImportValue platform-alarm-critical-alert-topic
-      OKActions:
-        # - !ImportValue core-infrastructure-AlarmTopic # OJ-3243: turning off pager duty notifications while we are seeing false positives
-        - !ImportValue platform-alarm-critical-alert-topic
-      InsufficientDataActions: []
-      MetricName: jwt_verification_failed
-      AlarmName: !Sub ${AWS::StackName}-${Environment}-TokenLambdaFailedToVerifyJWTAlarm
-      Namespace: !Sub "${CriIdentifier}"
-      Statistic: Sum
-      Dimensions:
-        - Name: service
-          Value: !Sub "${CriIdentifier}-access-token-2"
-      Period: 300
+      ComparisonOperator: GreaterThanThreshold
+      Threshold: 80
       DatapointsToAlarm: 3
       EvaluationPeriods: 3
-      Threshold: 1
-      ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
+      AlarmActions:
+        - !ImportValue core-infrastructure-AlarmTopic
+        - !ImportValue platform-alarm-critical-alert-topic
+      OKActions:
+        - !ImportValue core-infrastructure-AlarmTopic
+        - !ImportValue platform-alarm-critical-alert-topic
+      Metrics:
+        - Id: errors
+          Expression: IF(m2 != 0, (m1 / m2) * 100, 0)
+          Label: JWTErrorRate
+          ReturnData: true
+        - Id: m1
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: !Sub "${CriIdentifier}"
+              MetricName: jwt_verification_failed
+              Dimensions:
+                - Name: service
+                  Value: !Sub "${CriIdentifier}-sessionTS"
+            Period: 300
+            Stat: Sum
+        - Id: m2
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/Lambda
+              MetricName: Invocations
+              Dimensions:
+                - Name: FunctionName
+                  Value: !Sub ${CommonStackName}-SessionFunctionTS
+            Period: 300
+            Stat: Sum
+
+  TokenLambdaFailedToVerifyJWTWarningAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: DeployAlarms
+    Properties:
+      AlarmName: !Sub ${AWS::StackName}-${Environment}-TokenLambdaFailedToVerifyJWTWarningAlarm
+      AlarmDescription: !Sub
+        - "Errors verifying JWTs in Experian KBV (jwt_verification_failed) rate exceeds 10% of Token Lambda invocations consecutively for 3, 5 minute periods. Runbook: ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
+      ComparisonOperator: GreaterThanThreshold
+      Threshold: 10
+      DatapointsToAlarm: 3
+      EvaluationPeriods: 3
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      Metrics:
+        - Id: errors
+          Expression: IF(m2 != 0, (m1 / m2) * 100, 0)
+          Label: JWTErrorRate
+          ReturnData: true
+        - Id: m1
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: !Sub "${CriIdentifier}"
+              MetricName: jwt_verification_failed
+              Dimensions:
+                - Name: service
+                  Value: !Sub "${CriIdentifier}-access-token-2"
+            Period: 300
+            Stat: Sum
+        - Id: m2
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/Lambda
+              MetricName: Invocations
+              Dimensions:
+                - Name: FunctionName
+                  Value: !Sub ${CommonStackName}-AccessTokenFunctionTS
+            Period: 300
+            Stat: Sum
+
+  TokenLambdaFailedToVerifyJWTCriticalAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: DeployAlarms
+    Properties:
+      AlarmName: !Sub ${AWS::StackName}-${Environment}-TokenLambdaFailedToVerifyJWTCriticalAlarm
+      AlarmDescription: !Sub
+        - "Errors verifying JWTs in Experian KBV (jwt_verification_failed) rate exceeds 80% of Token Lambda invocations consecutively for 3, 5 minute periods. Runbook: ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
+      ComparisonOperator: GreaterThanThreshold
+      Threshold: 80
+      DatapointsToAlarm: 3
+      EvaluationPeriods: 3
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !ImportValue core-infrastructure-AlarmTopic
+        - !ImportValue platform-alarm-critical-alert-topic
+      OKActions:
+        - !ImportValue core-infrastructure-AlarmTopic
+        - !ImportValue platform-alarm-critical-alert-topic
+      Metrics:
+        - Id: errors
+          Expression: IF(m2 != 0, (m1 / m2) * 100, 0)
+          Label: JWTErrorRate
+          ReturnData: true
+        - Id: m1
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: !Sub "${CriIdentifier}"
+              MetricName: jwt_verification_failed
+              Dimensions:
+                - Name: service
+                  Value: !Sub "${CriIdentifier}-access-token-2"
+            Period: 300
+            Stat: Sum
+        - Id: m2
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/Lambda
+              MetricName: Invocations
+              Dimensions:
+                - Name: FunctionName
+                  Value: !Sub ${CommonStackName}-AccessTokenFunctionTS
+            Period: 300
+            Stat: Sum
 
   ExperianKBVQuestionFunction5xxCanaryErrors:
     Type: AWS::CloudWatch::Alarm


### PR DESCRIPTION
## Proposed changes

### What changed

Changed the critical alarm to have to be 80% of invocations for 3 periods instead of just 1 error. This should only alarm if it is a much greater issue. 

Added a warning alarm so team can see if this is happening at a much lower level (10%).

Bumped pre-commit cfn-lint version

### Why did it change

..LambdaFailedToVerifyJWTAlarm was firing to frequently for a critical (out of hours support) alarm.

### Issue tracking

- [OJ-3243](https://govukverify.atlassian.net/browse/OJ-3243)

[OJ-3243]: https://govukverify.atlassian.net/browse/OJ-3243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ