### PR TITLE
OJ-3428: Disable additional DT logs in build for perf test

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -226,8 +226,8 @@ Mappings:
       dtLoggingJavaFlags: log-Transformer=true,log-OpenTelemetryUtils=true,log-AsyncClassRetransformer=true,log-ClassValue=true
     build:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
-      dtLoggingDestination: stdout
-      dtLoggingJavaFlags: log-Transformer=true,log-OpenTelemetryUtils=true,log-AsyncClassRetransformer=true,log-ClassValue=true
+      dtLoggingDestination: ""
+      dtLoggingJavaFlags: ""
     staging:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       dtLoggingDestination: ""


### PR DESCRIPTION
## Proposed changes

### What changed

Disable additional DT logs in build for perf test

### Why did it change

A perf test is being ran to test the impact of disabling SnapStart. 

I noticed when I was running the perf tests script myself the additional DT logs caused memory issues with the Lambdas after a while. 

Will revert after the perf test is completed.

### Issue tracking

- [OJ-3428](https://govukverify.atlassian.net/browse/OJ-3428)