### PR TITLE
OJ-3439: fix - upgrade dependencies to the latest version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,13 +1,13 @@
 [versions]
 aws-sdk = "2.33.9"
 aws-lambda-events = "3.14.0"
-jackson = "2.15.4"
-nimbus-oauth = "11.2"
-nimbus-jwt = "9.36"
-junit = "5.10.2"
+jackson = "2.17.2"
+nimbus-oauth = "11.29.1"
+nimbus-jwt = "10.5"
+junit = "5.10.3"
 mockito = "5.2.0"
 powertools = "1.18.0"
-cri-common-lib = "6.5.0"
+cri-common-lib = "6.6.0"
 pact-provider = "4.5.11"
 webcompere = "2.1.6"
 otel = "1.46.0"
@@ -16,7 +16,7 @@ apache-cfx = "4.1.3"
 jakata-xml = "4.0.2"
 
 # Plugins
-spotless = "6.25.+"
+spotless = "8.0.+"
 sonarqube = "4.4.+"
 
 [libraries]


### PR DESCRIPTION
## Proposed changes

### What changed

- Updated to `com.nimbusds:oauth2-oidc-sdk` and `com.nimbusds:nimbus-jose-jwt` to use the latest version based on the dependabot alert [here](https://github.com/govuk-one-login/ipv-cri-kbv-api/security/dependabot/28) 
- Updated the latest version number for `com.diffplug.spotless:spotless-plugin-gradle` for this [alert](https://github.com/govuk-one-login/ipv-cri-kbv-api/security/dependabot/24)

NB: Unable to update `au.com.dius.pact:provider` dependency as the vulnerability is still in the latest release [here](https://mvnrepository.com/artifact/au.com.dius.pact/provider). No latest version for `org.apache.cxf:cxf-rt-frontend-jaxws` dependency [here](https://mvnrepository.com/artifact/org.apache.cxf/cxf-rt-frontend-jaxws).

### Why did it change
To resolve dependabot alerts.

### Issue tracking

- [OJ-3439](https://govukverify.atlassian.net/browse/OJ-3439)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[OJ-3439]: https://govukverify.atlassian.net/browse/OJ-3439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ