### PR TITLE
fix: use clientId when looking up wasp url in HealthCheckFunction

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -274,14 +274,14 @@ Resources:
           KeyStoreSecret: experian/keystore
           KeyStorePassword: experian/keystore-password
           WaspURLSecret: experian/iiq-wasp-service
-          WaspURLParameterName:
+          ClientId:
             !If
             - IsProductionEnvironment
-            - !Ref ProdIpvCoreWaspURL
+            - "ipv-core"
             - !If
               - IsStagingOrIntegration
-              - !Ref IpvCoreStubPreProdWaspURL
-              - !Ref IpvCoreStubAwsProdWaspURL
+              - "ipv-core-stub-pre-prod"
+              - "ipv-core-stub-aws-prod"
       Policies:
         - Statement:
             Effect: Allow

--- a/lambdas/healthcheck/src/main/java/uk/gov/di/ipv/cri/kbv/healthcheck/handler/config/Configuration.java
+++ b/lambdas/healthcheck/src/main/java/uk/gov/di/ipv/cri/kbv/healthcheck/handler/config/Configuration.java
@@ -3,7 +3,7 @@ package uk.gov.di.ipv.cri.kbv.healthcheck.handler.config;
 public final class Configuration {
     public static final int WASP_PORT = 443;
 
-    public static final String WASP_URL_PARAMETER = System.getenv("WaspURLParameterName");
+    public static final String CLIENT_ID = System.getenv("ClientId");
     public static final String KEYSTORE_SECRET = System.getenv("KeyStoreSecret");
     public static final String KEYSTORE_PASSWORD = System.getenv("KeyStorePassword");
 

--- a/lambdas/healthcheck/src/main/java/uk/gov/di/ipv/cri/kbv/healthcheck/handler/config/ExperianSecrets.java
+++ b/lambdas/healthcheck/src/main/java/uk/gov/di/ipv/cri/kbv/healthcheck/handler/config/ExperianSecrets.java
@@ -20,7 +20,8 @@ public class ExperianSecrets {
     }
 
     public String getWaspUrl() {
-        return configurationService.getParameterValue(Configuration.WASP_URL_PARAMETER);
+        return configurationService.getParameterValue(
+                "experian/iiq-wasp-service/%s".formatted(Configuration.CLIENT_ID));
     }
 
     public String getKeystorePassword() {


### PR DESCRIPTION
## Proposed changes

### What changed
Use the clientId when looking up SSM parameter

### Why did it change
The ConfigurationService looks up parameters using a prefix so the previous logic was failing. 
