### PR TITLE
feat: add latencyInMs to SOAP and SSL tests

### DIFF
--- a/lambdas/healthcheck/src/main/java/uk/gov/di/ipv/cri/kbv/healthcheck/util/LatencyTracker.java
+++ b/lambdas/healthcheck/src/main/java/uk/gov/di/ipv/cri/kbv/healthcheck/util/LatencyTracker.java
@@ -1,0 +1,30 @@
+package uk.gov.di.ipv.cri.kbv.healthcheck.util;
+
+public class LatencyTracker {
+    private long startTime;
+    private long endTime;
+
+    public LatencyTracker() {
+        reset();
+    }
+
+    public void start() {
+        this.startTime = System.nanoTime();
+    }
+
+    public void stop() {
+        this.endTime = System.nanoTime();
+    }
+
+    public void reset() {
+        this.startTime = 0;
+        this.endTime = 0;
+    }
+
+    public long getElapsedTimeInMs() {
+        if (endTime == 0 || endTime < startTime) {
+            throw new IllegalStateException("stop() must be called after start()");
+        }
+        return (endTime - startTime) / 1_000_000;
+    }
+}

--- a/lambdas/healthcheck/src/test/java/uk/gov/di/ipv/cri/kbv/healthcheck/util/LatencyTrackerTest.java
+++ b/lambdas/healthcheck/src/test/java/uk/gov/di/ipv/cri/kbv/healthcheck/util/LatencyTrackerTest.java
@@ -1,0 +1,45 @@
+package uk.gov.di.ipv.cri.kbv.healthcheck.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LatencyTrackerTest {
+
+    @Test
+    void testElapsedTimeIsMeasuredCorrectly() throws InterruptedException {
+        LatencyTracker tracker = new LatencyTracker();
+        tracker.start();
+
+        Thread.sleep(100); // NOSONAR
+
+        tracker.stop();
+        long elapsed = tracker.getElapsedTimeInMs();
+
+        assertTrue(
+                elapsed >= 100 && elapsed < 200,
+                "Elapsed time should be approximately 100ms, but was: " + elapsed);
+    }
+
+    @Test
+    void testGetElapsedTimeThrowsExceptionIfStopNotCalled() {
+        LatencyTracker tracker = new LatencyTracker();
+        tracker.start();
+
+        IllegalStateException exception =
+                assertThrows(IllegalStateException.class, tracker::getElapsedTimeInMs);
+        assertEquals("stop() must be called after start()", exception.getMessage());
+    }
+
+    @Test
+    void testResetClearsTimes() {
+        LatencyTracker tracker = new LatencyTracker();
+        tracker.start();
+        tracker.stop();
+        tracker.reset();
+
+        assertThrows(IllegalStateException.class, tracker::getElapsedTimeInMs);
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Added latency to SSL handshake and SOAP request tests.

### Why did it change
So that we can see the performance of Experian.

### Issue tracking
- [OJ-3390](https://govukverify.atlassian.net/browse/OJ-3390)


[OJ-3390]: https://govukverify.atlassian.net/browse/OJ-3390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ