### PR TITLE
OJ-3462: Fix GHA to set timestamp properly

### DIFF
--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -65,8 +65,9 @@ jobs:
       stack-name: ${{ steps.deploy.outputs.stack-name }}
       stack-outputs: ${{ steps.deploy.outputs.stack-outputs }}
     steps:
-      - name: Set TIMESTAMP env var
-        run: echo "TIMESTAMP=$(date +%s)" >> $GITHUB_ENV
+      - name: Set timestamp
+        id: set_timestamp
+        run: echo "timestamp=$(date +%s)" >> $GITHUB_OUTPUT
 
       - name: Deploy stack
         uses: govuk-one-login/github-actions/sam/deploy-stack@d201191485b645ec856a34e5ca48636cf97b2574
@@ -88,4 +89,4 @@ jobs:
           parameters: |
             Environment=localdev
             SecretPrefix=pre-merge-test
-            ForceLambdaUpdate=$TIMESTAMP
+            ForceLambdaUpdate=${{ steps.set_timestamp.outputs.timestamp }}


### PR DESCRIPTION
## Proposed changes

### What changed

Minor fix to timestamp generated in GHA for https://github.com/govuk-one-login/ipv-cri-kbv-api/pull/565

### Why did it change

Set timestamp correctly

### Issue tracking

- [OJ-3462](https://govukverify.atlassian.net/browse/OJ-3462)

[OJ-3462]: https://govukverify.atlassian.net/browse/OJ-3462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ