### PR TITLE
OJ-3264: Use UAT for ipv-core integration env

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -58,7 +58,11 @@ Conditions:
   IsDevEnvironment: !Or [!Equals [!Ref Environment, dev], !Condition IsLocalDevEnvironment]
   IsStubEnvironment: !Not [!Equals [!Ref Environment, production]]
   IsLocalDevEnvironment: !Equals [!Ref Environment, localdev]
+  IsIntEnvironment: !Equals [!Ref Environment, integration]
   IsProductionEnvironment: !Equals [!Ref Environment, production]
+  IsProdLikeEnvironment: !Or [!Condition IsProductionEnvironment, !Condition IsIntEnvironment]
+  IsNonProdLikeEnvironment: !Not
+    - !Condition IsProdLikeEnvironment
   IsStagingOrIntegration: !Or
     - !Equals [ !Ref Environment, staging ]
     - !Equals [ !Ref Environment, integration ]
@@ -1808,12 +1812,20 @@ Resources:
       Value: !FindInMap [ WaspServiceUrls, !Ref Environment, uat ]
 
   IpvCoreWaspURL:
-    Condition: IsStubEnvironment
+    Condition: IsNonProdLikeEnvironment
     Type: AWS::SSM::Parameter
     Properties:
       Name: !Sub "/${AWS::StackName}/experian/iiq-wasp-service/ipv-core"
       Type: String
       Value: !FindInMap [ WaspServiceUrls, !Ref Environment, stub ]
+
+  IntIpvCoreWaspURL:
+    Condition: IsIntEnvironment
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${AWS::StackName}/experian/iiq-wasp-service/ipv-core"
+      Type: String
+      Value: !FindInMap [ WaspServiceUrls, !Ref Environment, uat ]
 
   IpvCore3rdPartyStubsWaspURL:
     Condition: IsStubEnvironment
@@ -1889,12 +1901,20 @@ Resources:
       Value: !FindInMap [ IIQWebServiceUrls, !Ref Environment, uat ]
 
   IpvCoreIIQWebServiceURL:
-    Condition: IsStubEnvironment
+    Condition: IsNonProdLikeEnvironment
     Type: AWS::SSM::Parameter
     Properties:
       Name: !Sub "/${AWS::StackName}/experian/iiq-webservice/ipv-core"
       Type: String
       Value: !FindInMap [ IIQWebServiceUrls, !Ref Environment, stub ]
+
+  IntIpvCoreIIQWebServiceURL:
+    Condition: IsIntEnvironment
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${AWS::StackName}/experian/iiq-webservice/ipv-core"
+      Type: String
+      Value: !FindInMap [ IIQWebServiceUrls, !Ref Environment, uat ]
 
   IpvCore3rdPartyStubsIIQWebServiceURL:
     Condition: IsStubEnvironment


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Use UAT for ipv-core integration env

### Why did it change

So that e2e testing in int uses real third party

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-3264](https://govukverify.atlassian.net/browse/OJ-3264)
