### PR TITLE
fix: add permissions to HealthCheckFunction to fetch SSM params

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -289,6 +289,13 @@ Resources:
             Resource: !Sub
               - 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/${Prefix}/experian*'
               - Prefix: !If [ UseSecretPrefix, !Ref SecretPrefix , !Ref AWS::StackName ]
+        - Statement:
+            - Effect: Allow
+              Action:
+                - ssm:GetParametersByPath
+                - ssm:GetParameter
+                - ssm:GetParameters
+              Resource: !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/experian*"
 
   HealthCheckFunctionLogGroup:
     Type: AWS::Logs::LogGroup


### PR DESCRIPTION
## Proposed changes

### What changed
Added permissions to HealthCheckFunction to fetch SSM parameters

### Why did it change
Healthcheck endpoint is giving a 500 because it does not have permissions to read from SSM

### Issue tracking
- [OJ-3265](https://govukverify.atlassian.net/browse/OJ-3265)


[OJ-3265]: https://govukverify.atlassian.net/browse/OJ-3265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ