### PR TITLE
Fix: pin gradle version

### DIFF
--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -32,7 +32,8 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
-
+        with:
+          gradle-version: '8.13'
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/package-for-build.yml
+++ b/.github/workflows/package-for-build.yml
@@ -35,7 +35,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
-
+        with:
+          gradle-version: '8.13'
       - name: Assume temporary AWS role
         uses: aws-actions/configure-aws-credentials@v2
         with:

--- a/.github/workflows/package-for-dev.yml
+++ b/.github/workflows/package-for-dev.yml
@@ -34,7 +34,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
-
+        with:
+          gradle-version: '8.13'
       - name: Assume temporary AWS role
         uses: aws-actions/configure-aws-credentials@v2
         with:

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -39,7 +39,8 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
-
+        with:
+          gradle-version: '8.13'
       - name: Assume AWS Role
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/run-pact-tests.yml
+++ b/.github/workflows/run-pact-tests.yml
@@ -27,7 +27,8 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
-
+        with:
+          gradle-version: '8.13'
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -29,7 +29,8 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
-
+        with:
+          gradle-version: '8.13'
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/scan-repo.yml
+++ b/.github/workflows/scan-repo.yml
@@ -33,7 +33,8 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
-
+        with:
+          gradle-version: '8.13'
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
## Proposed changes

git-action underline gradle changed

### What changed

`post-compile-weaving` broke due to that `git-action` has upgrading the gradle version. 

Therefore pinning git-action to **version 8.13**

see: https://github.com/govuk-one-login/ipv-cri-kbv-api/blob/main/.sdkmanrc#L4

This is the error that would be seen **without** this change https://github.com/govuk-one-login/ipv-cri-kbv-api/actions/runs/16882903369/job/47823067700?pr=531