### PR TITLE
OJ-3294 - Certificate expiry SFN infra fixes

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -2147,3 +2147,9 @@ Outputs:
     Value: !Sub "${PublicKBVApi}"
     Export:
       Name: !Sub ${AWS::StackName}-KBVApiGatewayId
+
+  CertificateExpiryStateMachineArn:
+    Description: "ARN of the certificate expiry checker state machine. Used when invoking it for integration testing."
+    Value: !Ref CertificateExpiryStateMachine
+    Export:
+      Name: !Sub ${AWS::StackName}-CertificateExpiryStateMachineArn

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -1035,8 +1035,7 @@ Resources:
       Type: EXPRESS
       DefinitionUri: ../../step-functions/certificate-expiry.asl.json
       DefinitionSubstitutions:
-        PublicApiGatewayId: !Ref PublicKBVApi
-        Environment: !Ref Environment
+        HealthCheckFunctionName: !Ref HealthCheckFunction
       Logging:
         Destinations:
           - CloudWatchLogsLogGroup:
@@ -1054,8 +1053,8 @@ Resources:
             Resource: "*"
         - Statement:
             Effect: Allow
-            Action: apigateway:GET
-            Resource: !Sub "arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicKBVApi}/*/GET/"
+            Action: lambda:InvokeFunction
+            Resource: !GetAtt HealthCheckFunction.Arn
       PermissionsBoundary: !If
         - UsePermissionsBoundary
         - !Ref PermissionsBoundary

--- a/step-functions/certificate-expiry.asl.json
+++ b/step-functions/certificate-expiry.asl.json
@@ -1,24 +1,31 @@
 {
   "Comment": "A state machine that calls the healthcheck endpoint on a schedule and triggers an alarm via CloudWatch Metrics if one or more is set to expire soon.",
-  "StartAt": "GET /healthcheck/thirdparty/info",
+  "StartAt": "Invoke healthcheck Lambda",
   "States": {
-    "GET /healthcheck/thirdparty/info": {
+    "Invoke healthcheck Lambda": {
       "Type": "Task",
-      "Resource": "arn:aws:states:::apigateway:invoke",
-      "Arguments": {
-        "ApiEndpoint": "${PublicApiGatewayId}.execute-api.eu-west-2.amazonaws.com",
-        "Method": "GET",
-        "AllowNullValues": true,
-        "Headers": {},
-        "Stage": "${Environment}",
-        "Path": "/healthcheck/thirdparty/info",
-        "QueryParameters": {},
-        "RequestBody": {},
-        "AuthType": "IAM_ROLE"
-      },
+      "Resource": "arn:aws:states:::lambda:invoke",
       "Output": {
-        "KeyStoreEntries": "{% $exists($states.input.KeyStoreEntriesOverride) ? $states.input.KeyStoreEntriesOverride : $states.result.ResponseBody.KeyStoreAssertion.attributes.keystore.entries %}"
+        "KeyStoreEntries": "{% $exists($states.input.KeyStoreEntriesOverride) ? $states.input.KeyStoreEntriesOverride : $parse($states.result.Payload.body).KeyStoreAssertion.attributes.keystore.entries %}"
       },
+      "Arguments": {
+        "FunctionName": "${HealthCheckFunctionName}",
+        "Payload": "{\"path\":\"/info\"}"
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "IntervalSeconds": 1,
+          "MaxAttempts": 3,
+          "BackoffRate": 2,
+          "JitterStrategy": "FULL"
+        }
+      ],
       "Next": "Flatten mTLS certificate arrays"
     },
     "Flatten mTLS certificate arrays": {


### PR DESCRIPTION
## Proposed changes

### What changed

- Made the step function invoke the Lambda directly rather than hitting the API Gateway
  - The API Gateway has restrictive permissions to ensure that it can be only called on the GDS VPN - this rule is not enabled in localdev stacks so this issue was missed on the original release.
- Added the step function ARN to the outputs of the CloudFormation stack
  - This enables us to invoke the step function during integration testing

### Issue tracking
- OJ-3294

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks