### PR TITLE
OJ-3432: Update AWS deps and include CRT client

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,14 +26,16 @@ subprojects {
 		}
 	}
 
-	// The dynamodb enhanced package loads the apache-client as well as the spi-client, so
-	// we need to add the apache-client to the dependencies exclusion to not get a mismatch
+	// https://aws.amazon.com/blogs/developer/tuning-the-aws-java-sdk-2-x-to-reduce-startup-time/
 	configurations.configureEach {
 		exclude group:"software.amazon.awssdk", module: "apache-client"
+		exclude group:"software.amazon.awssdk", module: "netty-nio-client"
+		exclude group:"software.amazon.awssdk", module: "url-connection-client"
 	}
 
 	dependencies {
 		implementation(platform(libs.aws.sdk.bom))
+		implementation(libs.aws.crt.client)
 		runtimeOnly(libs.log4j.lambda)
 
 		implementation(libs.aspectjrt)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-aws-sdk = "2.20.162"
+aws-sdk = "2.33.9"
 aws-lambda-events = "3.14.0"
 jackson = "2.15.4"
 nimbus-oauth = "11.2"
@@ -29,6 +29,7 @@ aws-dynamodb-enhanced = { module = "software.amazon.awssdk:dynamodb-enhanced" }
 aws-lambda = { module = "software.amazon.awssdk:lambda" }
 aws-sqs = { module = "software.amazon.awssdk:sqs" }
 aws-kms = { module = "software.amazon.awssdk:kms" }
+aws-crt-client = { module = "software.amazon.awssdk:aws-crt-client"}
 aws-lambda-events = { module = "com.amazonaws:aws-lambda-java-events", version.ref = "aws-lambda-events" }
 
 # Jackson


### PR DESCRIPTION
## Proposed changes

### What changed
Exclude the following clients so it uses CRT:
* netty-nio-client
* url-connection-client

Add the AWS CRT client into build.gradle so that we are using the version compatible with the AWS BOM that is in this CRI. At the moment, we're using an older version which comes from cri-lib.

Bump BOM to 2.33.9 (latest). 

### Issue tracking
- [OJ-3432](https://govukverify.atlassian.net/browse/OJ-3432)


[OJ-3432]: https://govukverify.atlassian.net/browse/OJ-3432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ