### PR TITLE
OJ-3462: Add param to force localdev lambdas to update every time

### DIFF
--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -65,6 +65,9 @@ jobs:
       stack-name: ${{ steps.deploy.outputs.stack-name }}
       stack-outputs: ${{ steps.deploy.outputs.stack-outputs }}
     steps:
+      - name: Set TIMESTAMP env var
+        run: echo "TIMESTAMP=$(date +%s)" >> $GITHUB_ENV
+
       - name: Deploy stack
         uses: govuk-one-login/github-actions/sam/deploy-stack@d201191485b645ec856a34e5ca48636cf97b2574
         id: deploy
@@ -85,3 +88,4 @@ jobs:
           parameters: |
             Environment=localdev
             SecretPrefix=pre-merge-test
+            ForceLambdaUpdate=$TIMESTAMP

--- a/deploy.sh
+++ b/deploy.sh
@@ -33,4 +33,5 @@ sam deploy --stack-name "$stack_name" \
   Environment=localdev \
   SecretPrefix=pre-merge-test \
   ${common_stack_name:+CommonStackName=$common_stack_name} \
-  ${secret_prefix:+SecretPrefix=$secret_prefix}
+  ${secret_prefix:+SecretPrefix=$secret_prefix} \
+  ForceLambdaUpdate="$(date +%s)"

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -14,6 +14,10 @@ Parameters:
     Description: >-
       Specifies the configuration to enable gradual Lambda deployments.
       It can be used to set deployment type, and also allows skipping canary deployment by setting to 'AllAtOnce'.
+  ForceLambdaUpdate:
+    Type: String
+    Default: "initial"
+    Description: "For localdev only - used to force Lambda version updates"
   CodeSigningConfigArn:
     Type: String
     Default: "none"
@@ -105,6 +109,7 @@ Globals:
         POWERTOOLS_LOG_LEVEL: INFO
         AWS_LAMBDA_EXEC_WRAPPER: /opt/dynatrace
         JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1
+        FORCE_LAMBDA_UPDATE: !If [IsLocalDevEnvironment, !Ref ForceLambdaUpdate, !Ref AWS::NoValue]
         DT_CONNECTION_AUTH_TOKEN: !Sub
           - "{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CONNECTION_AUTH_TOKEN}}"
           - SecretArn:


### PR DESCRIPTION
## Proposed changes

### What changed

Add `ForceLambdaUpdate` CF param and env var that can be used to force sam deployed (localdev) stacks to deploy new lambda versions every time.

### Why did it change

With moving to resolving SSM Params at deploy time and passing them directly into our Lambda functions as environment variables, when deploying using Sam (local or pre-merge GHA) sometimes the small changes (e.g. an env var) do not publish new Lambda versions. This can cause deployment issues.

### Issue tracking
- [OJ-3462](https://govukverify.atlassian.net/browse/OJ-3462)


[OJ-3462]: https://govukverify.atlassian.net/browse/OJ-3462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ