### PR TITLE
OJ-3330

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,8 @@ pact-provider = "4.5.11"
 webcompere = "2.1.6"
 otel = "1.46.0"
 otel-alpha = "2.12.0-alpha"
+apache-cfx = "4.1.3"
+jakata-xml = "4.0.2"
 
 # Plugins
 spotless = "6.25.+"
@@ -41,11 +43,17 @@ jackson-jdk8 = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jdk8"
 javax-annotation = { module = "javax.annotation:javax.annotation-api", version = "1.3.2" }
 javax-validation = { module = "javax.validation:validation-api", version = "2.0.1.Final" }
 
+# Jakarta EE (for CXF 4.x)
+jakarta-xml-ws = { module = "jakarta.xml.ws:jakarta.xml.ws-api", version.ref = "jakata-xml" }
+jakarta-xml-bind = { module = "jakarta.xml.bind:jakarta.xml.bind-api", version.ref = "jakata-xml" }
+jakarta-activation = { module = "jakarta.activation:jakarta.activation-api", version = "2.1.3" }
+jakarta-annotation = { module = "jakarta.annotation:jakarta.annotation-api", version = "3.0.0" }
+
 # SOAP / CXF
-saaj = { module = "com.sun.xml.messaging.saaj:saaj-impl", version = "1.5.3" }
-cxf-jaxws = { module = "org.apache.cxf:cxf-rt-frontend-jaxws", version = "3.4.5" }
-cxf-http = { module = "org.apache.cxf:cxf-rt-transports-http", version = "3.4.5" }
-httpasyncclient = { module = "org.apache.httpcomponents:httpasyncclient", version = "4.1.4" }
+saaj = { module = "com.sun.xml.messaging.saaj:saaj-impl", version = "3.0.4" }
+cxf-jaxws = { module = "org.apache.cxf:cxf-rt-frontend-jaxws", version.ref = "apache-cfx" }
+cxf-http = { module = "org.apache.cxf:cxf-rt-transports-http", version.ref = "apache-cfx" }
+httpasyncclient = { module = "org.apache.httpcomponents:httpasyncclient", version = "4.1.5" }
 
 # Powertools
 powertools-logging = { module = "software.amazon.lambda:powertools-logging", version.ref = "powertools" }

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -18,6 +18,10 @@ dependencies {
 	implementation(libs.powertools.tracing)
 	implementation(libs.javax.annotation)
 	implementation(libs.javax.validation)
+	implementation(libs.jakarta.xml.ws)
+	implementation(libs.jakarta.xml.bind)
+	implementation(libs.jakarta.activation)
+	implementation(libs.jakarta.annotation)
 	implementation(libs.saaj)
 	implementation(libs.cxf.jaxws)
 	implementation(libs.cxf.http)
@@ -45,7 +49,7 @@ sourceSets {
 }
 
 wsdl2java {
-	useJakarta = false
+	useJakarta = true
 	includes = [
 		'wsdl/iiq-wasp-token.wsdl',
 		'wsdl/iiq-service.wsdl'

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/security/HeaderHandler.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/security/HeaderHandler.java
@@ -1,19 +1,19 @@
 package uk.gov.di.ipv.cri.kbv.api.security;
 
+import jakarta.xml.soap.Name;
+import jakarta.xml.soap.SOAPElement;
+import jakarta.xml.soap.SOAPEnvelope;
+import jakarta.xml.soap.SOAPException;
+import jakarta.xml.soap.SOAPHeader;
+import jakarta.xml.soap.SOAPHeaderElement;
+import jakarta.xml.soap.SOAPMessage;
+import jakarta.xml.ws.handler.MessageContext;
+import jakarta.xml.ws.handler.soap.SOAPHandler;
+import jakarta.xml.ws.handler.soap.SOAPMessageContext;
 import uk.gov.di.ipv.cri.kbv.api.exception.HeaderHandlerException;
 import uk.gov.di.ipv.cri.kbv.api.exception.InvalidSoapTokenException;
 
 import javax.xml.namespace.QName;
-import javax.xml.soap.Name;
-import javax.xml.soap.SOAPElement;
-import javax.xml.soap.SOAPEnvelope;
-import javax.xml.soap.SOAPException;
-import javax.xml.soap.SOAPHeader;
-import javax.xml.soap.SOAPHeaderElement;
-import javax.xml.soap.SOAPMessage;
-import javax.xml.ws.handler.MessageContext;
-import javax.xml.ws.handler.soap.SOAPHandler;
-import javax.xml.ws.handler.soap.SOAPMessageContext;
 
 import java.util.Collections;
 import java.util.Objects;

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/security/HeaderHandlerResolver.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/security/HeaderHandlerResolver.java
@@ -1,8 +1,8 @@
 package uk.gov.di.ipv.cri.kbv.api.security;
 
-import javax.xml.ws.handler.Handler;
-import javax.xml.ws.handler.HandlerResolver;
-import javax.xml.ws.handler.PortInfo;
+import jakarta.xml.ws.handler.Handler;
+import jakarta.xml.ws.handler.HandlerResolver;
+import jakarta.xml.ws.handler.PortInfo;
 
 import java.util.Collections;
 import java.util.List;

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/security/KBVClientFactory.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/security/KBVClientFactory.java
@@ -2,14 +2,13 @@ package uk.gov.di.ipv.cri.kbv.api.security;
 
 import com.experian.uk.schema.experian.identityiq.services.webservice.IdentityIQWebService;
 import com.experian.uk.schema.experian.identityiq.services.webservice.IdentityIQWebServiceSoap;
+import jakarta.xml.ws.BindingProvider;
+import jakarta.xml.ws.WebServiceException;
+import jakarta.xml.ws.soap.SOAPFaultException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
 import uk.gov.di.ipv.cri.kbv.api.exception.InvalidSoapTokenException;
-
-import javax.xml.ws.BindingProvider;
-import javax.xml.ws.WebServiceException;
-import javax.xml.ws.soap.SOAPFaultException;
 
 public class KBVClientFactory {
     private static final Logger LOGGER = LoggerFactory.getLogger(KBVClientFactory.class);

--- a/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/security/SoapToken.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/kbv/api/security/SoapToken.java
@@ -3,16 +3,15 @@ package uk.gov.di.ipv.cri.kbv.api.security;
 import com.experian.uk.wasp.TokenService;
 import com.experian.uk.wasp.TokenServiceSoap;
 import io.opentelemetry.api.trace.Span;
+import jakarta.xml.ws.BindingProvider;
+import jakarta.xml.ws.WebServiceException;
+import jakarta.xml.ws.soap.SOAPFaultException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
 import uk.gov.di.ipv.cri.kbv.api.exception.InvalidSoapTokenException;
 import uk.gov.di.ipv.cri.kbv.api.service.MetricsService;
 import uk.gov.di.ipv.cri.kbv.api.util.OpenTelemetryUtil;
-
-import javax.xml.ws.BindingProvider;
-import javax.xml.ws.WebServiceException;
-import javax.xml.ws.soap.SOAPFaultException;
 
 import java.util.Objects;
 

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/gateway/KBVGatewayTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/gateway/KBVGatewayTest.java
@@ -5,6 +5,17 @@ import com.experian.uk.schema.experian.identityiq.services.webservice.RTQRequest
 import com.experian.uk.schema.experian.identityiq.services.webservice.RTQResponse2;
 import com.experian.uk.schema.experian.identityiq.services.webservice.SAARequest;
 import com.experian.uk.schema.experian.identityiq.services.webservice.SAAResponse2;
+import jakarta.xml.soap.Name;
+import jakarta.xml.soap.SOAPElement;
+import jakarta.xml.soap.SOAPEnvelope;
+import jakarta.xml.soap.SOAPException;
+import jakarta.xml.soap.SOAPHeader;
+import jakarta.xml.soap.SOAPHeaderElement;
+import jakarta.xml.soap.SOAPMessage;
+import jakarta.xml.soap.SOAPPart;
+import jakarta.xml.ws.BindingProvider;
+import jakarta.xml.ws.handler.MessageContext;
+import jakarta.xml.ws.handler.soap.SOAPMessageContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -21,18 +32,6 @@ import uk.gov.di.ipv.cri.kbv.api.security.HeaderHandler;
 import uk.gov.di.ipv.cri.kbv.api.security.SoapToken;
 import uk.gov.di.ipv.cri.kbv.api.security.SoapTokenRetriever;
 import uk.gov.di.ipv.cri.kbv.api.service.MetricsService;
-
-import javax.xml.soap.Name;
-import javax.xml.soap.SOAPElement;
-import javax.xml.soap.SOAPEnvelope;
-import javax.xml.soap.SOAPException;
-import javax.xml.soap.SOAPHeader;
-import javax.xml.soap.SOAPHeaderElement;
-import javax.xml.soap.SOAPMessage;
-import javax.xml.soap.SOAPPart;
-import javax.xml.ws.BindingProvider;
-import javax.xml.ws.handler.MessageContext;
-import javax.xml.ws.handler.soap.SOAPMessageContext;
 
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/security/HeaderHandlerTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/security/HeaderHandlerTest.java
@@ -1,5 +1,15 @@
 package uk.gov.di.ipv.cri.kbv.api.security;
 
+import jakarta.xml.soap.Name;
+import jakarta.xml.soap.SOAPElement;
+import jakarta.xml.soap.SOAPEnvelope;
+import jakarta.xml.soap.SOAPException;
+import jakarta.xml.soap.SOAPHeader;
+import jakarta.xml.soap.SOAPHeaderElement;
+import jakarta.xml.soap.SOAPMessage;
+import jakarta.xml.soap.SOAPPart;
+import jakarta.xml.ws.handler.MessageContext;
+import jakarta.xml.ws.handler.soap.SOAPMessageContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -9,17 +19,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.cri.kbv.api.exception.HeaderHandlerException;
 import uk.gov.di.ipv.cri.kbv.api.exception.InvalidSoapTokenException;
-
-import javax.xml.soap.Name;
-import javax.xml.soap.SOAPElement;
-import javax.xml.soap.SOAPEnvelope;
-import javax.xml.soap.SOAPException;
-import javax.xml.soap.SOAPHeader;
-import javax.xml.soap.SOAPHeaderElement;
-import javax.xml.soap.SOAPMessage;
-import javax.xml.soap.SOAPPart;
-import javax.xml.ws.handler.MessageContext;
-import javax.xml.ws.handler.soap.SOAPMessageContext;
 
 import java.time.Instant;
 import java.util.Collections;

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/security/KBVClientFactoryTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/security/KBVClientFactoryTest.java
@@ -2,6 +2,9 @@ package uk.gov.di.ipv.cri.kbv.api.security;
 
 import com.experian.uk.schema.experian.identityiq.services.webservice.IdentityIQWebService;
 import com.experian.uk.schema.experian.identityiq.services.webservice.IdentityIQWebServiceSoap;
+import jakarta.xml.ws.BindingProvider;
+import jakarta.xml.ws.WebServiceException;
+import jakarta.xml.ws.soap.SOAPFaultException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -9,10 +12,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
 import uk.gov.di.ipv.cri.kbv.api.exception.InvalidSoapTokenException;
-
-import javax.xml.ws.BindingProvider;
-import javax.xml.ws.WebServiceException;
-import javax.xml.ws.soap.SOAPFaultException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/security/SoapTokenTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/kbv/api/security/SoapTokenTest.java
@@ -2,6 +2,9 @@ package uk.gov.di.ipv.cri.kbv.api.security;
 
 import com.experian.uk.wasp.TokenService;
 import com.experian.uk.wasp.TokenServiceSoap;
+import jakarta.xml.ws.BindingProvider;
+import jakarta.xml.ws.WebServiceException;
+import jakarta.xml.ws.soap.SOAPFaultException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -10,10 +13,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
 import uk.gov.di.ipv.cri.kbv.api.exception.InvalidSoapTokenException;
 import uk.gov.di.ipv.cri.kbv.api.service.MetricsService;
-
-import javax.xml.ws.BindingProvider;
-import javax.xml.ws.WebServiceException;
-import javax.xml.ws.soap.SOAPFaultException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;


### PR DESCRIPTION
## Proposed changes

Related to https://github.com/govuk-one-login/ipv-cri-kbv-api/pull/517

### What changed

To upgrade to higher version of CXF, the change required upgrading the Jakarta XML 

### Why did it change

AWS Inspector has reported that some of our libraries/transitive dependencies have CVEs

<img width="1257" height="621" alt="image" src="https://github.com/user-attachments/assets/3293a8fc-c221-4178-91f7-48c5008d440b" />

<img width="1095" height="886" alt="image" src="https://github.com/user-attachments/assets/a1b3d5f6-1f92-41ab-bec8-5b00007c8a1a" />

<img width="1280" height="967" alt="image" src="https://github.com/user-attachments/assets/058699e6-65e2-4284-9ef2-814c5db84745" />

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-3330](https://govukverify.atlassian.net/browse/OJ-3330)

## Checklists

depends on https://github.com/govuk-one-login/ipv-cri-kbv-api/pull/534

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[OJ-3330]: https://govukverify.atlassian.net/browse/OJ-3330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ