### PR TITLE
OJ-3445: Add FMS tags for custom WAF policy

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -64,6 +64,7 @@ Conditions:
   IsStagingOrIntegration: !Or
     - !Equals [!Ref Environment, staging]
     - !Equals [!Ref Environment, integration]
+  IsNotProductionOrIntegration: !Not [!Or [!Equals [!Ref Environment, integration], !Equals [!Ref Environment, production]]]
   IsNotDevEnvironment: !Not [!Condition IsDevEnvironment]
   IsDevLikeEnvironment:
     !Or [!Condition IsLocalDevEnvironment, !Condition IsDevEnvironment]
@@ -365,6 +366,7 @@ Resources:
       Name: !Sub kbv-cri-${AWS::StackName}
       Description: Public KBV CRI API
       StageName: !Ref Environment
+      AlwaysDeploy: true
       AccessLogSetting:
         DestinationArn: !GetAtt PublicKBVApiAccessLogGroup.Arn
       DefinitionBody:
@@ -400,6 +402,9 @@ Resources:
               Principal: "*"
               Action: execute-api:Invoke
               Resource: "execute-api:/*"
+      Tags:
+        FMSRegionalPolicy: !If [IsNotProductionOrIntegration, "false", ""]
+        CustomPolicy: !If [IsNotProductionOrIntegration, "true", ""]
 
   PrivateKBVApi:
     Type: AWS::Serverless::Api
@@ -407,6 +412,7 @@ Resources:
       Name: !Sub kbv-cri-private-${AWS::StackName}
       Description: Private KBV CRI API
       StageName: !Ref Environment
+      AlwaysDeploy: true
       AccessLogSetting:
         DestinationArn: !GetAtt PrivateKBVApiAccessLogGroup.Arn
       DefinitionBody:
@@ -438,6 +444,9 @@ Resources:
                 Condition:
                   StringNotEquals:
                     aws:SourceVpce: !ImportValue cri-vpc-ApiGatewayVpcEndpointId
+      Tags:
+        FMSRegionalPolicy: !If [IsNotProductionOrIntegration, "false", ""]
+        CustomPolicy: !If [IsNotProductionOrIntegration, "true", ""]
 
   PublicKBVApiAccessLogGroup:
     Type: AWS::Logs::LogGroup


### PR DESCRIPTION
## Proposed changes

As part of transitioning FMS WAF rule enforcement from COUNT to BLOCK, Security have set up custom policies for us to apply to our resources in scope. In COUNT mode FMS merely logs the rule violations, in BLOCK mode violating requests are actively blocked. 

The tags to implement this should only apply (conditionally) to resources deployed to dev, build and staging accounts. The tags must not apply to int and prod (there is a follow-up ticket for this:

### What changed

Apply tagging conditional to meet the above requirement

### Why did it change

Part of transitioning FMS WAF rule enforcement

**Tags on ApiGateway**



### Issue tracking

- [OJ-3445](https://govukverify.atlassian.net/browse/OJ-3445)

[OJ-3445]: https://govukverify.atlassian.net/browse/OJ-3445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ