### PR TITLE
OJ-3393: Update Dynatrace Lambda layer to 1.313

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -150,7 +150,7 @@ Globals:
         OTEL_JAVA_GLOBAL_AUTOCONFIGURE_ENABLED: "true"
     Layers:
       # SEE https://github.com/govuk-one-login/observability-infrastructure/tree/main/lambdalayer
-      - arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_311_51_20250331-143707_with_collector_java:1
+      - arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_313_36_20250507-184408_with_collector_java:1
   Api:
     TracingEnabled: true
     OpenApiVersion: 3.0.1


### PR DESCRIPTION
## Proposed changes

Update Dynatrace Arn to version 1_313

### Why did it change

There is a more update version of dynatrace, [previous PR ](https://github.com/govuk-one-login/ipv-cri-kbv-api/pull/542) should now enable upgrading to it 

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-3393](https://govukverify.atlassian.net/browse/OJ-3393)

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[OJ-3393]: https://govukverify.atlassian.net/browse/OJ-3393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ